### PR TITLE
✨ Feat: #254 Migrate Badge to Base UI useRender

### DIFF
--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,6 +1,8 @@
-import { Slot } from '@radix-ui/react-slot';
+import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { twMerge } from 'tailwind-merge';
+
+import { asChildToRender } from '../../utils/asChildToRender';
 
 const badgeVariants = cva(
   'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
@@ -121,20 +123,32 @@ const badgeVariants = cva(
   }
 );
 
+interface BadgeProps
+  extends Omit<useRender.ComponentProps<'span'>, 'color'>,
+    VariantProps<typeof badgeVariants> {
+  // Deprecated. Use the `render` prop. Kept for backward compatibility while
+  // consumer call sites migrate; removed once issue #254 closes.
+  asChild?: boolean;
+}
+
 export function Badge({
   className,
   variant,
   color,
   asChild = false,
+  render,
+  children,
   ...rest
-}: React.ComponentProps<'span'> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : 'span';
+}: BadgeProps) {
+  const renderProps = asChildToRender({ asChild, render, children });
 
-  return (
-    <Comp
-      className={twMerge(badgeVariants({ variant, color }), className)}
-      {...rest}
-    />
-  );
+  return useRender({
+    defaultTagName: 'span',
+    render: renderProps.render,
+    props: {
+      className: twMerge(badgeVariants({ variant, color }), className),
+      children: renderProps.children,
+      ...rest,
+    },
+  });
 }


### PR DESCRIPTION
## Summary

### What changed?

- Replaced `@radix-ui/react-slot`'s `Slot` with Base UI's `useRender` inside `packages/ui/src/components/Badge/Badge.tsx`.
- Badge now exposes a `render` prop matching Base UI's composition API.
- `asChild` is preserved as a deprecated alias and routed through `asChildToRender` so consumer call sites do not need to change yet. The legacy alias will be removed once every component in `packages/ui/` is on Base UI and consumer code is updated (issue #254).

### Why was this changed?

`@radix-ui/react-slot` is one of six `@radix-ui/*` packages we are removing as part of issue #254. Badge has the smallest surface area of any of them, so it goes first.

## Type of Change

- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [x] 📦 Dependency updates (the `@radix-ui/react-slot` dependency stays installed for now, used only by Button until the next PR)

## Affected Applications

- [x] 🎨 UI package (`packages/ui/`)

## Testing

### How to Test

1. `pnpm install`
2. `pnpm -F ui storybook`
3. Open `http://localhost:6006/?path=/story/components-badge--default` and confirm:
   - **Default** renders as a green pill with text `Badge`
   - **With Icon** renders as an orange/warning pill with the warning icon
   - **Border** renders as a red outlined pill

### Test Results

- [x] All existing tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm -F ui lint`) — only the pre-existing warning in `Icon/index.tsx` remains
- [x] Storybook builds (`pnpm -F ui build-storybook`)
- [x] Manually verified Default / WithIcon / Border stories render with no visual regression

## Screenshots/Videos

Default, WithIcon, and Border stories all render unchanged from `main`.

## Breaking Changes

- [x] No breaking changes

The public `asChild` prop still works. Consumer migration to `render` happens in a later PR.

## Documentation

- [x] No documentation changes needed

## Related Issues

Relates to #254