### PR TITLE
Fix info ghost button background

### DIFF
--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -121,7 +121,7 @@ const buttonVariants = cva(
       {
         variant: 'ghost',
         color: 'info',
-        class: 'text-info hover:bg-info hover:text-info/10',
+        class: 'text-info hover:bg-info/10',
       },
       {
         variant: 'default',


### PR DESCRIPTION
## Summary
- tweak Button component's `info` ghost variant so hover background uses transparent color

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.6.10.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684984b1223883218669b4a0ce5b0882