### PR TITLE
Update Dockerfile and devcontainer.json to include additional node_modules directories for improved permissions handling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,8 +33,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /workspace /home/node/.claude /home/node/.pnpm-store /home/node/.pnpm \
-    /workspace/node_modules /workspace/apps/blog/node_modules /workspace/apps/portfolio/node_modules && \
-    chown -R node:node /workspace /home/node
+  /workspace/node_modules /workspace/apps/blog/node_modules /workspace/apps/portfolio/node_modules \
+  /workspace/packages/ui/node_modules /workspace/packages/tailwind-config/node_modules \
+  /workspace/packages/tsconfig/node_modules /workspace/packages/test-utils/node_modules && \
+  chown -R node:node /workspace /home/node
 
 ARG USERNAME=node
 
@@ -105,6 +107,10 @@ ALLOWED_DIRS=(
 "/workspace/node_modules"
 "/workspace/apps/blog/node_modules"
 "/workspace/apps/portfolio/node_modules"
+"/workspace/packages/ui/node_modules"
+"/workspace/packages/tailwind-config/node_modules"
+"/workspace/packages/tsconfig/node_modules"
+"/workspace/packages/test-utils/node_modules"
 "/home/node/.pnpm-store"
 )
 
@@ -117,9 +123,9 @@ EOF
 
 # Set up all sudo permissions
 RUN chmod 755 /usr/local/bin/fix-node-modules-permissions.sh && \
-    echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-permissions && \
-    echo "node ALL=(root) NOPASSWD: /bin/chown -R node\\:node /workspace/node_modules, /bin/chown -R node\\:node /workspace/apps/blog/node_modules, /bin/chown -R node\\:node /workspace/apps/portfolio/node_modules, /bin/chown -R node\\:node /home/node/.pnpm-store" >> /etc/sudoers.d/node-permissions && \
-    echo "node ALL=(root) NOPASSWD: /usr/local/bin/fix-node-modules-permissions.sh" >> /etc/sudoers.d/node-permissions && \
-    chmod 0440 /etc/sudoers.d/node-permissions
+  echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-permissions && \
+  echo "node ALL=(root) NOPASSWD: /bin/chown -R node\\:node /workspace/node_modules, /bin/chown -R node\\:node /workspace/apps/blog/node_modules, /bin/chown -R node\\:node /workspace/apps/portfolio/node_modules, /bin/chown -R node\\:node /workspace/packages/ui/node_modules, /bin/chown -R node\\:node /workspace/packages/tailwind-config/node_modules, /bin/chown -R node\\:node /workspace/packages/tsconfig/node_modules, /bin/chown -R node\\:node /workspace/packages/test-utils/node_modules, /bin/chown -R node\\:node /home/node/.pnpm-store" >> /etc/sudoers.d/node-permissions && \
+  echo "node ALL=(root) NOPASSWD: /usr/local/bin/fix-node-modules-permissions.sh" >> /etc/sudoers.d/node-permissions && \
+  chmod 0440 /etc/sudoers.d/node-permissions
 
 USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,14 @@
   "remoteUser": "node",
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "type=volume,target=/workspace/node_modules",
+    "type=volume,target=/workspace/apps/blog/node_modules",
+    "type=volume,target=/workspace/apps/portfolio/node_modules",
+    "type=volume,target=/workspace/packages/ui/node_modules",
+    "type=volume,target=/workspace/packages/tailwind-config/node_modules",
+    "type=volume,target=/workspace/packages/tsconfig/node_modules",
+    "type=volume,target=/workspace/packages/test-utils/node_modules"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",


### PR DESCRIPTION
This pull request updates the devcontainer setup to improve support for multiple package-specific `node_modules` directories. The changes ensure that each package in the monorepo has its own persistent and properly permissioned `node_modules` directory, which helps avoid permission issues and improves development reliability.

**Devcontainer configuration improvements:**

* Added persistent volume mounts for `node_modules` directories in each package (`ui`, `tailwind-config`, `tsconfig`, `test-utils`) within the `mounts` array in `.devcontainer/devcontainer.json`.

**Dockerfile updates for permissions and allowed directories:**

* Updated the directory creation step to include new package-specific `node_modules` directories in `.devcontainer/Dockerfile`.
* Extended the `ALLOWED_DIRS` array to include the new package directories, ensuring permission scripts recognize them.
* Modified the sudoers configuration to allow the `node` user to recursively change ownership of the new `node_modules` directories.