### PR TITLE
♻️ Refactor: #123 Update Category imports to new architecture

### DIFF
--- a/apps/blog/app/category/[category]/page.tsx
+++ b/apps/blog/app/category/[category]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 import { Articles } from '../../../components/articles/Articles';
 import { ArticlesSkelton } from '../../../components/articles/ArticlesSkelton';
 import { createFetchPostsByCategoryUseCase } from '../../../infrastructure/di';
-import { Category } from '../../../modules/domain/post/types';
+import { Category } from '../../../modules/post/domain';
 
 const PAGE_SIZE = 6;
 

--- a/apps/blog/app/sitemap.ts
+++ b/apps/blog/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 
 import { createFetchAllSlugsUseCase } from '../infrastructure/di';
-import { Category } from '../modules/domain/post/types';
+import { Category } from '../modules/post/domain';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.SITE_BASE_URL || 'http://localhost:3000';

--- a/apps/blog/components/header/Header.tsx
+++ b/apps/blog/components/header/Header.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Button, Drawer, DropdownMenu, DropdownMenuItem, Icon } from 'ui';
-import { Category } from '../../modules/domain/post/types';
+import { Category } from '../../modules/post/domain';
 import { CompanyLogo } from '../company-logo/CompanyLogo';
 import Search from '../search/Search';
 import Sidebar from '../sidebar/Sidebar';


### PR DESCRIPTION
## Summary

- Update `Category` import paths in 3 files from old architecture (`modules/domain/post/`) to new architecture (`modules/post/domain/`) as specified in issue #123
- Verified TypeScript compilation and all tests (885 tests) pass

## Changes

| File | Before | After |
|------|--------|-------|
| `app/sitemap.ts` | `from '../modules/domain/post/types'` | `from '../modules/post/domain'` |
| `app/category/[category]/page.tsx` | `from '../../../modules/domain/post/types'` | `from '../../../modules/post/domain'` |
| `components/header/Header.tsx` | `from '../../modules/domain/post/types'` | `from '../../modules/post/domain'` |

## Out of Scope

Deletion of old directories (`modules/domain/post/`, `modules/domain/author/`) requires a separate issue, as other files (`modules/data-access/`, `modules/use-cases/`, etc.) still reference them via `Domain.Post`.

## Test Plan

- [x] TypeScript compilation succeeds
- [x] All tests pass (885 tests)
- [x] No new lint warnings

Closes #123

🤖 Generated with [Claude Code](https://claude.ai/claude-code)