### PR TITLE
💅 Improve content spacing - Optimize visual density

### DIFF
--- a/apps/blog/app/blog/page.tsx
+++ b/apps/blog/app/blog/page.tsx
@@ -147,7 +147,7 @@ export default async function Page() {
       </div>
       <hr className="col-span-full border-slate-200" />
       <div className="col-span-full grid grid-cols-[subgrid]">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-8 col-start-1 col-end-10 place-content-start">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-8 col-start-1 col-end-10 place-content-start">
           {featuresRecently.map((article) => (
             <div key={article.title} className="block xl:hidden">
               <BlogCard className="flex-col gap-spacious">

--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
         <ReactQueryClientProvider>
           <PageScrollArea>
             <div className="min-h-screen grid grid-rows-[3rem_1fr_18.75rem] grid-cols-[1fr_calc(100%-2rem)_1fr] md:grid-cols-[1fr_46rem_1fr] xl:grid-cols-[1fr_77rem_1fr]">
-              <main className="col-start-2 -col-end-2 grid grid-cols-4 md:grid-cols-6 xl:grid-cols-12 gap-x-6 gap-y-12 py-12">
+              <main className="col-start-2 -col-end-2 grid grid-cols-4 md:grid-cols-6 xl:grid-cols-12 gap-x-8 gap-y-12 py-12">
                 {children}
               </main>
               <Footer />

--- a/apps/blog/components/articles/Articles.tsx
+++ b/apps/blog/components/articles/Articles.tsx
@@ -27,7 +27,7 @@ export async function Articles(props: Props) {
   return (
     <>
       <div className="grid grid-cols-[subgrid] col-span-full">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 col-span-full gap-x-6 gap-y-8 place-content-start">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 col-span-full gap-x-8 gap-y-8 place-content-start">
           {articles.map((article) => (
             <BlogCard key={article.title} className="flex-col gap-spacious">
               {article.imageUrl && (

--- a/apps/blog/components/articles/ArticlesSkelton.tsx
+++ b/apps/blog/components/articles/ArticlesSkelton.tsx
@@ -3,7 +3,7 @@ import { Icon, Skelton } from 'ui';
 export async function ArticlesSkelton() {
   return (
     <div className="grid grid-cols-[subgrid] col-span-full">
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 col-span-full gap-6 place-content-start">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 col-span-full gap-8 place-content-start">
         {Array.from({ length: 6 }).map((_, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <Skelton key={index} className="flex flex-col gap-3">

--- a/packages/ui/src/foundations/layout.mdx
+++ b/packages/ui/src/foundations/layout.mdx
@@ -173,7 +173,7 @@ const SIZES = [
 <div className="grid grid-rows-[3rem_1fr_6rem] grid-cols-[1fr_calc(100%-2rem)_1fr] md:grid-cols-[1fr_46rem_1fr] xl:grid-cols-[1fr_calc(100%-2rem)_1fr] gap-y-12">
   <div className="col-span-full bg-main-default" />
 
-  <div className="col-start-2 -col-end-2 grid grid-cols-4 md:grid-cols-6 xl:grid-cols-12 gap-x-6 gap-y-8">
+  <div className="col-start-2 -col-end-2 grid grid-cols-4 md:grid-cols-6 xl:grid-cols-12 gap-x-8 gap-y-8">
 
     <div className="col-span-full grid grid-cols-[subgrid] gap-y-8">
       <div className="col-span-full xl:col-start-1 xl:col-end-7 bg-main-default h-24" />

--- a/packages/ui/src/guidelines/Accessibility.mdx
+++ b/packages/ui/src/guidelines/Accessibility.mdx
@@ -50,7 +50,7 @@ return sections.map((section, index) => (
 <section className='flex flex-col gap-spacious'>
 ## {i18n.t('accessibility.guidelines.heading')}
 
-<div className="grid grid-cols-2 gap-6">
+<div className="grid grid-cols-2 gap-8">
   {(() => {
       const items = i18n.t('accessibility.guidelines.items', { returnObjects: true });
       const gradients = [

--- a/packages/ui/src/guidelines/Introduction.mdx
+++ b/packages/ui/src/guidelines/Introduction.mdx
@@ -38,7 +38,7 @@ useTranslation();
       ];
 
       return (
-        <div className="grid grid-cols-2 gap-x-6 gap-y-8">
+        <div className="grid grid-cols-2 gap-x-8 gap-y-8">
           {items.map((item, i) => (
             <div key={i} className="flex flex-col gap-spacious">
               <div className="w-full h-[200px] rounded-lg relative overflow-hidden">

--- a/packages/ui/src/guidelines/Responsive.mdx
+++ b/packages/ui/src/guidelines/Responsive.mdx
@@ -46,7 +46,7 @@ useTranslation();
   <section className="flex flex-col gap-spacious">
     ## {i18n.t('responsive.guidelines.heading')}
 
-    <div className="grid grid-cols-2 gap-6">
+    <div className="grid grid-cols-2 gap-8">
     {(() => {
       const gradients = [
         "linear-gradient(73deg, #ff9a9e, #fad0c4)",


### PR DESCRIPTION
## Summary
- Increased gap spacing from 24px (gap-6) to 32px (gap-8) across article grids and components
- Improved visual breathing room between content elements
- Enhanced readability and content hierarchy

## Changes
- **Blog App**: Updated gap spacing in article grids and main layout
- **UI Package**: Updated gap spacing in documentation examples

## Why
The previous 24px gap created visual density issues, making content feel cramped. 
The new 32px spacing (4 × 8dp) provides better separation between elements while 
maintaining consistency with the 8dp grid system.

## Related Issue
Fixes #32

## Test Plan
- [x] Visual review of blog article grid spacing
- [x] Responsive design check (mobile/tablet/desktop)
- [x] Storybook component spacing verification
- [x] No breaking changes to existing layouts