### PR TITLE
🐛 Fix: #265 Stop dropping children in asChild render element

### DIFF
--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -78,3 +78,17 @@ export const Border: Story = {
     color: 'error',
   },
 };
+
+// Regression coverage for the `asChild` API: the rendered element must keep
+// the label that was passed as the child element's children.
+// @see https://github.com/k2bg-technology/k2bg-branding/issues/265
+export const AsChildLink: Story = {
+  args: {
+    asChild: true,
+    children: (
+      <a href="https://example.com" target="_blank" rel="noopener noreferrer">
+        AsChild Link
+      </a>
+    ),
+  },
+};

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -102,3 +102,17 @@ export const InputButton: Story = {
     />
   ),
 };
+
+// Regression coverage for the `asChild` API: the rendered element must keep
+// the label that was passed as the child element's children.
+// @see https://github.com/k2bg-technology/k2bg-branding/issues/265
+export const AsChildLink: Story = {
+  args: {
+    asChild: true,
+    children: (
+      <a href="https://example.com" target="_blank" rel="noopener noreferrer">
+        AsChild Link
+      </a>
+    ),
+  },
+};

--- a/packages/ui/src/utils/asChildToRender.ts
+++ b/packages/ui/src/utils/asChildToRender.ts
@@ -26,9 +26,12 @@ export function asChildToRender<Props extends AsChildProps>(
     children?: React.ReactNode;
   }>;
 
+  // Forward the element as-is: Base UI's `mergeProps(props, render.props)` is
+  // rightmost-wins, so stripping children here drops the label.
+  // @see https://github.com/k2bg-technology/k2bg-branding/issues/265
   return {
     ...rest,
-    render: React.cloneElement(element, { children: undefined }),
+    render: element,
     children: element.props.children,
   } as Omit<Props, 'asChild'>;
 }


### PR DESCRIPTION
## Summary

### What changed?

- Fix `asChildToRender` so it stops setting `children: undefined` on the cloned element passed to Base UI's `render` prop
- Pass the original child element through unchanged so `render.props.children` still carries the label
- Add `AsChildLink` stories on `Button` and `Badge` to keep this covered by Chromatic

### Why was this changed?

Base UI's `useRenderElement` runs `mergeProps(componentProps, render.props)` with rightmost-wins precedence on non-event keys. The previous implementation used `React.cloneElement(element, { children: undefined })`, which made `children: undefined` an own enumerable property on `render.props`. The merge then overwrote the wrapper-level `children` with `undefined`, so `<Button asChild><a>Label</a></Button>` rendered as `<a></a>` with the label silently dropped. Same bug applied to `<Badge asChild>` since both consumed the same util.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Affected Applications

- [x] 🎨 UI package (`packages/ui/`)

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] Storybook stories added (regression coverage via Chromatic)

### How to Test

1. Run `pnpm -F ui storybook`
2. Open `Button / AsChildLink` and confirm the rendered `<a>` shows the "AsChild Link" label with button styling applied
3. Open `Badge / AsChildLink` and confirm the rendered `<a>` shows the label with badge styling applied
4. Confirm the `Default` and other existing stories still render correctly

### Test Results

- [x] Build succeeds (`pnpm -F ui build-storybook`)
- [x] Linting passes (`pnpm -F ui lint`) — no new warnings introduced

## Documentation

- [x] Storybook stories added/updated

## Related Issues

Closes #265
Relates to #254

## Additional Context

- Raised in PR review: https://github.com/k2bg-technology/k2bg-branding/pull/264#discussion_r3179067139
- The util is still in place as a backward-compat shim until #254 closes; this PR keeps the public API intact and only changes how the child element is forwarded to Base UI