### PR TITLE
✨ Feat: #254 Migrate Avatar to Base UI primitives

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@heroicons/react": "^2.0.18",
-    "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-popover": "^1.1.4",

--- a/packages/ui/public/locales/en/translation.json
+++ b/packages/ui/public/locales/en/translation.json
@@ -190,8 +190,8 @@
           "reason": "Core React library for component functionality"
         },
         {
-          "package": "@radix-ui/react-avatar",
-          "version": "^1.1.1",
+          "package": "@base-ui/react",
+          "version": "^1.4.1",
           "reason": "Provides accessible avatar primitives with image loading states"
         },
         {
@@ -207,8 +207,8 @@
           "description": "Official WCAG documentation on alternative text requirements"
         },
         {
-          "linkText": "Radix UI Avatar Documentation",
-          "url": "https://www.radix-ui.com/primitives/docs/components/avatar",
+          "linkText": "Base UI Avatar Documentation",
+          "url": "https://base-ui.com/react/components/avatar",
           "description": "Official documentation for the underlying primitive component"
         }
       ]

--- a/packages/ui/public/locales/ja/translation.json
+++ b/packages/ui/public/locales/ja/translation.json
@@ -190,8 +190,8 @@
           "reason": "コンポーネント機能のためのコアReactライブラリ"
         },
         {
-          "package": "@radix-ui/react-avatar",
-          "version": "^1.1.1",
+          "package": "@base-ui/react",
+          "version": "^1.4.1",
           "reason": "画像読み込み状態を持つアクセシブルなアバタープリミティブを提供"
         },
         {
@@ -207,8 +207,8 @@
           "description": "代替テキスト要件に関する公式WCAGドキュメント"
         },
         {
-          "linkText": "Radix UI Avatarドキュメント",
-          "url": "https://www.radix-ui.com/primitives/docs/components/avatar",
+          "linkText": "Base UI Avatarドキュメント",
+          "url": "https://base-ui.com/react/components/avatar",
           "description": "基礎となるプリミティブコンポーネントの公式ドキュメント"
         }
       ]

--- a/packages/ui/src/components/Avatar/Fallback.tsx
+++ b/packages/ui/src/components/Avatar/Fallback.tsx
@@ -1,18 +1,18 @@
-import * as AvatarPrimitive from '@radix-ui/react-avatar';
-import { twMerge } from 'tailwind-merge';
+import { Avatar as AvatarPrimitive } from '@base-ui/react/avatar';
 
-type Props = React.ComponentPropsWithRef<'span'>;
+import { cn } from '../../utils/cn';
 
