### PR TITLE
✨ Add Badge component with variants and color options

### DIFF
--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Icon } from '../Icon';
+
+import { Badge } from '.';
+
+const meta = {
+  component: Badge,
+  args: {
+    children: 'Badge',
+    variant: 'default',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'outline'],
+    },
+    color: {
+      control: 'select',
+      options: [
+        'main',
+        'accent',
+        'inherit',
+        'success',
+        'info',
+        'error',
+        'warning',
+        'dark',
+        'light',
+      ],
+    },
+    asChild: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        <Icon
+          name="exclamation-triangle"
+          width={16}
+          height={16}
+          color="var(--color-white)"
+        />
+        Badge
+      </>
+    ),
+    color: 'warning',
+  },
+};
+
+export const Border: Story = {
+  args: {
+    children: 'Badge',
+    variant: 'outline',
+    color: 'error',
+  },
+};

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,0 +1,140 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { twMerge } from 'tailwind-merge';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent',
+        outline: '',
+      },
+      color: {
+        main: '',
+        accent: '',
+        success: '',
+        error: '',
+        info: '',
+        warning: '',
+        dark: '',
+        light: '',
+        inherit: '',
+      },
+    },
+    compoundVariants: [
+      {
+        variant: 'default',
+        color: 'main',
+        class: 'bg-main-default text-white',
+      },
+      {
+        variant: 'outline',
+        color: 'main',
+        class: 'border-main-default/20 text-main-default',
+      },
+      {
+        variant: 'default',
+        color: 'accent',
+        class: 'bg-accent-default text-white',
+      },
+      {
+        variant: 'outline',
+        color: 'accent',
+        class: 'border-accent-default/20 text-accent-default',
+      },
+      {
+        variant: 'default',
+        color: 'inherit',
+        class: 'bg-transparent text-current',
+      },
+      {
+        variant: 'outline',
+        color: 'inherit',
+        class: 'border-transparent/20 text-current',
+      },
+      {
+        variant: 'default',
+        color: 'error',
+        class: 'bg-error text-white',
+      },
+      {
+        variant: 'outline',
+        color: 'error',
+        class: 'border-error/20 text-error',
+      },
+      {
+        variant: 'default',
+        color: 'warning',
+        class: 'bg-warning text-white',
+      },
+      {
+        variant: 'outline',
+        color: 'warning',
+        class: 'border-warning/20 text-warning',
+      },
+      {
+        variant: 'default',
+        color: 'info',
+        class: 'bg-info text-white',
+      },
+      {
+        variant: 'outline',
+        color: 'info',
+        class: 'border-info/20 text-info',
+      },
+      {
+        variant: 'default',
+        color: 'success',
+        class: 'bg-success text-white',
+      },
+      {
+        variant: 'outline',
+        color: 'success',
+        class: 'border-success/20 text-success',
+      },
+      {
+        variant: 'default',
+        color: 'dark',
+        class: 'bg-base-black text-white',
+      },
+      {
+        variant: 'outline',
+        color: 'dark',
+        class: 'border-base-black/20 text-base-black',
+      },
+      {
+        variant: 'default',
+        color: 'light',
+        class: 'bg-white text-base-black',
+      },
+      {
+        variant: 'outline',
+        color: 'light',
+        class: 'border-white/20 text-white',
+      },
+    ],
+    defaultVariants: {
+      variant: 'default',
+      color: 'main',
+    },
+  }
+);
+
+export default function Badge({
+  className,
+  variant,
+  color,
+  asChild = false,
+  ...rest
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span';
+
+  return (
+    <Comp
+      className={twMerge(badgeVariants({ variant, color }), className)}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/components/Badge/index.tsx
+++ b/packages/ui/src/components/Badge/index.tsx
@@ -1,0 +1,1 @@
+export { default as Badge } from './Badge';


### PR DESCRIPTION
This pull request introduces a new, customizable `Badge` component to the UI library, complete with Storybook stories for documentation and testing. The implementation uses utility libraries for styling and supports multiple variants and colors, as well as the ability to render as a child element.

**Badge component implementation and export:**

* Added a new `Badge` component in `Badge.tsx`, featuring configurable variants and colors, compound styling rules via `class-variance-authority`, and support for rendering as either a `span` or a child element using Radix UI's `Slot`.
* Exported the `Badge` component from the main index file for easy import elsewhere in the codebase.

**Storybook integration and documentation:**

* Created Storybook stories in `Badge.stories.tsx` to showcase default, outlined, and icon-enhanced versions of the `Badge` component, with interactive controls for variant, color, and child rendering.

close #42