### PR TITLE
✨ Feat: Add Related Components section to Storybook

### DIFF
--- a/packages/ui/.storybook/DocumentationTemplate.mdx
+++ b/packages/ui/.storybook/DocumentationTemplate.mdx
@@ -19,6 +19,7 @@ import Description from './Description';
 import Stories from './Stories';
 import API from './API';
 import References from './References';
+import RelatedComponents from './RelatedComponents';
 
 import '../src/docs.css';
 
@@ -49,6 +50,8 @@ import '../src/docs.css';
 <DoDont />
 
 <Stories />
+
+<RelatedComponents />
 
 <References />
 

--- a/packages/ui/.storybook/RelatedComponents.tsx
+++ b/packages/ui/.storybook/RelatedComponents.tsx
@@ -1,0 +1,40 @@
+import { useOf } from '@storybook/addon-docs/blocks';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '../src/components/Icon';
+
+export default function RelatedComponents() {
+  const { story } = useOf('story', ['story']);
+  const storyDocs = story?.parameters?.docs || {};
+  const { t } = useTranslation();
+
+  const relatedComponents = t(storyDocs.relatedComponents, {
+    returnObjects: true,
+    defaultValue: [],
+  });
+
+  if (!Array.isArray(relatedComponents) || relatedComponents.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-spacious">
+      <h2>Related Components</h2>
+      <ul className="flex gap-normal flex-col">
+        {relatedComponents.map((component, index) => (
+          <li key={index}>
+            <span className="flex items-center gap-condensed">
+              <Icon name="arrow-right" width={14} height={14} />
+              <a
+                href={component.path}
+                className="text-base-black/80 underline hover:opacity-80"
+              >
+                {component.name}
+              </a>
+            </span>
+            <p>{component.description}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/ui/src/components/Icon/const.ts
+++ b/packages/ui/src/components/Icon/const.ts
@@ -36,6 +36,8 @@ export const HERO_ICON_NAMES = [
   'check-circle',
   'exclamation-triangle',
   'x-circle',
+  'arrow-left',
+  'arrow-right',
 ] as const;
 
 export const ICON_NAMES = [...MULTI_COLOR_ICON_NAMES, ...HERO_ICON_NAMES];


### PR DESCRIPTION
Closes #51

## Summary

Added a new "Related Components" section to Storybook documentation template to improve component discoverability and navigation.

### Changes Made

- **Created `RelatedComponents.tsx`**: New component that displays related components with names, links, and descriptions
- **Updated `DocumentationTemplate.mdx`**: Integrated RelatedComponents between Stories and References sections
- **Enhanced Icon component**: Added `arrow-left` and `arrow-right` icons for visual navigation

### Key Features

- ✅ Reads `relatedComponents` metadata from Storybook component meta
- ✅ Supports internationalization (English/Japanese) via i18next
- ✅ Conditional rendering - only shows when metadata is defined
- ✅ Consistent with existing `References` component pattern
- ✅ Semantic HTML with proper accessibility

## Technical Details

**Component Architecture:**
- Uses Storybook's `useOf` hook to access component metadata
- Leverages i18next for translation support
- Follows same pattern as existing documentation components

**Usage Example:**
```typescript
// In component.stories.tsx
export default {
  ...
  parameters: {
    docs: {
      relatedComponents: 'components.avatar.relatedComponents'
    }
  }
} satisfies Meta<typeof Component>;

// In translation.json
{
  "components": {
    "avatar": {
      "relatedComponents": [
        {
          "name": "Badge",
          "path": "/?path=/docs/components-badge--docs",
          "description": "Status indicators for avatars"
        }
      ]
    }
  }
}
```

## Test Plan

- [ ] Verify RelatedComponents renders correctly in Storybook
- [ ] Test with component having `relatedComponents` metadata (e.g., Avatar)
- [ ] Test with component without `relatedComponents` metadata (should render nothing)
- [ ] Verify English and Japanese translations work correctly
- [ ] Test responsive design on different screen sizes
- [ ] Verify arrow-right icon displays correctly
- [ ] Check link navigation works properly
- [ ] Confirm accessibility with screen readers

## Screenshots

The Related Components section appears between Stories and References:

```
┌─────────────────────────────┐
│   Component Stories         │
└─────────────────────────────┘
         ↓
┌─────────────────────────────┐
│   Related Components  ← NEW │
│   • Badge → (link)          │
│   • Icon → (link)           │
└─────────────────────────────┘
         ↓
┌─────────────────────────────┐
│   References                │
└─────────────────────────────┘
```

## Breaking Changes

None - This is a purely additive feature.

## Follow-up

After this PR is merged, we can:
1. Add `relatedComponents` metadata to existing component stories
2. Document the usage pattern in component contribution guidelines
3. Consider adding similar navigation features (e.g., Dependencies section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
