### PR TITLE
✨ Feat: #255 Add escapeLike helper and Drizzle row test factories

### DIFF
--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/escapeLike.test.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/escapeLike.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { escapeLike } from './escapeLike';
+
+describe('drizzle/escapeLike', () => {
+  it('returns the value unchanged when it contains no wildcards', () => {
+    const result = escapeLike('hello world');
+
+    expect(result).toBe('hello world');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    const result = escapeLike('');
+
+    expect(result).toBe('');
+  });
+
+  it.each([
+    { input: '%foo%', expected: '\\%foo\\%' },
+    { input: '100_pct', expected: '100\\_pct' },
+    { input: 'back\\slash', expected: 'back\\\\slash' },
+    { input: '50%_off\\foo', expected: '50\\%\\_off\\\\foo' },
+  ])('escapes %, _ and backslash in $input', ({ input, expected }) => {
+    const result = escapeLike(input);
+
+    expect(result).toBe(expected);
+  });
+});

--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/escapeLike.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/escapeLike.ts
@@ -1,0 +1,7 @@
+// Escapes characters that PostgreSQL LIKE/ILIKE treats as wildcards so user
+// input matches as a literal substring (parity with Prisma's `contains`).
+// Backslash must be replaced first via the single regex; otherwise the
+// escapes inserted for % and _ would themselves be re-escaped.
+export function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
+}

--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/index.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/index.ts
@@ -1,0 +1,3 @@
+export { escapeLike } from './escapeLike';
+export type { PostRowWithAuthor } from './mapper';
+export { toDomain, toPersistence } from './mapper';

--- a/apps/blog/modules/post/adapters/shared/index.ts
+++ b/apps/blog/modules/post/adapters/shared/index.ts
@@ -6,8 +6,13 @@ export {
   RepositoryError,
 } from './errors';
 export { postLogger } from './logger';
