### PR TITLE
✨ Feat: #254 Add cn class-merging utility for Base UI migration

### DIFF
--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -16,4 +16,5 @@ export { Popover } from './src/components/Popover';
 export { ScrollArea } from './src/components/ScrollArea';
 export { Skelton } from './src/components/Skelton';
 export { Toaster, useToast } from './src/components/Toaster';
+export { cn } from './src/utils/cn';
 export { twMerge } from './src/utils/extendTailwindMerge';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
     "i18next": "^23.4.6",
     "i18next-browser-languagedetector": "^7.1.0",
     "i18next-http-backend": "^2.6.1",

--- a/packages/ui/src/utils/cn.ts
+++ b/packages/ui/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from './extendTailwindMerge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       i18next:
         specifier: ^23.4.6
         version: 23.12.2
@@ -4679,6 +4682,10 @@ packages:
 
   clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
   color-convert@1.9.3:
@@ -13474,6 +13481,8 @@ snapshots:
       q: 1.5.1
 
   clsx@2.0.0: {}
+
+  clsx@2.1.1: {}
 
   color-convert@1.9.3:
     dependencies:


### PR DESCRIPTION
## Summary

Adds `clsx` and a shadcn-style `cn` helper as foundational prep for the Base UI migration tracked under #254.

### What changed?

- Add `clsx` dependency to `packages/ui`
- Add `cn` helper at `packages/ui/src/utils/cn.ts` that composes class names through `clsx` and the existing extended `twMerge`
- Re-export `cn` from `packages/ui/index.ts`

### Why was this changed?

Base UI's `className` prop is typed `string | ((state) => string)`. Following shadcn's pattern, we want components to drop the function form and accept plain strings, composed with `cn(...)`. This PR introduces the helper without touching any component, so the actual Button (and future component) rewrites can land as separate, focused PRs on top of this.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📦 Dependency updates

## Affected Applications

- [x] 🎨 UI package (`packages/ui/`)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

The `cn` helper is a thin composition of `clsx` and `twMerge`, both of which are independently tested upstream. No behavior beyond pass-through is added.

### How to Test

1. `pnpm install`
2. `pnpm --filter ui lint` — passes (only a pre-existing warning in `Icon/index.tsx`, unrelated)
3. Optional: `import { cn } from 'ui'` from a downstream package and verify it composes Tailwind classes with proper conflict resolution via the extended `twMerge`

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main

## Related Issues

Relates to #254

## Additional Context

This is intentionally a small, isolated PR. The Button migration that consumes `cn` and drops function-className handling will follow as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)