### PR TITLE
Include blog server directory in Biome lint configuration

### DIFF
--- a/apps/blog/app/api/[[...route]]/route.ts
+++ b/apps/blog/app/api/[[...route]]/route.ts
@@ -1,5 +1,5 @@
 import { handle } from 'hono/vercel';
-import app from '../../../server/app';
+import { app } from '../../../server/app';
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/apps/blog/biome.jsonc
+++ b/apps/blog/biome.jsonc
@@ -6,6 +6,7 @@
     "includes": [
       "app/**/*.{ts,tsx}",
       "modules/**/*.{ts,tsx}",
+      "server/**/*.ts",
       "lib/**/*.{ts,tsx}",
       "components/**/*.{ts,tsx}",
       "*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}",

--- a/apps/blog/server/app.test.ts
+++ b/apps/blog/server/app.test.ts
@@ -5,7 +5,7 @@ import {
   createSyncPostsFromExternalUseCase,
 } from '../infrastructure/di';
 
-import app from './app';
+import { app } from './app';
 
 const { infoMock, errorMock } = vi.hoisted(() => ({
   infoMock: vi.fn(),
@@ -58,7 +58,7 @@ describe('Hono app composition', () => {
       expect(res.status).toBe(statusUnauthorized);
       expect(infoMock).toHaveBeenCalledWith(
         { method: 'PATCH', path: '/api/posts' },
-        'Request started',
+        'Request started'
       );
     });
 
@@ -66,7 +66,7 @@ describe('Hono app composition', () => {
       await app.request('/api/posts', { method: 'PATCH' });
 
       const completionCall = infoMock.mock.calls.find(
-        (call) => call[1] === 'Request completed',
+        (call) => call[1] === 'Request completed'
       );
       expect(completionCall).toBeDefined();
     });

--- a/apps/blog/server/app.ts
+++ b/apps/blog/server/app.ts
@@ -12,4 +12,4 @@ app.route('/', postRoutes);
 app.route('/', mediaRoutes);
 app.onError(errorHandler);
 
-export default app;
+export { app };

--- a/apps/blog/server/middleware/apiKeyAuth.ts
+++ b/apps/blog/server/middleware/apiKeyAuth.ts
@@ -1,5 +1,5 @@
-import { HTTPException } from 'hono/http-exception';
 import { createMiddleware } from 'hono/factory';
+import { HTTPException } from 'hono/http-exception';
 
 export const apiKeyAuth = createMiddleware(async (c, next) => {
   const apiKey = c.req.header('x-api-key');

--- a/apps/blog/server/middleware/errorHandler.ts
+++ b/apps/blog/server/middleware/errorHandler.ts
@@ -32,7 +32,7 @@ export const errorHandler: ErrorHandler = (err, c) => {
 
   apiLogger.error(
     { err, status, errorName: err.name, path: c.req.path },
-    message,
+    message
   );
 
   return c.json(
@@ -44,6 +44,6 @@ export const errorHandler: ErrorHandler = (err, c) => {
         timestamp: new Date().toISOString(),
       },
     },
-    status,
+    status
   );
 };

--- a/apps/blog/server/routes/index.ts
+++ b/apps/blog/server/routes/index.ts
@@ -1,2 +1,2 @@
-export { postRoutes } from './post';
 export { mediaRoutes } from './media';
+export { postRoutes } from './post';

--- a/apps/blog/server/routes/media.test.ts
+++ b/apps/blog/server/routes/media.test.ts
@@ -12,9 +12,7 @@ import { createSyncHeroImagesUseCase } from '../../infrastructure/di';
 
 const mockCreateUseCase = vi.mocked(createSyncHeroImagesUseCase);
 
-function stubUseCaseWith(
-  execute: Mock<() => Promise<SyncHeroImagesOutput>>,
-) {
+function stubUseCaseWith(execute: Mock<() => Promise<SyncHeroImagesOutput>>) {
   mockCreateUseCase.mockReturnValue({ execute } as unknown as ReturnType<
     typeof createSyncHeroImagesUseCase
   >);
@@ -65,9 +63,7 @@ describe('mediaRoutes', () => {
     });
 
     it('propagates use case errors', async () => {
-      stubUseCaseWith(
-        vi.fn().mockRejectedValue(new Error('Sync failed')),
-      );
+      stubUseCaseWith(vi.fn().mockRejectedValue(new Error('Sync failed')));
       const app = createApp();
 
       const res = await app.request('/images', { method: 'PATCH' });

--- a/apps/blog/server/routes/post.test.ts
+++ b/apps/blog/server/routes/post.test.ts
@@ -13,7 +13,7 @@ import { createSyncPostsFromExternalUseCase } from '../../infrastructure/di';
 const mockCreateUseCase = vi.mocked(createSyncPostsFromExternalUseCase);
 
 function stubUseCaseWith(
-  execute: Mock<() => Promise<SyncPostsFromExternalOutput>>,
+  execute: Mock<() => Promise<SyncPostsFromExternalOutput>>
 ) {
   mockCreateUseCase.mockReturnValue({ execute } as unknown as ReturnType<
     typeof createSyncPostsFromExternalUseCase
@@ -63,9 +63,7 @@ describe('postRoutes', () => {
     });
 
     it('propagates use case errors', async () => {
-      stubUseCaseWith(
-        vi.fn().mockRejectedValue(new Error('Sync failed')),
-      );
+      stubUseCaseWith(vi.fn().mockRejectedValue(new Error('Sync failed')));
       const app = createApp();
 
       const res = await app.request('/posts', { method: 'PATCH' });


### PR DESCRIPTION
## Summary

### What changed?

- Added `server/**/*.ts` to the `files.includes` array in `apps/blog/biome.jsonc`
- Converted default export in `server/app.ts` to a named export (`export { app }`) to satisfy Biome's `noDefaultExport` rule
- Updated all import references in `server/app.test.ts` and `app/api/[[...route]]/route.ts`
- Applied Biome auto-fixes: import sorting in middleware and routes, trailing comma removal across server files

### Why was this changed?

The blog app's `server/` directory (containing Hono routes, middleware, and tests) was excluded from Biome's lint scope, meaning server-side code did not benefit from automated linting, formatting, or import type enforcement. This caused inconsistencies with the rest of the codebase.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions or updates
- [ ] 🔒 Security improvements
- [ ] 📦 Dependency updates
- [x] 🏗️ Build/CI changes

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)
- [ ] 💼 Portfolio app (`apps/portfolio/`)
- [ ] 🎨 UI package (`packages/ui/`)
- [ ] 🔧 Shared packages (`packages/`)
- [ ] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed
- [x] No tests needed (explain why below)

No new tests needed. This is a configuration change with auto-fix formatting adjustments. Existing tests validate that the code still works correctly.

### How to Test

1. Run `pnpm lint` from the repo root or `apps/blog/` to confirm Biome now covers server files
2. Run `pnpm test` in `apps/blog/` to confirm all 32 tests pass
3. Run `pnpm build` to confirm the build succeeds

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [ ] New tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes
- [ ] Database migration included
- [ ] Prisma schema updated
- [ ] Seed data updated

## Environment Variables

- [x] No environment variable changes
- [ ] New environment variables added (documented below)
- [ ] Existing environment variables modified

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements
- [ ] Requires environment variable updates
- [ ] Requires database migration
- [ ] Requires cache clearing
- [ ] Other (specify below)

## Documentation

- [ ] Documentation updated (README, CLAUDE.md, etc.)
- [ ] Storybook stories added/updated
- [ ] TypeScript types documented
- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings
- [ ] Responsive design tested (if applicable)
- [ ] Accessibility tested (if applicable)
- [x] Performance impact considered

## Related Issues

Closes #223

## Additional Context

The changes are minimal and mechanical: 1 line added to the Biome config, and the remaining 8 files are auto-fix results (import sorting, trailing comma removal, default-to-named export conversion).

## Reviewer Notes

- All changes in server files (other than `biome.jsonc` and `server/app.ts` export) are Biome auto-fix formatting only
- The `export default app` to `export { app }` conversion is the only semantic change, driven by Biome's `noDefaultExport` rule

### For Reviewers

Please ensure:

- [x] Code quality and maintainability
- [x] Test coverage is adequate
- [x] Breaking changes are clearly documented
- [x] Performance implications are considered
- [x] Security implications are considered