### PR TITLE
🐛 Fix: #251 Use webpack for production builds to resolve Prisma + Turbopack incompatibility

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -49,10 +49,14 @@ const monorepoRoot = resolve(__dirname, '..', '..');
 const config = {
   reactStrictMode: true,
   reactCompiler: true,
-  transpilePackages: ['ui', 'tailwind-config', '@prisma/client'],
+  transpilePackages: ['ui', 'tailwind-config'],
+  serverExternalPackages: ['@prisma/client'],
   outputFileTracingRoot: monorepoRoot,
   outputFileTracingIncludes: {
-    '/*': ['../../node_modules/.prisma/client/**/*'],
+    '/*': [
+      '../../node_modules/.prisma/client/libquery_engine-rhel-openssl-3.0.x.so.node',
+      '../../node_modules/.prisma/client/schema.prisma',
+    ],
   },
   turbopack: {},
   async redirects() {

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && next build --webpack",
     "start": "next start",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

### What changed?

- Removed `@prisma/client` from `transpilePackages`
- Added `@prisma/client` to `serverExternalPackages`
- Tightened `outputFileTracingIncludes` to only include the Lambda engine binary and `schema.prisma`
- Changed build script to `next build --webpack` for production builds

### Why was this changed?

Turbopack (Next.js 16 default bundler) hardcodes build-time absolute paths (e.g., `/ROOT/node_modules/.prisma/client`) when transpiling `@prisma/client`, causing `PrismaClientInitializationError` on Lambda at runtime. Switching to webpack for production builds resolves this because webpack correctly handles `serverExternalPackages` without the hashed module name issue (prisma/prisma#29025).

### Investigation Details

See #251 for the full investigation, including all attempted approaches and findings.

| Approach | Problem |
|----------|---------|
| `transpilePackages` + Turbopack | Hardcoded absolute paths in bundle |
| `serverExternalPackages` + Turbopack | Hashed module name (`@prisma/client-2c3a283f134fdcb6`) |
| `outputFileTracingIncludes` (`**/*`) + Turbopack | Files included but paths still hardcoded |
| **`serverExternalPackages` + webpack** (this PR) | Correct module resolution + explicit file inclusion |

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

Build configuration change. Verified by local build success with `pnpm build --filter=blog`.

### How to Test

1. Deploy to Amplify staging
2. Access any page that queries the database (e.g., `/blog`, `/category/ENGINEERING`)
3. Verify no `PrismaClientInitializationError` in CloudWatch logs
4. Verify `next dev` still uses Turbopack correctly

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

Production builds now use webpack instead of Turbopack. Dev server continues to use Turbopack. Build time may differ slightly.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main

## Related Issues

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)