### PR TITLE
🔧 Config: #255 Add Drizzle Kit configuration

### DIFF
--- a/apps/blog/drizzle.config.ts
+++ b/apps/blog/drizzle.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './infrastructure/drizzle/schema.ts',
+  out: './infrastructure/drizzle/migrations',
+  dbCredentials: {
+    url: process.env.DATABASE_URL ?? '',
+  },
+  // Restrict introspection to the application's own tables so a `drizzle-kit
+  // pull` / `generate` diff against the live database is not polluted by the
+  // residual `_prisma_migrations` bookkeeping table.
+  tablesFilter: ['Author', 'Post'],
+  strict: true,
+  verbose: true,
+});


### PR DESCRIPTION
## Summary

Adds `apps/blog/drizzle.config.ts` so `drizzle-kit pull` / `generate` can be invoked against the existing PostgreSQL database. This unlocks the **schema-continuity safety gate** called out by #255 before any runtime Drizzle code is added. Strictly additive — Prisma stays installed and fully functional.

### What changed?

- Add `apps/blog/drizzle.config.ts` (the only file touched)
  - `dialect: 'postgresql'`, `schema: './infrastructure/drizzle/schema.ts'`, `out: './infrastructure/drizzle/migrations'`
  - `dbCredentials.url` reads `DATABASE_URL` (the same env var Prisma uses; see `apps/blog/prisma/schema.prisma:14`)
  - `tablesFilter: ['Author', 'Post']` — restricts introspection to app tables so the residual `_prisma_migrations` table (left over from Prisma's external migrations) does **not** pollute the pull/generate diff
  - `strict: true`, `verbose: true` for safer CLI-only operation
  - `casing` is **not** set — `schema.ts` already encodes the exact column names (`created_at`, `updated_at`, PascalCase tables), so the default `'preserve'` is correct

### Why was this changed?

Continuation of the #255 Prisma → Drizzle migration. Previous PRs added the Drizzle dependencies (#275) and the schema mirror (#276). With this config in place, the implementer can run `drizzle-kit pull` against a production snapshot followed by `drizzle-kit generate` and confirm an empty diff — the safety gate that proves `schema.ts` matches the live database before any adapter rewrite begins.

A `drizzle.config.ts`-only PR mirrors the granularity of #275 / #276 and keeps the review surface minimal. The Drizzle client (`infrastructure/drizzle/client.ts`) is deferred to a follow-up PR so the safety gate is run before any runtime code lands.

## Type of Change

- [x] 🏗️ Build/CI changes

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

`drizzle.config.ts` is a Drizzle Kit CLI config consumed only by the `drizzle-kit` binary. It is not imported by application code, not bundled by Next.js, and not loaded by Vitest. There is no behaviour to unit-test.

### How to Test

Run the schema-continuity safety gate locally against a **prod snapshot** (e.g. `pg_dump` of prod restored into a local PG instance). Never against production directly. `drizzle-kit migrate` / `push` are never invoked.

1. Restore a snapshot of the production DB into a local PostgreSQL instance.
2. From `apps/blog/`:
   ```bash
   DATABASE_URL="<snapshot-url>" pnpm exec drizzle-kit pull
   DATABASE_URL="<snapshot-url>" pnpm exec drizzle-kit generate
   ```
3. Confirm `generate` reports an **empty diff** (no SQL emitted). Any non-empty diff is a regression in `infrastructure/drizzle/schema.ts` and must be reconciled before merge.
4. After the run, do **not** commit any files produced under `infrastructure/drizzle/migrations/`.

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

`pnpm lint` and `pnpm exec tsc --noEmit` (from `apps/blog/`) both pass. The pre-existing 5 Biome warnings on `modules/media/domain/entities/media.test.ts` are unrelated to this change. Prisma-backed tests are unaffected — this PR introduces no runtime imports.

## Database Changes

- [x] No database changes

This PR does not modify the database, run any migrations, or change the Prisma schema. Drizzle Kit is configured for **read-only introspection** (`pull` / `generate`); `migrate` and `push` will never be invoked. External migrations remain the model.

## Environment Variables

- [x] No environment variable changes

Reuses the existing `DATABASE_URL` (already documented in `apps/blog/.env.example`). The variable is read only when `drizzle-kit` CLI is invoked locally, not at application runtime.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

The config file is invisible to Next.js bundling and Lambda runtime. Production builds still run via `next build --webpack` with the existing Prisma client.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings
- [x] Performance impact considered

## Related Issues

Relates to #255

## Reviewer Notes

- Verify the `tablesFilter` whitelist matches the two tables defined in `infrastructure/drizzle/schema.ts` (`Author`, `Post`) so the residual `_prisma_migrations` table is excluded from any future pull/generate diff.
- The `out` directory (`infrastructure/drizzle/migrations/`) is only a scratch destination for the local safety gate; nothing is committed there in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)