### PR TITLE
✨ Feat: #255 Add Drizzle Post mapper alongside Prisma mapper

### DIFF
--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/mapper.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/mapper.ts
@@ -1,0 +1,121 @@
+import type {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import {
+  AuthorId,
+  Category,
+  Content,
+  Excerpt,
+  ImageUrl,
+  Post,
+  PostId,
+  type PostProps,
+  PostStatus,
+  PostType,
+  ReleaseDate,
+  RevisionDate,
+  Slug,
+  Tags,
+  Title,
+} from '../../../../domain';
+import { MappingError } from '../../../shared';
+
+type PostRow = typeof posts.$inferSelect;
+type AuthorRow = typeof authors.$inferSelect;
+export type PostRowWithAuthor = PostRow & { author: AuthorRow };
+
+export function toDomain(row: PostRowWithAuthor): Post {
+  try {
+    const props: PostProps = {
+      id: PostId.create(row.uuid),
+      title: Title.create(row.title),
+      content: Content.create(row.content),
+      type: mapPostType(row.type),
+      excerpt: row.excerpt ? Excerpt.create(row.excerpt) : Excerpt.empty(),
+      imageUrl: ImageUrl.create(row.imageUrl),
+      slug: Slug.create(row.slug),
+      status: mapPostStatus(row.status),
+      category: mapCategory(row.category),
+      tags: Tags.create(row.tags ?? []),
+      authorId: AuthorId.create(row.authorId),
+      releaseDate: ReleaseDate.create(row.releaseDate),
+      revisionDate: RevisionDate.create(row.revisionDate),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      deletedAt: null,
+    };
+
+    return Post.reconstitute(props);
+  } catch (error) {
+    throw new MappingError(
+      `Failed to map Drizzle Post to Domain: ${error instanceof Error ? error.message : String(error)}`,
+      error
+    );
+  }
+}
+
+export function toPersistence(post: Post): typeof posts.$inferInsert {
+  return {
+    uuid: post.id.getValue(),
+    title: post.title.getValue(),
+    content: post.content.getValue(),
+    type: post.type,
+    excerpt: post.excerpt.getValue() ?? '',
+    imageUrl: post.imageUrl.getValue(),
+    slug: post.slug.getValue(),
+    status: post.status,
+    category: post.category,
+    tags: [...post.tags.getValues()],
+    releaseDate: post.releaseDate.toISOString(),
+    revisionDate: post.revisionDate.toISOString(),
+    authorId: post.authorId.getValue(),
+    createdAt: post.createdAt,
+    updatedAt: post.updatedAt,
+  };
+}
+
+function mapPostType(value: string): PostType {
+  switch (value) {
+    case 'ARTICLE':
+      return PostType.ARTICLE;
+    case 'PAGE':
+      return PostType.PAGE;
+    default:
+      return PostType.ARTICLE;
+  }
+}
+
+function mapPostStatus(value: string): PostStatus {
+  switch (value) {
+    case 'IDEA':
+      return PostStatus.IDEA;
+    case 'DRAFT':
+      return PostStatus.DRAFT;
+    case 'PREVIEW':
+      return PostStatus.PREVIEW;
+    case 'PUBLISHED':
+      return PostStatus.PUBLISHED;
+    case 'ARCHIVED':
+      return PostStatus.ARCHIVED;
+    default:
+      return PostStatus.DRAFT;
+  }
+}
+
+function mapCategory(value: string): Category {
+  switch (value) {
+    case 'ENGINEERING':
+      return Category.ENGINEERING;
+    case 'DESIGN':
+      return Category.DESIGN;
+    case 'DATA_SCIENCE':
+      return Category.DATA_SCIENCE;
+    case 'LIFE_STYLE':
+      return Category.LIFE_STYLE;
+    case 'OTHER':
+      return Category.OTHER;
+    default:
+      return Category.OTHER;
+  }
+}


### PR DESCRIPTION
## Summary

### What changed?

- Added `apps/blog/modules/post/adapters/output/repositories/drizzle/mapper.ts` with `toDomain(row)` / `toPersistence(post)` mirroring the existing Prisma mapper.
- The new file is intentionally unused — it lays the groundwork for the rest of the Phase 2 adapter rewrite (post repositories and 5 query services) in subsequent PRs.

### Why was this changed?

Phase 2 of the Prisma → Drizzle migration (#255) needs a Drizzle ↔ domain converter before any repository or query service can be rewritten. Doing it in its own small PR matches the per-step cadence of #275–#279 and lets reviewers focus on the type plumbing (`typeof posts.$inferSelect` / `$inferInsert`, nullable `tags`, explicit `updatedAt`) without competing changes. Prisma stays installed; the existing Prisma mapper and its tests are untouched.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] No tests needed (deferred — Phase 4 introduces Testcontainers and provides DB-backed integration tests for the new Drizzle adapters)

### How to Test

1. `pnpm install`
2. `pnpm --filter test-utils build`
3. `pnpm --filter blog typecheck` — passes
4. `pnpm --filter blog test` — 971 tests still pass (no change)
5. `pnpm --filter blog lint` — clean (only pre-existing warnings outside this PR's scope)

### Test Results

- [x] All existing tests pass (`pnpm --filter blog test` — 971 passed)
- [x] Type checking passes (`pnpm --filter blog typecheck`)
- [x] Linting passes (`pnpm --filter blog lint`)

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

The new mapper is not yet referenced from runtime code paths. Production builds (`prisma generate && next build --webpack`) are unchanged.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards (no JSDoc, no comments beyond what's necessary)
- [x] Self-review completed
- [x] Changes are minimal and focused (single new file, no existing files modified)
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main

## Related Issues

Relates to #255

## Reviewer Notes

- `tags` in `infrastructure/drizzle/schema.ts` is nullable (no `.notNull()`), so `toDomain` uses `row.tags ?? []` before handing to `Tags.create` (which requires a `string[]`).
- `toPersistence` includes both `createdAt` and `updatedAt` because the Drizzle schema only defaults `createdAt` (`updatedAt` is `.notNull()` without `defaultNow()`). The domain `Post` entity already stamps `_updatedAt` on every mutation, so using `post.updatedAt` keeps the domain as the source of truth (issue body's "explicit `updatedAt` on every write path").
- Enum casts (`PostType` / `PostStatus` / `Category`) are safe because both the domain enums and the Drizzle pgEnum types resolve to the same string literal unions.
- No `index.ts` was added under `drizzle/` (YAGNI — will be added when the first consumer arrives in a follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)