### PR TITLE
✨ Feat: #255 Add Drizzle Post repository

### DIFF
--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/index.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/index.ts
@@ -1,3 +1,4 @@
 export { escapeLike } from './escapeLike';
 export type { PostRowWithAuthor } from './mapper';
 export { toDomain, toPersistence } from './mapper';
+export { DrizzlePostRepository } from './postRepository';

--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.db.test.ts
@@ -1,0 +1,144 @@
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import { PostId, Title } from '../../../../domain';
+import { createPost } from '../../../../use-cases/shared/testing/factories';
+import { createDrizzleAuthorRow, RepositoryError } from '../../../shared';
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../../shared/testing/testDatabase';
+import { DrizzlePostRepository } from './postRepository';
+
+async function insertAuthor(
+  overrides: Parameters<typeof createDrizzleAuthorRow>[0] = {}
+) {
+  const db = getTestDb();
+  const author = createDrizzleAuthorRow(overrides);
+  await db.insert(authors).values({
+    uuid: author.uuid,
+    name: author.name,
+    avatarUrl: author.avatarUrl,
+    updatedAt: author.updatedAt,
+  });
+  return author;
+}
+
+describe('DrizzlePostRepository', () => {
+  beforeAll(async () => {
+    await truncateAllTables();
+  });
+
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  describe('findById', () => {
+    it('returns Post when found', async () => {
+      await insertAuthor();
+      const sut = new DrizzlePostRepository(getTestDb());
+      const post = createPost();
+      await sut.save(post);
+
+      const result = await sut.findById(post.id);
+
+      expect(result).not.toBeNull();
+      expect(result?.id.getValue()).toBe(post.id.getValue());
+      expect(result?.title.getValue()).toBe(post.title.getValue());
+      expect(result?.authorId.getValue()).toBe(post.authorId.getValue());
+    });
+
+    it('returns null when not found', async () => {
+      const sut = new DrizzlePostRepository(getTestDb());
+
+      const result = await sut.findById(
+        PostId.create('00000000-0000-4000-a000-000000000001')
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('save', () => {
+    it('inserts a new post', async () => {
+      await insertAuthor();
+      const sut = new DrizzlePostRepository(getTestDb());
+      const post = createPost();
+
+      await sut.save(post);
+
+      const [stored] = await getTestDb()
+        .select()
+        .from(posts)
+        .where(eq(posts.uuid, post.id.getValue()));
+      expect(stored).toMatchObject({
+        uuid: post.id.getValue(),
+        title: post.title.getValue(),
+        authorId: post.authorId.getValue(),
+        slug: post.slug.getValue(),
+      });
+    });
+
+    it('updates an existing post by uuid', async () => {
+      await insertAuthor();
+      const sut = new DrizzlePostRepository(getTestDb());
+      const original = createPost();
+      await sut.save(original);
+
+      const updatedTitleValue = 'Updated Title';
+      const updatedAt = new Date('2024-02-01T00:00:00.000Z');
+      const revised = createPost({
+        title: Title.create(updatedTitleValue),
+        updatedAt,
+      });
+      await sut.save(revised);
+
+      const [stored] = await getTestDb()
+        .select()
+        .from(posts)
+        .where(eq(posts.uuid, original.id.getValue()));
+      expect(stored.title).toBe(updatedTitleValue);
+      expect(stored.updatedAt).toEqual(updatedAt);
+      const allRows = await getTestDb()
+        .select()
+        .from(posts)
+        .where(eq(posts.uuid, original.id.getValue()));
+      expect(allRows).toHaveLength(1);
+    });
+
+    it('throws RepositoryError when authorId does not match an existing author', async () => {
+      const sut = new DrizzlePostRepository(getTestDb());
+      const post = createPost();
+
+      await expect(sut.save(post)).rejects.toThrow(RepositoryError);
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the post by id', async () => {
+      await insertAuthor();
+      const sut = new DrizzlePostRepository(getTestDb());
+      const post = createPost();
+      await sut.save(post);
+
+      await sut.delete(post.id);
+
+      const stored = await getTestDb()
+        .select()
+        .from(posts)
+        .where(eq(posts.uuid, post.id.getValue()));
+      expect(stored).toEqual([]);
+    });
+
+    it('is a no-op when the post does not exist', async () => {
+      const sut = new DrizzlePostRepository(getTestDb());
+
+      await expect(
+        sut.delete(PostId.create('00000000-0000-4000-a000-000000000002'))
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.ts
@@ -1,0 +1,73 @@
+import { eq } from 'drizzle-orm';
+import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
+import { posts } from '../../../../../../infrastructure/drizzle/schema';
+import type { Post, PostId, PostRepository } from '../../../../domain';
+import { RepositoryError } from '../../../shared';
+import { toDomain, toPersistence } from './mapper';
+
+export class DrizzlePostRepository implements PostRepository {
+  constructor(private readonly db: DrizzleClient) {}
+
+  async findById(id: PostId): Promise<Post | null> {
+    try {
+      const row = await this.db.query.posts.findFirst({
+        where: eq(posts.uuid, id.getValue()),
+        with: { author: true },
+      });
+
+      if (!row) {
+        return null;
+      }
+
+      return toDomain(row);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find post by ID: ${id.getValue()}`,
+        error
+      );
+    }
+  }
+
+  async save(post: Post): Promise<void> {
+    const data = toPersistence(post);
+
+    try {
+      await this.db
+        .insert(posts)
+        .values(data)
+        .onConflictDoUpdate({
+          target: posts.uuid,
+          set: {
+            title: data.title,
+            content: data.content,
+            type: data.type,
+            excerpt: data.excerpt,
+            imageUrl: data.imageUrl,
+            slug: data.slug,
+            status: data.status,
+            category: data.category,
+            tags: data.tags,
+            releaseDate: data.releaseDate,
+            revisionDate: data.revisionDate,
+            updatedAt: data.updatedAt,
+          },
+        });
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to save post: ${post.id.getValue()}`,
+        error
+      );
+    }
+  }
+
+  async delete(id: PostId): Promise<void> {
+    try {
+      await this.db.delete(posts).where(eq(posts.uuid, id.getValue()));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to delete post: ${id.getValue()}`,
+        error
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### What changed?

- `apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.ts`: implements `PostRepository` (findById / save / delete) against the existing Drizzle client and `posts` / `authors` schema
- `apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.db.test.ts`: 7 integration tests against the Testcontainers Postgres set up in PR #282
- Barrel `drizzle/index.ts` re-exports `DrizzlePostRepository`
- Additive only — Prisma version stays in place; DI swap lands in a later PR

### Why was this changed?

Part of the Issue #255 Phase 2 work, replacing Prisma adapters one-by-one before the single DI swap. This PR adds the first Drizzle repository alongside the existing Prisma one so both can coexist while the rest of Tier-1 lands.

### Key behavioral notes

- `save` writes `updatedAt` explicitly on both the insert and the conflict-update branches because Drizzle has no `@updatedAt` equivalent; the value comes from the domain (`Post.updatedAt`), which is the source of truth.
- The author connection that Prisma did via `connect: { uuid }` is enforced by the FK on `Post.authorId → Author.uuid`. Saving a Post whose author doesn't exist now surfaces as `RepositoryError` (covered by a test).
- `delete` returns silently for a missing uuid (Drizzle's natural behavior). Prisma threw on missing — the only caller (`SoftDeletePostUseCase`-style flows) does not observe the difference because it loads + checks existence first.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Integration tests added (7 cases via `*.db.test.ts`)

### How to Test

```bash
pnpm --filter=blog typecheck
pnpm --filter=blog lint
pnpm --filter=blog test        # 977 jsdom tests pass
pnpm --filter=blog test:db     # 9 node-db tests pass (~4s once container is cached)
```

## Deployment

- [x] No special deployment requirements (DI still wires PrismaPostRepository)

## Related Issues

Relates to #255

## Reviewer Notes

- The Drizzle relational-query API (`db.query.posts.findFirst({ with: { author: true } })`) requires `schema` to be registered on the client — already configured in `infrastructure/drizzle/client.ts` so no change here.
- The "throws on FK violation" test is the canonical proof that the try/catch wraps real DB errors into `RepositoryError`; equivalent error paths in findById / delete share the same shape so they're not re-tested.