-export function Fallback({ className, ...rest }: Props) {
+export function Fallback({
+  className,
+  ...rest
+}: AvatarPrimitive.Fallback.Props) {
   return (
     <AvatarPrimitive.Fallback
       {...rest}
-      className={twMerge(
+      className={cn(
         'flex h-full w-full items-center justify-center rounded-full bg-gray-200',
         className
       )}
     />
   );
 }
-
-Fallback.displayName = AvatarPrimitive.Fallback.displayName;

--- a/packages/ui/src/components/Avatar/Image.tsx
+++ b/packages/ui/src/components/Avatar/Image.tsx
@@ -1,10 +1,5 @@
-import * as AvatarPrimitive from '@radix-ui/react-avatar';
-import { twMerge } from 'tailwind-merge';
+import { Avatar as AvatarPrimitive } from '@base-ui/react/avatar';
 
-type Props = React.ComponentPropsWithRef<'img'>;
-
-export function Image({ className, ...rest }: Props) {
-  return <AvatarPrimitive.Image {...rest} className={twMerge(className)} />;
+export function Image(props: AvatarPrimitive.Image.Props) {
+  return <AvatarPrimitive.Image {...props} />;
 }
-
-Image.displayName = AvatarPrimitive.Image.displayName;

--- a/packages/ui/src/components/Avatar/Root.tsx
+++ b/packages/ui/src/components/Avatar/Root.tsx
@@ -1,18 +1,15 @@
-import * as AvatarPrimitive from '@radix-ui/react-avatar';
-import { twMerge } from 'tailwind-merge';
+import { Avatar as AvatarPrimitive } from '@base-ui/react/avatar';
 
-type Props = React.ComponentPropsWithRef<'span'>;
+import { cn } from '../../utils/cn';
 
-export function Root({ className, ...rest }: Props) {
+export function Root({ className, ...rest }: AvatarPrimitive.Root.Props) {
   return (
     <AvatarPrimitive.Root
       {...rest}
-      className={twMerge(
+      className={cn(
         'relative flex h-6 w-6 shrink-0 overflow-hidden rounded-full',
         className
       )}
     />
   );
 }
-
-Root.displayName = AvatarPrimitive.Root.displayName;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,9 +334,6 @@ importers:
       '@heroicons/react':
         specifier: ^2.0.18
         version: 2.1.5(react@19.2.1)
-      '@radix-ui/react-avatar':
-        specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-dialog':
         specifier: ^1.0.4
         version: 1.1.1(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -2487,19 +2484,6 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-avatar@1.1.1':
-    resolution: {integrity: sha512-eoOtThOmxeoizxpX6RiEsQZ2wj5r4+zoeqAwO0cBaFQGjJwIH3dIX0OCxNrCyrrdxG+vBweMETh3VziQG7c1kw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -11027,18 +11011,6 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-    optionalDependencies:
-      '@types/react': 19.0.10
-      '@types/react-dom': 19.0.4(@types/react@19.0.10)
-
-  '@radix-ui/react-avatar@1.1.1(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
-    dependencies:
-      '@radix-ui/react-context': 1.1.1(@types/react@19.0.10)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.10)(react@19.2.1)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.10)(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:


### PR DESCRIPTION
## Summary

Phase 3 of the Radix UI → Base UI migration tracked in #254. Switches the Avatar component family to Base UI primitives.

### What changed?

- `Avatar.Root` / `Avatar.Image` / `Avatar.Fallback` now wrap `@base-ui/react/avatar` instead of `@radix-ui/react-avatar`.
- Component prop types use `Avatar.Root.Props` / `Avatar.Image.Props` / `Avatar.Fallback.Props` from Base UI, which means consumers automatically gain access to the `render` prop and (for Image) `onLoadingStatusChange`.
- Default styles (`relative flex h-6 w-6 shrink-0 …` on Root, `flex h-full w-full … bg-gray-200` on Fallback) are preserved verbatim. Image is now a pass-through to the primitive.
- `@radix-ui/react-avatar` removed from `packages/ui/package.json` and `pnpm-lock.yaml` (no other usage in the repo).
- Storybook docs (en/ja `translation.json`) updated to reference `@base-ui/react` and the Base UI Avatar docs URL.

### Why was this changed?

Radix UI development pace has slowed; the project is migrating headless primitives to Base UI per the plan in #254. Avatar is the third component (after Phase 0 Setup, Phase 1 Badge, Phase 2 Button). It is a direct primitive mapping: Base UI exports `Avatar.Root` / `Image` / `Fallback` rendering the same `<span>` / `<img>` / `<span>` elements as Radix, so this phase has the simplest blast radius.

`asChild` shim is **not** needed for Avatar — no consumer in `apps/blog`, `apps/portfolio`, or `packages/ui` passes `asChild` to Avatar.

## Type of Change

- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [x] 📦 Dependency updates

## Affected Applications

- [x] 🎨 UI package (`packages/ui/`)

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] No tests needed (explain why below)

The UI package has no co-located unit tests; verification relies on Storybook + Chromatic visual regression, plus typecheck across consumer apps.

### How to Test

1. `pnpm install` (lockfile changed)
2. `pnpm --filter ui storybook` and visit the **Avatar** stories (`Default`, `WithFallback`, `WithImageAndFallback`, `Small`, `Large`) — visual output should be identical to the previous Radix-backed implementation.
3. Verify in the consumer apps where Avatar appears (e.g. `apps/blog/components/article-heading`, `apps/blog/components/profile-card`, `apps/blog/app/blog/page.tsx`).

### Test Results

- [x] Linting passes (`pnpm --filter ui lint`) — only the pre-existing `Icon/index.tsx` `noAccumulatingSpread` warning remains; unrelated.
- [x] Type checking passes
  - `apps/blog`: `tsc --noEmit` exit 0
  - `apps/portfolio`: `tsc --noEmit` exit 0
  - `packages/ui`: only pre-existing `HelperText.stories.tsx` TS2590 error remains; unrelated.
- [ ] Chromatic visual regression — will run on PR; please review any diffs.

## Breaking Changes

- [x] No breaking changes

The public Avatar API (`<Avatar>{children}</Avatar>` with `<Avatar.Image>` / `<Avatar.Fallback>` and a `className` override) is preserved. Consumers compile and render unchanged.

## Documentation

- [x] Storybook stories added/updated — Avatar stories untouched (no behavior change to demonstrate); only Avatar's "dependencies" / "references" entries in `translation.json` updated.

## Related Issues

Relates to #254

## Reviewer Notes

- Please double-check the Chromatic diff for `Avatar` stories — Base UI's image loading transition uses `data-[transition-status]` attributes rather than Radix's `data-[state]`, but our default styles don't reference either, so visuals should match.
- I deliberately scoped this PR to **just** Avatar. The other Radix → Base UI phases (Phase 4 ScrollArea onward) will land separately per the issue checklist.
