### PR TITLE
✨ Feat: #259 Add Claude Code hooks for secret protection and auto-formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; b=$(basename \"$f\"); case \"$b\" in .env|.env.*) case \"$b\" in .env.example|.env.template|.env.sample) ;; *) printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Editing %s is not allowed (contains secrets; see SECURITY.md). Edit manually if absolutely necessary.\"}}\\n' \"$b\";; esac;; pnpm-lock.yaml) printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Editing pnpm-lock.yaml is not allowed; let pnpm manage it.\"}}\\n';; esac; }"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js|*.jsx|*.json|*.jsonc) cd \"$(git -C \"$(dirname \"$f\")\" rev-parse --show-toplevel)\" 2>/dev/null && pnpm --silent biome format --write \"$f\" 2>/dev/null;; esac; } || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Add a team-shared `.claude/settings.json` that ships two Claude Code hooks for everyone working in this repo: a **PreToolUse** guard that denies edits to secret-bearing files, and a **PostToolUse** auto-formatter that runs Biome on edited source files.

### What changed?

- Added `.claude/settings.json` (git-tracked, team-shared) with two hooks.
  - **PreToolUse** (matcher `Edit|Write|MultiEdit|NotebookEdit`): denies edits to `.env`, any `.env.*` (allowing `.env.example`, `.env.template`, `.env.sample`), and `pnpm-lock.yaml`. Emits a `permissionDecision: "deny"` JSON with a reason pointing at `SECURITY.md`.
  - **PostToolUse** (matcher `Edit|Write|MultiEdit`): runs `pnpm --silent biome format --write` on edited `.ts`, `.tsx`, `.js`, `.jsx`, `.json`, and `.jsonc` files. Resolves the git toplevel from the edited file's directory; wrapped with `2>/dev/null || true` so unrelated failures stay silent.

### Why was this changed?

- **Defense-in-depth against secret leakage**: prevents accidental Claude-Code-driven edits to `.env`-family files at edit time, before they reach the working tree or commit.
- **Lockfile integrity**: blocks hand edits to `pnpm-lock.yaml`, which should be managed exclusively by pnpm.
- **Consistent formatting**: removes the need to remember `pnpm lint` after every edit; PRs no longer pick up formatting-only diffs.
- **Team-wide policy**: shipped as `.claude/settings.json` (committed) rather than `.claude/settings.local.json` (personal-only), so every contributor benefits without opting in.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security improvements
- [x] 🏗️ Build/CI changes

## Affected Applications

- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] No tests needed (explain why below)

> The hooks are pure shell pipelines that read `tool_input.file_path` from stdin. They were verified live in the authoring session: pipe-tests passed for all input cases (allowed templates, denied `.env.*`, denied `pnpm-lock.yaml`, no-op for unrelated paths), `pnpm --silent biome format --write` exited 0 on a real source file, and the PostToolUse hook fired and reformatted a throwaway `.ts` file successfully. There is no unit-test harness for Claude Code hook configs in this repo.

### How to Test

1. Pull this branch and ensure Claude Code picks up `.claude/settings.json`.
2. Ask Claude Code to edit `.env.local` (or any `.env.*` other than the templates) — the request should be denied with a reason referencing `SECURITY.md`.
3. Ask Claude Code to edit `.env.example` — the request should succeed.
4. Ask Claude Code to edit `pnpm-lock.yaml` — the request should be denied.
5. Ask Claude Code to edit any `.ts`/`.tsx`/`.js`/`.jsx`/`.json`/`.jsonc` file with intentionally bad formatting; verify the file is auto-formatted by Biome after the write.

### Test Results

- [x] All existing tests pass (`pnpm test`) — N/A, no production code changed
- [x] Build succeeds (`pnpm build`) — N/A, no production code changed
- [x] Linting passes (`pnpm lint`) — `.claude/settings.json` is configuration, not part of the lint surface

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main

## Related Issues

Closes #259

## Additional Context

`.claude/settings.local.json` (personal, gitignored) is intentionally untouched — this PR adds team-wide defaults only.

## Reviewer Notes

- Confirm the `case` patterns in the PreToolUse hook cover the `.env.*` files relevant to your local setup.
- Confirm `pnpm --silent biome format --write` is the right Biome invocation for this repo (alternative: `pnpm biome check --write`, which would also run lints — kept narrower here to avoid surprising behavior).