### PR TITLE
✨ Feat: #254 Migrate ScrollArea to Base UI primitives

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,6 @@
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-popover": "^1.1.4",
-    "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/packages/ui/public/locales/en/translation.json
+++ b/packages/ui/public/locales/en/translation.json
@@ -642,8 +642,8 @@
           "reason": "Core React library for component functionality"
         },
         {
-          "package": "@radix-ui/react-scroll-area",
-          "version": "^1.2.3",
+          "package": "@base-ui/react",
+          "version": "^1.4.1",
           "reason": "Provides accessible scroll area primitives with customizable scrollbar styling"
         },
         {
@@ -659,8 +659,8 @@
           "description": "Official WCAG documentation on content reflow and scrolling behavior"
         },
         {
-          "linkText": "Radix UI Scroll Area Documentation",
-          "url": "https://www.radix-ui.com/primitives/docs/components/scroll-area",
+          "linkText": "Base UI Scroll Area Documentation",
+          "url": "https://base-ui.com/react/components/scroll-area",
           "description": "Official documentation for the underlying scroll area primitive component"
         },
         {

--- a/packages/ui/public/locales/ja/translation.json
+++ b/packages/ui/public/locales/ja/translation.json
@@ -642,8 +642,8 @@
           "reason": "コンポーネント機能のためのコアReactライブラリ"
         },
         {
-          "package": "@radix-ui/react-scroll-area",
-          "version": "^1.2.3",
+          "package": "@base-ui/react",
+          "version": "^1.4.1",
           "reason": "カスタマイズ可能なスクロールバースタイルを持つアクセシブルなスクロールエリアプリミティブを提供"
         },
         {
@@ -659,8 +659,8 @@
           "description": "コンテンツのリフローとスクロール動作に関する公式WCAGドキュメント"
         },
         {
-          "linkText": "Radix UI Scroll Areaドキュメント",
-          "url": "https://www.radix-ui.com/primitives/docs/components/scroll-area",
+          "linkText": "Base UI Scroll Areaドキュメント",
+          "url": "https://base-ui.com/react/components/scroll-area",
           "description": "基礎となるスクロールエリアプリミティブコンポーネントの公式ドキュメント"
         },
         {

--- a/packages/ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
 import type * as React from 'react';
-import { twMerge } from 'tailwind-merge';
+
+import { cn } from '../../utils/cn';
 
 import { ScrollBar } from './ScrollBar/ScrollBar';
 
-interface ScrollAreaProps
-  extends React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root> {
+interface ScrollAreaProps extends ScrollAreaPrimitive.Root.Props {
   scrollbar?: React.ReactElement<
     React.ComponentPropsWithoutRef<typeof ScrollBar>
   > | null;
@@ -23,7 +23,7 @@ export function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       {...rest}
-      className={twMerge('flex flex-col relative overflow-hidden', className)}
+      className={cn('flex flex-col relative overflow-hidden', className)}
     >
       <ScrollAreaPrimitive.Viewport
         ref={ref}
@@ -36,4 +36,3 @@ export function ScrollArea({
     </ScrollAreaPrimitive.Root>
   );
 }
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;

--- a/packages/ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.tsx
@@ -29,7 +29,7 @@ export function ScrollArea({
         ref={ref}
         className="flex-grow w-full rounded-[inherit]"
       >
-        {children}
+        <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       {scrollbar || <ScrollBar />}
       <ScrollAreaPrimitive.Corner />

--- a/packages/ui/src/components/ScrollArea/ScrollBar/ScrollBar.module.css
+++ b/packages/ui/src/components/ScrollArea/ScrollBar/ScrollBar.module.css
@@ -1,29 +1,10 @@
 .root {
-  &[data-state='visible'] {
-    animation: fadein 0.2s ease-in 1;
-  }
+  opacity: 0;
+  transition: opacity 0.2s ease-in 0.3s;
 
-  &[data-state='hidden'] {
-    animation: fadeout 0.2s ease-in 1;
-  }
-}
-
-@keyframes fadein {
-  from {
-    opacity: 0;
-  }
-
-  to {
+  &[data-hovering],
+  &[data-scrolling] {
     opacity: 1;
-  }
-}
-
-@keyframes fadeout {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
+    transition-delay: 0s;
   }
 }

--- a/packages/ui/src/components/ScrollArea/ScrollBar/ScrollBar.tsx
+++ b/packages/ui/src/components/ScrollArea/ScrollBar/ScrollBar.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
-import type * as React from 'react';
-import { twMerge } from 'tailwind-merge';
+import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
+
+import { cn } from '../../../utils/cn';
 
 import styles from './ScrollBar.module.css';
 
-type ScrollBarProps = React.ComponentPropsWithRef<
-  typeof ScrollAreaPrimitive.ScrollAreaScrollbar
->;
+type ScrollBarProps = ScrollAreaPrimitive.Scrollbar.Props;
 
 export function ScrollBar({
   className,
@@ -16,10 +14,10 @@ export function ScrollBar({
   ...rest
 }: ScrollBarProps) {
   return (
-    <ScrollAreaPrimitive.ScrollAreaScrollbar
+    <ScrollAreaPrimitive.Scrollbar
       {...rest}
       orientation={orientation}
-      className={twMerge(
+      className={cn(
         'flex touch-none select-none transition-colors',
         orientation === 'vertical' &&
           'h-full w-1.5 md:w-2.5 border-l border-l-transparent p-px',
@@ -29,8 +27,7 @@ export function ScrollBar({
         className
       )}
     >
-      <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-neutral-500/40" />
-    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+      <ScrollAreaPrimitive.Thumb className="relative flex-1 rounded-full bg-neutral-500/40" />
+    </ScrollAreaPrimitive.Scrollbar>
   );
 }
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,9 +343,6 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.4
         version: 1.1.15(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@radix-ui/react-scroll-area':
-        specifier: ^1.2.3
-        version: 1.2.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.3(@types/react@19.0.10)(react@19.2.1)
@@ -2457,14 +2454,8 @@ packages:
   '@prisma/get-platform@5.22.0':
     resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
 
-  '@radix-ui/number@1.1.0':
-    resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
-
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
-
-  '@radix-ui/primitive@1.1.1':
-    resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -2517,15 +2508,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-compose-refs@1.1.1':
-    resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -2537,15 +2519,6 @@ packages:
 
   '@radix-ui/react-context@1.1.0':
     resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-context@1.1.1':
-    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2776,19 +2749,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-presence@1.1.2':
-    resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
@@ -2804,19 +2764,6 @@ packages:
 
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-primitive@2.0.2':
-    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2854,30 +2801,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-scroll-area@1.2.3':
-    resolution: {integrity: sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-slot@1.1.0':
     resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-slot@1.1.2':
-    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -10991,11 +10916,7 @@ snapshots:
     dependencies:
       '@prisma/debug': 5.22.0
 
-  '@radix-ui/number@1.1.0': {}
-
   '@radix-ui/primitive@1.1.0': {}
-
-  '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -11035,12 +10956,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.10
 
-  '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.10)(react@19.2.1)':
-    dependencies:
-      react: 19.2.1
-    optionalDependencies:
-      '@types/react': 19.0.10
-
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.0.10)(react@19.2.1)':
     dependencies:
       react: 19.2.1
@@ -11048,12 +10963,6 @@ snapshots:
       '@types/react': 19.0.10
 
   '@radix-ui/react-context@1.1.0(@types/react@19.0.10)(react@19.2.1)':
-    dependencies:
-      react: 19.2.1
-    optionalDependencies:
-      '@types/react': 19.0.10
-
-  '@radix-ui/react-context@1.1.1(@types/react@19.0.10)(react@19.2.1)':
     dependencies:
       react: 19.2.1
     optionalDependencies:
@@ -11297,16 +11206,6 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
-  '@radix-ui/react-presence@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.2.1)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.10)(react@19.2.1)
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-    optionalDependencies:
-      '@types/react': 19.0.10
-      '@types/react-dom': 19.0.4(@types/react@19.0.10)
-
   '@radix-ui/react-presence@1.1.5(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.2.1)
@@ -11320,15 +11219,6 @@ snapshots:
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@19.0.10)(react@19.2.1)
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-    optionalDependencies:
-      '@types/react': 19.0.10
-      '@types/react-dom': 19.0.4(@types/react@19.0.10)
-
-  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
-    dependencies:
-      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.10)(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     optionalDependencies:
@@ -11361,33 +11251,9 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
-  '@radix-ui/react-scroll-area@1.2.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
-    dependencies:
-      '@radix-ui/number': 1.1.0
-      '@radix-ui/primitive': 1.1.1
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.1(@types/react@19.0.10)(react@19.2.1)
-      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.10)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.10)(react@19.2.1)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.10)(react@19.2.1)
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-    optionalDependencies:
-      '@types/react': 19.0.10
-      '@types/react-dom': 19.0.4(@types/react@19.0.10)
-
   '@radix-ui/react-slot@1.1.0(@types/react@19.0.10)(react@19.2.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.0.10)(react@19.2.1)
-      react: 19.2.1
-    optionalDependencies:
-      '@types/react': 19.0.10
-
-  '@radix-ui/react-slot@1.1.2(@types/react@19.0.10)(react@19.2.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.10)(react@19.2.1)
       react: 19.2.1
     optionalDependencies:
       '@types/react': 19.0.10


### PR DESCRIPTION
## Summary

Phase 4 of the Radix UI → Base UI migration tracked in #254. Switches the ScrollArea component to Base UI's `@base-ui/react/scroll-area` primitives.

### What changed?

- `ScrollArea` Root/Viewport/Corner now use `@base-ui/react/scroll-area`
- `ScrollBar` switched from `ScrollAreaScrollbar`/`ScrollAreaThumb` to `Scrollbar`/`Thumb`
- Scrollbar fade CSS rewritten to key off Base UI's `data-hovering`/`data-scrolling` attributes (Radix's `data-state="visible|hidden"` no longer applies)
- `twMerge` replaced with the shared `cn` helper, matching the prior Avatar/Button migrations
- `@radix-ui/react-scroll-area` dropped from `packages/ui` deps and the lockfile
- Storybook docs (EN/JA) point at the Base UI package and docs URL

### Why was this changed?

Continues the migration plan from #254 (Phase 4: ScrollArea). No `asChild` shim is needed — no consumer passes `asChild` to ScrollArea.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [x] 📦 Dependency updates

## Affected Applications

- [x] 🎨 UI package (`packages/ui/`)

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] No tests needed (no unit tests existed for ScrollArea; behavioral parity verified via Storybook stories)

### How to Test

1. `pnpm --filter ui storybook`
2. Open Components → ScrollArea: Default, VerticalScroll, HorizontalScroll, LongContent, CompactSize
3. Confirm scrollbar appears on hover/scroll and fades after idle
4. Open Components → Drawer (consumer of ScrollArea internally) and confirm content still scrolls

### Test Results

- [x] Build succeeds (`pnpm --filter ui build-storybook`)
- [x] Linting passes (`pnpm --filter ui lint`)
- [x] Type checking passes (`tsc --noEmit` on `packages/ui`, `apps/blog`, `apps/portfolio`)

## Breaking Changes

- [x] No breaking changes (public API of `ScrollArea` and `ScrollArea.ScrollBar` preserved)

## Documentation

- [x] Storybook stories added/updated (translation strings only — references `@base-ui/react` and Base UI docs URL)

## Related Issues

Relates to #254