### PR TITLE
Fix footer positioning on pages with minimal content

### DIFF
--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
       <body>
         <ReactQueryClientProvider>
           <PageScrollArea>
-            <div className="grid grid-rows-[3rem_1fr_18.75rem] grid-cols-[1fr_calc(100%-2rem)_1fr] md:grid-cols-[1fr_46rem_1fr] xl:grid-cols-[1fr_77rem_1fr]">
+            <div className="min-h-screen grid grid-rows-[3rem_1fr_18.75rem] grid-cols-[1fr_calc(100%-2rem)_1fr] md:grid-cols-[1fr_46rem_1fr] xl:grid-cols-[1fr_77rem_1fr]">
               <main className="col-start-2 -col-end-2 grid grid-cols-4 md:grid-cols-6 xl:grid-cols-12 gap-x-6 gap-y-12 py-12">
                 {children}
               </main>


### PR DESCRIPTION
## Summary
Fixed footer positioning issue where the footer would float upward on pages with minimal content instead of staying at the bottom of the screen.

## Changes
- Added `min-h-screen` class to the main grid container in `apps/blog/app/layout.tsx`
- Ensures footer consistently appears at the bottom of the viewport regardless of content amount

## Impact
- ✅ Improved UX on pages with minimal content (search results, category pages with few posts)
- ✅ Footer now consistently positioned at screen bottom
- ✅ No impact on pages with sufficient content
- ✅ Maintains responsive design across all breakpoints

## Testing
- [x] Verified on development server (localhost:3000)
- [x] Tested with Next.js 15.1.7 + Turbopack
- [x] Confirmed footer positioning on various content scenarios

## Test Plan
- [ ] Test search pages with no results
- [ ] Test category pages with minimal posts
- [ ] Verify responsive behavior on mobile/tablet/desktop
- [ ] Confirm no regression on content-heavy pages

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)