### PR TITLE
✨ Feat: #255 Add Drizzle fetch-post query service

### DIFF
--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostQueryService.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostQueryService.db.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import { PostId } from '../../../../domain';
+import { createPost } from '../../../../use-cases/shared/testing/factories';
+import {
+  createDrizzleAuthorRow,
+  type DrizzlePostRowWithAuthor,
+} from '../../../shared';
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../../shared/testing/testDatabase';
+import { toPersistence } from '../../repositories/drizzle/mapper';
+import { DrizzleFetchPostQueryService } from './fetchPostQueryService';
+
+async function seedAuthorAndPost(
+  options: {
+    author?: Parameters<typeof createDrizzleAuthorRow>[0];
+    postOverrides?: Parameters<typeof createPost>[0];
+  } = {}
+): Promise<{ postUuid: string; authorUuid: string }> {
+  const db = getTestDb();
+  const author = createDrizzleAuthorRow(options.author);
+  await db.insert(authors).values({
+    uuid: author.uuid,
+    name: author.name,
+    avatarUrl: author.avatarUrl,
+    updatedAt: author.updatedAt,
+  });
+
+  const post = createPost(options.postOverrides);
+  await db.insert(posts).values(toPersistence(post));
+  return { postUuid: post.id.getValue(), authorUuid: author.uuid };
+}
+
+describe('DrizzleFetchPostQueryService', () => {
+  beforeAll(async () => {
+    await truncateAllTables();
+  });
+
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  it('returns the post and author when the post exists', async () => {
+    const { postUuid, authorUuid } = await seedAuthorAndPost();
+    const sut = new DrizzleFetchPostQueryService(getTestDb());
+
+    const result = await sut.fetchPost(PostId.create(postUuid));
+
+    expect(result).not.toBeNull();
+    expect(result?.post.id.getValue()).toBe(postUuid);
+    expect(result?.author).toEqual({
+      id: authorUuid,
+      name: 'Test Author',
+      avatarUrl: 'https://example.com/avatar.jpg',
+    });
+  });
+
+  it('returns null when the post does not exist', async () => {
+    const sut = new DrizzleFetchPostQueryService(getTestDb());
+
+    const result = await sut.fetchPost(
+      PostId.create('00000000-0000-4000-a000-000000000003')
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the post with author.avatarUrl null when the author has none', async () => {
+    const { postUuid } = await seedAuthorAndPost({
+      author: { avatarUrl: null } satisfies Partial<
+        DrizzlePostRowWithAuthor['author']
+      >,
+    });
+    const sut = new DrizzleFetchPostQueryService(getTestDb());
+
+    const result = await sut.fetchPost(PostId.create(postUuid));
+
+    expect(result?.author?.avatarUrl).toBeNull();
+  });
+});

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostQueryService.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostQueryService.ts
@@ -1,0 +1,40 @@
+import { eq } from 'drizzle-orm';
+import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
+import { posts } from '../../../../../../infrastructure/drizzle/schema';
+import type { PostId } from '../../../../domain';
+import type {
+  FetchPostQueryService,
+  PostWithAuthor,
+} from '../../../../use-cases/query/fetch-post/queryService';
+import { RepositoryError } from '../../../shared';
+import { toDomain } from '../../repositories/drizzle/mapper';
+
+export class DrizzleFetchPostQueryService implements FetchPostQueryService {
+  constructor(private readonly db: DrizzleClient) {}
+
+  async fetchPost(id: PostId): Promise<PostWithAuthor | null> {
+    try {
+      const row = await this.db.query.posts.findFirst({
+        where: eq(posts.uuid, id.getValue()),
+        with: { author: true },
+      });
+
+      if (!row) {
+        return null;
+      }
+
+      return {
+        post: toDomain(row),
+        author: row.author
+          ? {
+              id: row.author.uuid,
+              name: row.author.name,
+              avatarUrl: row.author.avatarUrl,
+            }
+          : null,
+      };
+    } catch (error) {
+      throw new RepositoryError('Failed to fetch post', error);
+    }
+  }
+}

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
@@ -1,0 +1,1 @@
+export { DrizzleFetchPostQueryService } from './fetchPostQueryService';


### PR DESCRIPTION
## Summary

### What changed?

- `apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostQueryService.ts`: implements `FetchPostQueryService` against Drizzle's relational query API
- New `query-services/drizzle/` directory with barrel `index.ts` exporting the new service
- `*.db.test.ts` covers happy path, missing post (null), nullable `author.avatarUrl`
- Additive only

### Why was this changed?

Issue #255 Phase 2. First of the five Drizzle query services. The other four follow the same pattern.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Integration tests added (3 cases via `*.db.test.ts`)

### How to Test

```bash
pnpm --filter=blog typecheck
pnpm --filter=blog lint
pnpm --filter=blog test          # jsdom green
pnpm --filter=blog test:db       # 5 node-db tests pass
```

## Deployment

- [x] No special deployment requirements (DI still uses Prisma)

## Related Issues

Relates to #255

## Reviewer Notes

- Reuses `toDomain` from `repositories/drizzle/mapper` so the row → domain mapping stays consistent across query services and the repository.
- The author shape matches `AuthorOutput` (`{ id, name, avatarUrl }`); `id` is the public-facing UUID, not the integer PK.