### PR TITLE
✨ Feat: #255 Add Drizzle schema mirroring production database

### DIFF
--- a/apps/blog/infrastructure/drizzle/schema.ts
+++ b/apps/blog/infrastructure/drizzle/schema.ts
@@ -1,0 +1,109 @@
+// Mirrors the existing production database (created via the Prisma migrations).
+// Table names, enum type names, and constraint/index/FK names are pinned to the
+// values Prisma generated so a future `drizzle-kit pull` then `drizzle-kit
+// generate` reports an empty diff (the schema-continuity safety gate for #255).
+import { relations } from 'drizzle-orm';
+import {
+  foreignKey,
+  pgEnum,
+  pgTable,
+  primaryKey,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+
+export const typeEnum = pgEnum('Type', ['ARTICLE', 'PAGE']);
+
+export const statusEnum = pgEnum('Status', [
+  'IDEA',
+  'DRAFT',
+  'PREVIEW',
+  'PUBLISHED',
+  'ARCHIVED',
+]);
+
+export const categoryEnum = pgEnum('Category', [
+  'ENGINEERING',
+  'DESIGN',
+  'DATA_SCIENCE',
+  'LIFE_STYLE',
+  'OTHER',
+]);
+
+export const authors = pgTable(
+  'Author',
+  {
+    id: serial('id'),
+    uuid: text('uuid').notNull(),
+    name: text('name').notNull(),
+    avatarUrl: text('avatarUrl'),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'date',
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', {
+      withTimezone: true,
+      mode: 'date',
+    }).notNull(),
+  },
+  (table) => [
+    primaryKey({ name: 'Author_pkey', columns: [table.id] }),
+    uniqueIndex('Author_uuid_key').on(table.uuid),
+  ]
+);
+
+export const posts = pgTable(
+  'Post',
+  {
+    id: serial('id'),
+    uuid: text('uuid').notNull(),
+    title: text('title').notNull(),
+    content: text('content').notNull(),
+    type: typeEnum('type').notNull().default('ARTICLE'),
+    excerpt: text('excerpt').notNull(),
+    imageUrl: text('imageUrl').notNull(),
+    slug: text('slug').notNull(),
+    status: statusEnum('status').notNull().default('DRAFT'),
+    category: categoryEnum('category').notNull().default('OTHER'),
+    tags: text('tags').array(),
+    releaseDate: text('releaseDate').notNull(),
+    revisionDate: text('revisionDate').notNull(),
+    authorId: text('authorId').notNull(),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'date',
+    })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', {
+      withTimezone: true,
+      mode: 'date',
+    }).notNull(),
+  },
+  (table) => [
+    primaryKey({ name: 'Post_pkey', columns: [table.id] }),
+    uniqueIndex('Post_uuid_key').on(table.uuid),
+    foreignKey({
+      name: 'Post_authorId_fkey',
+      columns: [table.authorId],
+      foreignColumns: [authors.uuid],
+    })
+      .onDelete('restrict')
+      .onUpdate('cascade'),
+  ]
+);
+
+export const postsRelations = relations(posts, ({ one }) => ({
+  author: one(authors, {
+    fields: [posts.authorId],
+    references: [authors.uuid],
+  }),
+}));
+
+export const authorsRelations = relations(authors, ({ many }) => ({
+  posts: many(posts),
+}));


### PR DESCRIPTION
## Summary

### What changed?

- Add `apps/blog/infrastructure/drizzle/schema.ts` — the Drizzle ORM schema mirroring the existing production database **exactly**.
  - 3 native PG enums: `Type`, `Status`, `Category` (PascalCase type names)
  - `Author` and `Post` tables (PascalCase, matching Prisma-generated DDL)
  - Pinned constraint / index / FK names: `Author_pkey`, `Post_pkey`, `Author_uuid_key`, `Post_uuid_key`, `Post_authorId_fkey` (FK `ON DELETE RESTRICT ON UPDATE CASCADE`)
  - `posts ↔ authors` 1:N `relations()` (TS-only metadata; consumed by Phase 2 adapters)

### Why was this changed?

- Phase 1 item 2 of #255 (Prisma → Drizzle ORM migration). The schema is reconstructed from the two Prisma migrations + `schema.prisma`, with names pinned so a future `drizzle-kit pull` then `drizzle-kit generate` reports an empty diff (the schema-continuity safety gate).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

> Additive, unreferenced schema definition (no other module imports it yet). Correctness of the DB mirror is validated by the next checklist item — `drizzle-kit pull` vs a production snapshot — which requires DB access and is out of scope for this PR.

### How to Test

1. `pnpm --filter=blog exec tsc --noEmit` → passes (verified)
2. `git grep "infrastructure/drizzle"` → no importers (additive, zero blast radius)

### Test Results

- [x] Type checking passes
- [x] Build unaffected (still uses Prisma; Drizzle path not wired up yet)

## Database Changes

- [x] No database changes

> Schema definition only. No migration is run; `drizzle-kit` never touches prod. Prisma remains the live ORM until Phase 5.

## Scope notes

This PR is intentionally **`schema.ts` only**, matching the fine-grained per-checklist-item pattern (deps install was its own PR #275). Explicitly deferred to their own follow-ups:

- Verify schema continuity (`drizzle-kit pull` vs prod snapshot → empty-diff gate) — next Phase 1 item, needs DB access
- `drizzle.config.ts`, `infrastructure/drizzle/client.ts` — separate Phase 1 PRs
- Phases 2–5 (adapters, DI, tests, Prisma removal)

## Implementation notes for reviewers

- `tags` is intentionally **nullable** (`text('tags').array()`, no `.notNull()`): the Prisma migration created `"tags" TEXT[]` without `NOT NULL`.
- `updated_at` has **no** DB default (`.notNull()` only): Prisma `@updatedAt` is app-managed; Phase 2 sets `updatedAt` explicitly on every write path.
- Primary keys use the table-config callback (`primaryKey({ name: ... })`) rather than `serial().primaryKey()` to pin the exact constraint names.
- `@unique` in Prisma generates a unique **index**, so `uniqueIndex(...)` is used (not `.unique()`).
- `infrastructure/**` is outside the blog Biome `files.includes` (same as the existing `infrastructure/prisma/` files), so `pnpm lint` does not cover it; the file follows the established house style.

## Related Issues

Relates to #255