### PR TITLE
✨ Feat: #254 Migrate Button to Base UI ButtonPrimitive and update consumers

### DIFF
--- a/apps/blog/components/error-content/ErrorContent.tsx
+++ b/apps/blog/components/error-content/ErrorContent.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'motion/react';
 import Link from 'next/link';
-import { Button } from 'ui';
+import { Button, buttonVariants } from 'ui';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -84,9 +84,16 @@ export function ErrorContent({
           <Button variant="outline" color="dark" size="lg" onClick={reset}>
             再読み込み
           </Button>
-          <Button variant="default" color="dark" size="lg" asChild>
-            <Link href="/">ホームに戻る</Link>
-          </Button>
+          <Link
+            href="/"
+            className={buttonVariants({
+              variant: 'default',
+              color: 'dark',
+              size: 'lg',
+            })}
+          >
+            ホームに戻る
+          </Link>
         </motion.div>
 
         <motion.p

--- a/apps/blog/components/footer/Footer.tsx
+++ b/apps/blog/components/footer/Footer.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import Link from 'next/link';
-import { Button, Icon } from 'ui';
+import { buttonVariants, Icon } from 'ui';
 
 import { CompanyLogo } from '../company-logo/CompanyLogo';
 
@@ -29,81 +29,84 @@ export function Footer() {
                 <li>
                   <Link
                     href="/category/ENGINEERING"
+                    className={buttonVariants({
+                      color: 'light',
+                      variant: 'ghost',
+                      className: '!font-normal',
+                    })}
                     data-gtm="footer_click_engineering"
                   >
-                    <Button
-                      className="!font-normal"
-                      color="light"
-                      variant="ghost"
-                    >
-                      Engineering
-                    </Button>
+                    Engineering
                   </Link>
                 </li>
 
                 <li>
-                  <Link href="/category/DESIGN" data-gtm="footer_click_design">
-                    <Button
-                      className="!font-normal"
-                      color="light"
-                      variant="ghost"
-                    >
-                      Design
-                    </Button>
+                  <Link
+                    href="/category/DESIGN"
+                    className={buttonVariants({
+                      color: 'light',
+                      variant: 'ghost',
+                      className: '!font-normal',
+                    })}
+                    data-gtm="footer_click_design"
+                  >
+                    Design
                   </Link>
                 </li>
 
                 <li>
                   <Link
                     href="/category/DATA_SCIENCE"
+                    className={buttonVariants({
+                      color: 'light',
+                      variant: 'ghost',
+                      className: '!font-normal',
+                    })}
                     data-gtm="footer_click_data_science"
                   >
-                    <Button
-                      className="!font-normal"
-                      color="light"
-                      variant="ghost"
-                    >
-                      Data Science
-                    </Button>
+                    Data Science
                   </Link>
                 </li>
 
                 <li>
                   <Link
                     href="/category/LIFE_STYLE"
+                    className={buttonVariants({
+                      color: 'light',
+                      variant: 'ghost',
+                      className: '!font-normal',
+                    })}
                     data-gtm="footer_click_life_style"
                   >
-                    <Button
-                      className="!font-normal"
-                      color="light"
-                      variant="ghost"
-                    >
-                      Life Style
-                    </Button>
+                    Life Style
                   </Link>
                 </li>
 
                 <li>
-                  <Link href="/concept" data-gtm="footer_click_concept">
-                    <Button
-                      className="!font-normal"
-                      color="light"
-                      variant="ghost"
-                    >
-                      Concept
-                    </Button>
+                  <Link
+                    href="/concept"
+                    className={buttonVariants({
+                      color: 'light',
+                      variant: 'ghost',
+                      className: '!font-normal',
+                    })}
+                    data-gtm="footer_click_concept"
+                  >
+                    Concept
                   </Link>
                 </li>
 
                 <li>
-                  <Link href="/contact" data-gtm="footer_click_contact">
-                    <Button
-                      className="!font-normal"
-                      color="light"
-                      variant="ghost"
-                    >
-                      Contact
-                    </Button>
+                  <Link
+                    href="/contact"
+                    className={buttonVariants({
+                      color: 'light',
+                      variant: 'ghost',
+                      className: '!font-normal',
+                    })}
+                    data-gtm="footer_click_contact"
+                  >
+                    Contact
                   </Link>
                 </li>
               </ul>
@@ -124,43 +127,37 @@ export function Footer() {
                   className="flex relative items-center gap-5"
                   data-gtm="footer_click_instagram"
                 >
-                  <Button
-                    variant="ghost"
-                    color="light"
-                    size="icon"
-                    type="button"
-                    asChild
+                  <a
+                    href="https://www.instagram.com/k2bg_graphics"
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="instagram"
+                    className={buttonVariants({
+                      variant: 'ghost',
+                      color: 'light',
+                      size: 'icon',
+                    })}
                   >
-                    <a
-                      href="https://www.instagram.com/k2bg_graphics"
-                      target="_blank"
-                      rel="noreferrer"
-                      aria-label="instagram"
-                    >
-                      <Icon name="instagram" color="var(--color-base-white)" />
-                    </a>
-                  </Button>
+                    <Icon name="instagram" color="var(--color-base-white)" />
+                  </a>
                 </li>
                 <li
                   className="flex relative items-center gap-5"
                   data-gtm="footer_click_github"
                 >
-                  <Button
-                    variant="ghost"
-                    color="light"
-                    size="icon"
-                    type="button"
-                    asChild
+                  <a
+                    href="https://github.com/k2bg-technology"
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="github"
+                    className={buttonVariants({
+                      variant: 'ghost',
+                      color: 'light',
+                      size: 'icon',
+                    })}
                   >
-                    <a
-                      href="https://github.com/k2bg-technology"
-                      target="_blank"
-                      rel="noreferrer"
-                      aria-label="github"
-                    >
-                      <Icon name="github" color="var(--color-base-white)" />
-                    </a>
-                  </Button>
+                    <Icon name="github" color="var(--color-base-white)" />
+                  </a>
                 </li>
               </ul>
             </div>

--- a/apps/blog/components/header/Header.tsx
+++ b/apps/blog/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Button, Drawer, DropdownMenu, Icon } from 'ui';
+import { Button, buttonVariants, Drawer, DropdownMenu, Icon } from 'ui';
 import { Category } from '../../modules/post/domain';
 import { CompanyLogo } from '../company-logo/CompanyLogo';
 import { Search } from '../search/Search';
@@ -23,76 +23,82 @@ export function Header() {
               <nav>
                 <ul className="flex items-center gap-x-4">
                   <li>
-                    <Link href={`/category/${Category.ENGINEERING}`}>
-                      <Button
-                        className="!font-normal"
-                        color="dark"
-                        variant="ghost"
-                        data-gtm="header_click_engineering"
-                      >
-                        Engineering
-                      </Button>
+                    <Link
+                      href={`/category/${Category.ENGINEERING}`}
+                      className={buttonVariants({
+                        color: 'dark',
+                        variant: 'ghost',
+                        className: '!font-normal',
+                      })}
+                      data-gtm="header_click_engineering"
+                    >
+                      Engineering
                     </Link>
                   </li>
                   <li>
-                    <Link href={`/category/${Category.DESIGN}`}>
-                      <Button
-                        className="!font-normal"
-                        color="dark"
-                        variant="ghost"
-                        data-gtm="header_click_design"
-                      >
-                        Design
-                      </Button>
+                    <Link
+                      href={`/category/${Category.DESIGN}`}
+                      className={buttonVariants({
+                        color: 'dark',
+                        variant: 'ghost',
+                        className: '!font-normal',
+                      })}
+                      data-gtm="header_click_design"
+                    >
+                      Design
                     </Link>
                   </li>
                   <li>
-                    <Link href={`/category/${Category.DATA_SCIENCE}`}>
-                      <Button
-                        className="!font-normal"
-                        color="dark"
-                        variant="ghost"
-                        data-gtm="header_click_data_science"
-                      >
-                        Data Science
-                      </Button>
+                    <Link
+                      href={`/category/${Category.DATA_SCIENCE}`}
+                      className={buttonVariants({
+                        color: 'dark',
+                        variant: 'ghost',
+                        className: '!font-normal',
+                      })}
+                      data-gtm="header_click_data_science"
+                    >
+                      Data Science
                     </Link>
                   </li>
                   <li>
-                    <Link href={`/category/${Category.LIFE_STYLE}`}>
-                      <Button
-                        className="!font-normal"
-                        color="dark"
-                        variant="ghost"
-                        data-gtm="header_click_life_style"
-                      >
-                        Life Style
-                      </Button>
+                    <Link
+                      href={`/category/${Category.LIFE_STYLE}`}
+                      className={buttonVariants({
+                        color: 'dark',
+                        variant: 'ghost',
+                        className: '!font-normal',
+                      })}
+                      data-gtm="header_click_life_style"
+                    >
+                      Life Style
                     </Link>
                   </li>
                 </ul>
               </nav>
             </div>
             <div className="hidden xl:flex items-center gap-x-4">
-              <Link href="/concept">
-                <Button
-                  className="!font-normal"
-                  color="dark"
-                  variant="ghost"
-                  data-gtm="header_click_concept"
-                >
-                  Concept
-                </Button>
+              <Link
+                href="/concept"
+                className={buttonVariants({
+                  color: 'dark',
+                  variant: 'ghost',
+                  className: '!font-normal',
+                })}
+                data-gtm="header_click_concept"
+              >
+                Concept
               </Link>
-              <Link href="/contact">
-                <Button
-                  className="!font-normal"
-                  color="dark"
-                  variant="ghost"
-                  data-gtm="header_click_contact"
-                >
-                  Contact
-                </Button>
+              <Link
+                href="/contact"
+                className={buttonVariants({
+                  color: 'dark',
+                  variant: 'ghost',
+                  className: '!font-normal',
+                })}
+                data-gtm="header_click_contact"
+              >
+                Contact
               </Link>
               <DropdownMenu>
                 <DropdownMenu.Trigger>

--- a/apps/blog/components/promotion/ProductPromotion.tsx
+++ b/apps/blog/components/promotion/ProductPromotion.tsx
@@ -1,4 +1,4 @@
-import { Button } from 'ui';
+import { buttonVariants } from 'ui';
 
 interface Provider {
   linkText: string;
@@ -38,15 +38,15 @@ export function ProductPromotion(props: ProductPromotionProps) {
         <ul className="flex gap-normal list-none">
           {providers?.map((provider) => (
             <li key={provider.linkText}>
-              <Button asChild style={{ backgroundColor: provider.color }}>
-                <a
-                  href={provider.linkUrl}
-                  target="_blank"
-                  rel="noopener nofollow"
-                >
-                  {provider.linkText}
-                </a>
-              </Button>
+              <a
+                href={provider.linkUrl}
+                target="_blank"
+                rel="noopener nofollow"
+                className={buttonVariants()}
+                style={{ backgroundColor: provider.color }}
+              >
+                {provider.linkText}
+              </a>
             </li>
           ))}
         </ul>

--- a/apps/blog/components/sns-share-button/FacebookShareButton.tsx
+++ b/apps/blog/components/sns-share-button/FacebookShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Icon } from 'ui';
+import { buttonVariants, Icon } from 'ui';
 
 import { useSnsShareInfo } from './useSnsShareInfo';
 
@@ -8,15 +8,18 @@ export function FacebookShareButton() {
   const { fullUrl } = useSnsShareInfo();
 
   return (
-    <Button variant="ghost" color="dark" size="icon" type="button" asChild>
-      <a
-        href={`https://www.facebook.com/sharer/sharer.php?u=${fullUrl}`}
-        target="_blank"
-        rel="noreferrer"
-        aria-label="facebook"
-      >
-        <Icon name="facebook" originalColor width={20} height={20} />
-      </a>
-    </Button>
+    <a
+      href={`https://www.facebook.com/sharer/sharer.php?u=${fullUrl}`}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="facebook"
+      className={buttonVariants({
+        variant: 'ghost',
+        color: 'dark',
+        size: 'icon',
+      })}
+    >
+      <Icon name="facebook" originalColor width={20} height={20} />
+    </a>
   );
 }

--- a/apps/blog/components/sns-share-button/HatenaShareButton.tsx
+++ b/apps/blog/components/sns-share-button/HatenaShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Icon } from 'ui';
+import { buttonVariants, Icon } from 'ui';
 
 import { useSnsShareInfo } from './useSnsShareInfo';
 
@@ -8,15 +8,18 @@ export function HatenaShareButton() {
   const { title, fullUrl } = useSnsShareInfo();
 
   return (
-    <Button variant="ghost" color="dark" size="icon" type="button" asChild>
-      <a
-        href={`https://b.hatena.ne.jp/add?mode=confirm&url=${fullUrl}&title=${title}`}
-        target="_blank"
-        rel="noreferrer"
-        aria-label="hatena"
-      >
-        <Icon name="hatena" originalColor width={20} height={20} />
-      </a>
-    </Button>
+    <a
+      href={`https://b.hatena.ne.jp/add?mode=confirm&url=${fullUrl}&title=${title}`}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="hatena"
+      className={buttonVariants({
+        variant: 'ghost',
+        color: 'dark',
+        size: 'icon',
+      })}
+    >
+      <Icon name="hatena" originalColor width={20} height={20} />
+    </a>
   );
 }

--- a/apps/blog/components/sns-share-button/LineShareButton.tsx
+++ b/apps/blog/components/sns-share-button/LineShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Icon } from 'ui';
+import { buttonVariants, Icon } from 'ui';
 
 import { useSnsShareInfo } from './useSnsShareInfo';
 
@@ -8,15 +8,18 @@ export function LineShareButton() {
   const { title, fullUrl } = useSnsShareInfo();
 
   return (
-    <Button variant="ghost" color="dark" size="icon" type="button" asChild>
-      <a
-        href={`https://line.me/R/msg/text/?${title}%0D%0A${fullUrl}`}
-        target="_blank"
-        rel="noreferrer"
-        aria-label="line"
-      >
-        <Icon name="line" originalColor width={20} height={20} />
-      </a>
-    </Button>
+    <a
+      href={`https://line.me/R/msg/text/?${title}%0D%0A${fullUrl}`}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="line"
+      className={buttonVariants({
+        variant: 'ghost',
+        color: 'dark',
+        size: 'icon',
+      })}
+    >
+      <Icon name="line" originalColor width={20} height={20} />
+    </a>
   );
 }

--- a/apps/blog/components/sns-share-button/PinterestShareButton.tsx
+++ b/apps/blog/components/sns-share-button/PinterestShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Icon } from 'ui';
+import { buttonVariants, Icon } from 'ui';
 
 import { useSnsShareInfo } from './useSnsShareInfo';
 
@@ -8,15 +8,18 @@ export function PinterestShareButton() {
   const { title, fullUrl } = useSnsShareInfo();
 
   return (
-    <Button variant="ghost" color="dark" size="icon" type="button" asChild>
-      <a
-        href={`https://pinterest.com/pin/create/button/?url=${fullUrl}&description=${title}`}
-        target="_blank"
-        rel="noreferrer"
-        aria-label="pinterest"
-      >
-        <Icon name="pinterest" originalColor width={20} height={20} />
-      </a>
-    </Button>
+    <a
+      href={`https://pinterest.com/pin/create/button/?url=${fullUrl}&description=${title}`}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="pinterest"
+      className={buttonVariants({
+        variant: 'ghost',
+        color: 'dark',
+        size: 'icon',
+      })}
+    >
+      <Icon name="pinterest" originalColor width={20} height={20} />
+    </a>
   );
 }

--- a/apps/blog/components/sns-share-button/XShareButton.tsx
+++ b/apps/blog/components/sns-share-button/XShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Icon } from 'ui';
+import { buttonVariants, Icon } from 'ui';
 
 import { useSnsShareInfo } from './useSnsShareInfo';
 
@@ -8,15 +8,18 @@ export function XShareButton() {
   const { title, fullUrl } = useSnsShareInfo();
 
   return (
-    <Button variant="ghost" color="dark" size="icon" type="button" asChild>
-      <a
-        href={`https://twitter.com/share?url=${fullUrl}&text=${title}`}
-        target="_blank"
-        rel="noreferrer"
-        aria-label="x"
-      >
-        <Icon name="x" originalColor width={20} height={20} />
-      </a>
-    </Button>
+    <a
+      href={`https://twitter.com/share?url=${fullUrl}&text=${title}`}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="x"
+      className={buttonVariants({
+        variant: 'ghost',
+        color: 'dark',
+        size: 'icon',
+      })}
+    >
+      <Icon name="x" originalColor width={20} height={20} />
+    </a>
   );
 }

--- a/apps/portfolio/components/ExternalLinkButton.tsx
+++ b/apps/portfolio/components/ExternalLinkButton.tsx
@@ -1,21 +1,28 @@
-import { Button, Icon } from 'ui';
+import { buttonVariants, Icon } from 'ui';
 
 type Props = React.ComponentPropsWithoutRef<'a'>;
 
-export function ExternalLinkButton({ children, ...rest }: Props) {
+export function ExternalLinkButton({ children, className, ...rest }: Props) {
   return (
-    <Button color="light" variant="outline" asChild>
-      <a {...rest} target="_blank" rel="noreferrer">
-        <span className="flex justify-center gap-condensed">
-          <Icon
-            name="arrow-top-right-on-square"
-            color="var(--color-base-white)"
-            width={14}
-            height={14}
-          />
-          {children}
-        </span>
-      </a>
-    </Button>
+    <a
+      {...rest}
+      target="_blank"
+      rel="noreferrer"
+      className={buttonVariants({
+        color: 'light',
+        variant: 'outline',
+        className,
+      })}
+    >
+      <span className="flex justify-center gap-condensed">
+        <Icon
+          name="arrow-top-right-on-square"
+          color="var(--color-base-white)"
+          width={14}
+          height={14}
+        />
+        {children}
+      </span>
+    </a>
   );
 }

--- a/apps/portfolio/components/LanguageSelector.tsx
+++ b/apps/portfolio/components/LanguageSelector.tsx
@@ -1,29 +1,31 @@
 import Link from 'next/link';
-import { Button } from 'ui';
+import { buttonVariants } from 'ui';
 
 export function LanguageSelector() {
   return (
     <div className="fixed left-4 bottom-4 overflow-hidden rounded-md border w-max bg-white/80 shadow-xs">
-      <Button
-        type="button"
-        color="dark"
-        variant="ghost"
-        asChild
-        className="rounded-none"
+      <Link
+        href="/ja"
+        className={buttonVariants({
+          color: 'dark',
+          variant: 'ghost',
+          className: 'rounded-none',
+        })}
         data-gtm="i18n_click_ja_button"
       >
-        <Link href="/ja">ja</Link>
-      </Button>
-      <Button
-        type="button"
-        color="dark"
-        variant="ghost"
-        asChild
-        className="rounded-none"
+        ja
+      </Link>
+      <Link
+        href="/en"
+        className={buttonVariants({
+          color: 'dark',
+          variant: 'ghost',
+          className: 'rounded-none',
+        })}
         data-gtm="i18n_click_en_button"
       >
-        <Link href="/en">en</Link>
-      </Button>
+        en
+      </Link>
     </div>
   );
 }

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,5 +1,5 @@
 export { Avatar } from './src/components/Avatar';
-export { Button } from './src/components/Button';
+export { Button, buttonVariants } from './src/components/Button';
 export { Dialog } from './src/components/Dialog';
 export { Drawer } from './src/components/Drawer';
 export { DropdownMenu } from './src/components/DropdownMenu';

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 import { Icon } from '../Icon';
 
-import { Button } from './Button';
+import { Button, buttonVariants } from './Button';
 
 const meta = {
   component: Button,
@@ -65,12 +65,18 @@ export const IconButton: Story = {
   },
 };
 
+// Renders as a real `<a>` so that link semantics are preserved.
+// Apply `buttonVariants` directly instead of going through the Button
+// component, because Base UI's Button overrides link semantics with
+// `role="button"` when used with a non-button render target.
 export const ExternalLinkButton: Story = {
-  args: {
-    render: (
-      <a href="https://example.com" target="_blank" rel="noopener noreferrer" />
-    ),
-    children: (
+  render: () => (
+    <a
+      href="https://example.com"
+      target="_blank"
+      rel="noopener noreferrer"
+      className={buttonVariants({ color: 'main' })}
+    >
       <span className="flex gap-condensed">
         <Icon
           name="arrow-top-right-on-square"
@@ -80,12 +86,19 @@ export const ExternalLinkButton: Story = {
         />
         External Link
       </span>
-    ),
-  },
+    </a>
+  ),
 };
 
+// Renders as `<input type="submit">` for form submissions where a real
+// `<button type="submit">` cannot be used. Apply `buttonVariants` directly
+// to keep native input semantics.
 export const InputButton: Story = {
-  args: {
-    render: <input type="submit" value="submit" className="cursor-pointer" />,
-  },
+  render: () => (
+    <input
+      type="submit"
+      value="submit"
+      className={buttonVariants({ color: 'main' })}
+    />
+  ),
 };

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -29,9 +29,6 @@ const meta = {
       control: 'select',
       options: ['default', 'sm', 'lg', 'icon'],
     },
-    asChild: {
-      control: 'boolean',
-    },
   },
   parameters: {
     docs: {
@@ -70,26 +67,25 @@ export const IconButton: Story = {
 
 export const ExternalLinkButton: Story = {
   args: {
-    children: (
-      <a href="https://example.com" target="_blank" rel="noopener noreferrer">
-        <span className="flex gap-condensed">
-          <Icon
-            name="arrow-top-right-on-square"
-            color="var(--color-base-white)"
-            width={14}
-            height={14}
-          />
-          External Link
-        </span>
-      </a>
+    render: (
+      <a href="https://example.com" target="_blank" rel="noopener noreferrer" />
     ),
-    asChild: true,
+    children: (
+      <span className="flex gap-condensed">
+        <Icon
+          name="arrow-top-right-on-square"
+          color="var(--color-base-white)"
+          width={14}
+          height={14}
+        />
+        External Link
+      </span>
+    ),
   },
 };
 
 export const InputButton: Story = {
   args: {
-    children: <input type="submit" value="submit" className="cursor-pointer" />,
-    asChild: true,
+    render: <input type="submit" value="submit" className="cursor-pointer" />,
   },
 };

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,11 +1,18 @@
-import { useRender } from '@base-ui/react/use-render';
+import { Button as ButtonPrimitive } from '@base-ui/react/button';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { asChildToRender } from '../../utils/asChildToRender';
-import { twMerge } from '../../utils/extendTailwindMerge';
+import { cn } from '../../utils/cn';
 
-const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap text-button-b-md rounded-md font-bold leading-none focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 transition duration-300 ease-in-out',
+/**
+ * Exported standalone so button styling can be applied to non-`<button>`
+ * elements (e.g. `<a>`, `next/link`'s `Link`). Mirrors shadcn/ui's pattern.
+ *
+ * @see https://ui.shadcn.com/docs/components/button
+ * @see https://github.com/shadcn-ui/ui/blob/main/apps/v4/registry/bases/base/ui/button.tsx
+ */
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap text-button-b-md rounded-md font-bold leading-none cursor-pointer focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed transition duration-300 ease-in-out',
   {
     variants: {
       variant: {
@@ -179,7 +186,7 @@ const buttonVariants = cva(
 );
 
 export interface Props
-  extends Omit<useRender.ComponentProps<'button'>, 'color'>,
+  extends Omit<ButtonPrimitive.Props, 'color'>,
     VariantProps<typeof buttonVariants> {
   // Deprecated. Use the `render` prop. Kept for backward compatibility while
   // consumer call sites migrate; removed once issue #254 closes.
@@ -198,15 +205,15 @@ export function Button({
 }: Props) {
   const renderProps = asChildToRender({ asChild, render, children });
 
-  return useRender({
-    defaultTagName: 'button',
-    render: renderProps.render,
-    props: {
-      className: twMerge(buttonVariants({ variant, color, size }), className),
-      children: renderProps.children,
-      ...rest,
-    },
-  });
+  return (
+    <ButtonPrimitive
+      className={cn(buttonVariants({ variant, color, size }), className)}
+      render={renderProps.render}
+      {...rest}
+    >
+      {renderProps.children}
+    </ButtonPrimitive>
+  );
 }
 
 Button.displayName = 'Button';

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
-import { Slot } from '@radix-ui/react-slot';
+import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';
 
+import { asChildToRender } from '../../utils/asChildToRender';
 import { twMerge } from '../../utils/extendTailwindMerge';
 
 const buttonVariants = cva(
@@ -178,8 +179,10 @@ const buttonVariants = cva(
 );
 
 export interface Props
-  extends Omit<React.ComponentPropsWithRef<'button'>, 'color'>,
+  extends Omit<useRender.ComponentProps<'button'>, 'color'>,
     VariantProps<typeof buttonVariants> {
+  // Deprecated. Use the `render` prop. Kept for backward compatibility while
+  // consumer call sites migrate; removed once issue #254 closes.
   asChild?: boolean;
 }
 
@@ -189,15 +192,21 @@ export function Button({
   size,
   asChild = false,
   className,
+  render,
+  children,
   ...rest
 }: Props) {
-  const Comp = asChild ? Slot : 'button';
-  return (
-    <Comp
-      className={twMerge(buttonVariants({ variant, color, size }), className)}
-      {...rest}
-    />
-  );
+  const renderProps = asChildToRender({ asChild, render, children });
+
+  return useRender({
+    defaultTagName: 'button',
+    render: renderProps.render,
+    props: {
+      className: twMerge(buttonVariants({ variant, color, size }), className),
+      children: renderProps.children,
+      ...rest,
+    },
+  });
 }
 
 Button.displayName = 'Button';

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -1,1 +1,1 @@
-export { Button } from './Button';
+export { Button, buttonVariants } from './Button';


### PR DESCRIPTION
## Summary

Migrates the UI package's Button to Base UI's `ButtonPrimitive` component and updates every downstream consumer that was wrapping a non-button element (`Link`, `<a>`, `<input>`) to apply `buttonVariants` directly to the link/input element instead.

### What changed?

- `packages/ui` Button rewritten on top of `<ButtonPrimitive>` from `@base-ui/react/button` (replacing the previous `useRender` hook approach)
- Class composition switched from `twMerge` to the new `cn` helper; function-form `className` handling is dropped, mirroring shadcn/ui's pattern
- `buttonVariants` is now exported standalone, with TSDoc explaining when to apply it directly to a link/input vs. wrapping with `<Button>`
- Stories updated to demonstrate `buttonVariants` on `<a>` and `<input type="submit">`
- All consumer call sites migrated:
  - `apps/portfolio`: `LanguageSelector`, `ExternalLinkButton`
  - `apps/blog`: 5 SNS share buttons (X, Facebook, Hatena, Pinterest, Line), `Footer` (external icon links + category navigation), `Header` (category navigation + Concept/Contact), `ProductPromotion` (provider links), `ErrorContent` (home link)

### Why was this changed?

Base UI's Button enforces native `<button>` semantics by default. Routing non-button elements through `<Button render={...}>` (or via the legacy `asChild` prop) triggered `nativeButton` console warnings and, in the case of `<Link>`-wrapped-`<Button>` patterns in Header/Footer, produced invalid `<a><button></button></a>` HTML nesting. Applying `buttonVariants` directly to link/input elements preserves their native semantics (focus, role, prefetch, "open in new tab", screen reader announcement) while reusing the Button's design tokens — this is shadcn/ui's recommended composition for "Button as Link".

This PR also unblocks closing the `asChild` deprecation path on the Button component.

## Type of Change

- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 Style/UI changes

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)
- [x] 💼 Portfolio app (`apps/portfolio/`)
- [x] 🎨 UI package (`packages/ui/`)

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] No tests needed (explain why below)

Visual fidelity is covered by the existing Storybook + Chromatic setup; behavioral changes are confined to swapping the underlying primitive while keeping the public API stable. No new logic to unit-test.

### How to Test

1. `pnpm install` (no new dependencies in this PR — `clsx` was added in #263)
2. `pnpm dev`
3. Blog app (`http://localhost:3000`):
   - Open any post → confirm the SNS share icons (X, Facebook, Hatena, Pinterest, Line) render and open the correct share URL in a new tab. Console should show no `nativeButton` warning.
   - Header / Footer: click any category link, Concept, Contact → navigate correctly. Right-click → "Open in new tab" works (proves they are real `<a>` now).
   - Trigger an error route → "ホームに戻る" navigates to `/`.
   - "再読み込み" button still triggers `reset()`.
   - DropdownMenu / Drawer triggers, Search button, scroll-to-top, Contact form submit/reset, Popover triggers in `TableOfContents` → all still work.
4. Portfolio app (`http://localhost:3001`):
   - Bottom-left language switcher: clicking "ja" / "en" navigates and prefetches.
   - Any external link rendered with `ExternalLinkButton` → confirms the consumer-supplied `className` is now respected (was previously silently dropped).
5. Storybook (`pnpm -F ui storybook`): the `ExternalLinkButton` and `InputButton` stories now use the standalone `buttonVariants` pattern.

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`) — no new warnings on the modified files
- [x] Type checking passes — only pre-existing, unrelated errors remain (`HelperText.stories.tsx`, a couple of test files)

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

The Button component's public API is stable. The only behavior shift is that a function-form `className` (`(state) => string`) is now silently ignored instead of being resolved — this matches shadcn/ui upstream and was previously only used internally during the `useRender` phase of #254, so no real consumers relied on it.

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Storybook stories added/updated
- [x] TypeScript types documented (TSDoc on `buttonVariants`)

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main

## Related Issues

Relates to #254
Builds on #263 (cn utility)

## Reviewer Notes

- The PR is split into focused commits; `6906042` is the package-level rewrite, `d74b4d9` is the consumer migration. Reviewing them in that order may be easier than the squashed diff.
- For the Header/Footer category navigation cases, the prior code produced `<a><button></button></a>`, which is invalid HTML. The new code produces a single `<a>` styled with the button variants — please confirm via DevTools that the rendered DOM is what we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)