+export type { DrizzlePostRowWithAuthor } from './testing';
 export {
   createAuthorRecord,
+  createDrizzleAuthorRow,
+  createDrizzlePostRow,
+  createDrizzlePostRowsWithAuthor,
+  createDrizzlePostRowWithAuthor,
   createNotionPageResponse,
   createNotionPageResponses,
   createPrismaPost,

--- a/apps/blog/modules/post/adapters/shared/testing/factories.ts
+++ b/apps/blog/modules/post/adapters/shared/testing/factories.ts
@@ -2,6 +2,16 @@ import type {
   Author as PrismaAuthor,
   Post as PrismaPost,
 } from '@prisma/client';
+import type {
+  authors as drizzleAuthors,
+  posts as drizzlePosts,
+} from '../../../../../infrastructure/drizzle/schema';
+
+type DrizzleAuthorRow = typeof drizzleAuthors.$inferSelect;
+type DrizzlePostRow = typeof drizzlePosts.$inferSelect;
+export type DrizzlePostRowWithAuthor = DrizzlePostRow & {
+  author: DrizzleAuthorRow;
+};
 
 /**
  * Creates a mock Prisma Post record for testing.
@@ -73,6 +83,72 @@ export function createPrismaPostsWithAuthor(
 ): Array<PrismaPost & { author: PrismaAuthor }> {
   return Array.from({ length: count }, (_, index) =>
     createPrismaPostWithAuthor({
+      id: index + 1,
+      uuid: `550e8400-e29b-41d4-a716-44665544000${index}`,
+      slug: `test-post-${index}`,
+      ...overrides,
+    })
+  );
+}
+
+export function createDrizzleAuthorRow(
+  overrides: Partial<DrizzleAuthorRow> = {}
+): DrizzleAuthorRow {
+  return {
+    id: 1,
+    uuid: '660e8400-e29b-41d4-a716-446655440000',
+    name: 'Test Author',
+    avatarUrl: 'https://example.com/avatar.jpg',
+    createdAt: new Date('2024-01-15T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+export function createDrizzlePostRow(
+  overrides: Partial<DrizzlePostRow> = {}
+): DrizzlePostRow {
+  return {
+    id: 1,
+    uuid: '550e8400-e29b-41d4-a716-446655440000',
+    title: 'Test Post Title',
+    content: 'This is the test post content.',
+    type: 'ARTICLE',
+    excerpt: 'Test excerpt',
+    imageUrl: 'https://example.com/image.jpg',
+    slug: 'test-post',
+    status: 'PUBLISHED',
+    category: 'ENGINEERING',
+    tags: ['typescript', 'testing'],
+    releaseDate: '2024-01-15',
+    revisionDate: '2024-01-15',
+    authorId: '660e8400-e29b-41d4-a716-446655440000',
+    createdAt: new Date('2024-01-15T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+export function createDrizzlePostRowWithAuthor(
+  postOverrides: Partial<DrizzlePostRow> = {},
+  authorOverrides: Partial<DrizzleAuthorRow> = {}
+): DrizzlePostRowWithAuthor {
+  const author = createDrizzleAuthorRow(authorOverrides);
+  return {
+    ...createDrizzlePostRow({
+      ...postOverrides,
+      authorId: postOverrides.authorId ?? author.uuid,
+    }),
+    author,
+  };
+}
+
+export function createDrizzlePostRowsWithAuthor(
+  count: number,
+  overrides: Partial<DrizzlePostRow> = {}
+): DrizzlePostRowWithAuthor[] {
+  return Array.from({ length: count }, (_, index) =>
+    createDrizzlePostRowWithAuthor({
       id: index + 1,
       uuid: `550e8400-e29b-41d4-a716-44665544000${index}`,
       slug: `test-post-${index}`,

--- a/apps/blog/modules/post/adapters/shared/testing/index.ts
+++ b/apps/blog/modules/post/adapters/shared/testing/index.ts
@@ -1,5 +1,10 @@
+export type { DrizzlePostRowWithAuthor } from './factories';
 export {
   createAuthorRecord,
+  createDrizzleAuthorRow,
+  createDrizzlePostRow,
+  createDrizzlePostRowsWithAuthor,
+  createDrizzlePostRowWithAuthor,
   createNotionPageResponse,
   createNotionPageResponses,
   createPrismaPost,


### PR DESCRIPTION
## Summary

### What changed?

- Add `escapeLike()` helper at `apps/blog/modules/post/adapters/output/repositories/drizzle/escapeLike.ts` (escapes `%`, `_`, and `\` for PostgreSQL `LIKE`/`ILIKE`)
- Add `createDrizzleAuthorRow` / `createDrizzlePostRow` / `createDrizzlePostRowWithAuthor` / `createDrizzlePostRowsWithAuthor` to `apps/blog/modules/post/adapters/shared/testing/factories.ts`
- Re-export the new helper, factories, and `DrizzlePostRowWithAuthor` type through the existing barrel files

### Why was this changed?

Both pieces are prerequisites for the parallel Drizzle adapter PRs that follow under #255:

- `escapeLike` is needed by the upcoming `searchPostSummariesQueryService` so that `ilike(title, '%' + escapeLike(q) + '%')` preserves the literal-substring behavior of Prisma's `contains`. Without it, user queries containing `%` or `_` would falsely match.
- Drizzle row factories let new adapter tests build fixtures from the Drizzle `posts` / `authors` schema (`$inferSelect`) without importing `@prisma/client`. Prisma factories stay in place — they will be removed in #255 Phase 5 alongside the Prisma adapter code.

This PR is additive only: no existing code paths or tests change.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated (`escapeLike.test.ts`, 6 cases incl. table-driven)
- [x] No tests needed for factories (used by future tests)

### How to Test

```bash
pnpm --filter=blog typecheck
pnpm --filter=blog lint
pnpm --filter=blog test          # 977 tests pass (6 new escapeLike)
```

## Deployment

- [x] No special deployment requirements

## Related Issues

Relates to #255

## Reviewer Notes

- `escapeLike` uses a single regex (`/[\\%_]/g` → `\\$&`) so the backslash insertion can't be re-escaped on a second pass. The test suite includes the combined `50%_off\foo` → `50\%\_off\\foo` case to lock in that ordering.
- Drizzle factories intentionally mirror the existing Prisma factory shape (same defaults for `uuid`, `slug`, etc.) so future side-by-side mapper / repository tests can reuse identical fixture values.