### PR TITLE
⬆️ Upgrade: pnpm 9.15.9 to 10.33.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,8 +55,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -85,8 +81,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Build, Test, and Development Commands
 
-- Install: `pnpm install` (pnpm 9+).
+- Install: `pnpm install` (pnpm 10+).
 - Develop all: `pnpm dev` (runs `turbo run dev`).
 - Filter to one app: `pnpm -F blog dev` or `pnpm -F portfolio dev`.
 - Build: `pnpm build`; Start: `pnpm start` (per app/package via filter as above).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
 ### Prerequisites
 
 - Node.js 20.9+
-- pnpm 9.15.9+
+- pnpm 10.33.2+
 
 ### Installation
 

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -25,7 +25,7 @@ A **Next.js 16** blog application with **Notion CMS** integration, built followi
 ### Prerequisites
 
 - Node.js 20.9+
-- pnpm 9.15.9+
+- pnpm 10.33.2+
 - PostgreSQL (or Docker)
 
 ### Installation

--- a/apps/portfolio/README.md
+++ b/apps/portfolio/README.md
@@ -19,7 +19,7 @@ A **Next.js 16** multilingual portfolio website supporting **English** and **Jap
 ### Prerequisites
 
 - Node.js 20.9+
-- pnpm 9.15.9+
+- pnpm 10.33.2+
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -25,11 +25,20 @@
     "turbo": "latest",
     "typescript": "^5.4.5"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.33.2",
   "name": "k2bg-branding",
   "pnpm": {
     "overrides": {
       "esbuild": "0.25.2"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@prisma/client",
+      "@prisma/engines",
+      "@swc/core",
+      "esbuild",
+      "prisma",
+      "sharp",
+      "workerd"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

<!-- Provide a brief overview of what this PR accomplishes -->

Upgrade the workspace's package manager from pnpm 9.15.9 to 10.33.2 so that we stay on a supported major and benefit from faster installs and stricter default security around dependency lifecycle scripts.

### What changed?

- Bumped `packageManager` in root `package.json` from `pnpm@9.15.9` to `pnpm@10.33.2`.
- Added `pnpm.onlyBuiltDependencies` allowlist for deps that require install / postinstall scripts under pnpm 10's new default: `@prisma/client`, `@prisma/engines`, `prisma`, `@swc/core`, `esbuild`, `sharp`, `workerd`.
- Removed the explicit `version: 9.15.9` pin from `.github/workflows/test.yml` (3 jobs); `pnpm/action-setup@v4` now auto-detects from the `packageManager` field, matching what `chromatic.yml` already does.
- Updated README files (`README.md`, `apps/blog/README.md`, `apps/portfolio/README.md`) and `AGENTS.md` to reflect the new pnpm version requirement.

### Why was this changed?

- pnpm 10 is the latest stable major; staying on 9 will fall out of support.
- pnpm 10 by default does NOT run dependency lifecycle scripts. Without an explicit allowlist, Prisma client / native binaries (sharp, esbuild, workerd) silently fail to build, causing prod runtime errors. Pinning the allowlist makes installs deterministic across local, CI, and Vercel.
- Centralizing the pnpm version on the `packageManager` field removes the duplicated CI version pin and prevents future drift.

## Type of Change

<!-- Mark the type of change with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions or updates
- [ ] 🔒 Security improvements
- [x] 📦 Dependency updates
- [x] 🏗️ Build/CI changes

## Affected Applications

<!-- Mark which applications are affected by this change -->

- [x] 📝 Blog app (`apps/blog/`)
- [x] 💼 Portfolio app (`apps/portfolio/`)
- [x] 🎨 UI package (`packages/ui/`)
- [x] 🔧 Shared packages (`packages/`)
- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] No tests needed (explain why below)

> This is a tooling-only change; no application behavior is altered, so no new tests are added. Coverage is verified by running the full existing test suite.

### How to Test

<!-- Provide step-by-step instructions for testing this change -->

1. Pull this branch and ensure pnpm 10.33.2 is active (`volta install pnpm@10.33.2` or rely on `corepack` / `packageManager` auto-detect).
2. Run `pnpm install` from the repo root — expect postinstall logs for `esbuild` and `@swc/core` (Prisma / sharp / workerd run on a fresh store).
3. Run `pnpm --filter=blog exec prisma generate` and confirm the client is generated.
4. Run `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build` and verify all pass.

### Test Results

<!-- Describe the testing performed and results -->

- [x] All existing tests pass (`pnpm test`) — 959 / 959 passing
- [ ] New tests pass
- [x] Build succeeds (`pnpm build`) — both `blog` and `portfolio`
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

<!-- If this PR includes database changes -->

- [x] No database changes
- [ ] Database migration included
- [ ] Prisma schema updated
- [ ] Seed data updated

**Migration details:**

N/A

## Environment Variables

<!-- If this PR requires new or changed environment variables -->

- [x] No environment variable changes
- [ ] New environment variables added (documented below)
- [ ] Existing environment variables modified

**Required environment variables:**

N/A

## Screenshots/Videos

<!-- Include screenshots or videos for UI changes -->

N/A — tooling-only change.

## Breaking Changes

<!-- List any breaking changes and migration instructions -->

- [x] No breaking changes

**Breaking changes:**

No runtime breaking changes. Local developer note: pnpm 10 is required after this lands. Run `volta install pnpm@10.33.2` or rely on `corepack` / `packageManager` auto-detect.

## Deployment Notes

<!-- Special instructions for deployment -->

- [x] No special deployment requirements
- [ ] Requires environment variable updates
- [ ] Requires database migration
- [ ] Requires cache clearing
- [ ] Other (specify below)

**Deployment instructions:**

Vercel auto-detects `packageManager` so deploys should pick up pnpm 10 transparently. Watch the first preview deploy for the blog app to confirm Prisma client generation succeeds.

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)
- [ ] Storybook stories added/updated
- [ ] TypeScript types documented
- [ ] No documentation changes needed

## Checklist

<!-- Verify these items before requesting review -->

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings
- [ ] Responsive design tested (if applicable)
- [ ] Accessibility tested (if applicable)
- [x] Performance impact considered

## Related Issues

<!-- Link to related issues -->

N/A

## Additional Context

<!-- Add any other context about the pull request here -->

- The lockfile (`pnpm-lock.yaml`) is unchanged — pnpm 10 reads the existing v9 lockfile format as-is, no re-resolution was needed.
- The `onlyBuiltDependencies` list was derived by inspecting `node_modules` for packages with `install` / `postinstall` scripts. If a dep is added later that needs build scripts, it must be added here or its build will be silently skipped.

## Reviewer Notes

<!-- Specific areas you'd like reviewers to focus on -->

- Verify the `pnpm.onlyBuiltDependencies` list is complete — please call out any deps you know rely on build scripts that I missed.
- Confirm CI test/lint/type-check jobs install pnpm via `packageManager` field correctly without the version pin.

---

### For Reviewers

Please ensure:

- [ ] Code quality and maintainability
- [ ] Test coverage is adequate
- [ ] Breaking changes are clearly documented
- [ ] Performance implications are considered
- [ ] Security implications are considered