### PR TITLE
✨ Feat: #255 Add Drizzle fetch-post-summaries query service

### DIFF
--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.db.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import { PostType, ReleaseDate, Slug } from '../../../../domain';
+import {
+  createPost,
+  createPosts,
+} from '../../../../use-cases/shared/testing/factories';
+import { createDrizzleAuthorRow } from '../../../shared';
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../../shared/testing/testDatabase';
+import { toPersistence } from '../../repositories/drizzle/mapper';
+import { DrizzleFetchPostSummariesQueryService } from './fetchPostSummariesQueryService';
+
+async function seedAuthor() {
+  const db = getTestDb();
+  const author = createDrizzleAuthorRow();
+  await db.insert(authors).values({
+    uuid: author.uuid,
+    name: author.name,
+    avatarUrl: author.avatarUrl,
+    updatedAt: author.updatedAt,
+  });
+  return author;
+}
+
+describe('DrizzleFetchPostSummariesQueryService', () => {
+  beforeAll(async () => {
+    await truncateAllTables();
+  });
+
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  it('returns a page of ARTICLE summaries with total count', async () => {
+    await seedAuthor();
+    const db = getTestDb();
+    const articles = createPosts(3);
+    for (const post of articles) {
+      await db.insert(posts).values(toPersistence(post));
+    }
+    const sut = new DrizzleFetchPostSummariesQueryService(db);
+
+    const result = await sut.fetchPostSummaries({
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result.totalCount).toBe(3);
+    expect(result.posts).toHaveLength(3);
+    expect(result.posts[0]).toMatchObject({
+      title: articles[0].title.getValue(),
+      slug: `${articles[0].id.getValue()}/${articles[0].slug.getValue()}`,
+      author: {
+        id: articles[0].authorId.getValue(),
+        name: 'Test Author',
+      },
+    });
+  });
+
+  it('excludes posts whose type is PAGE', async () => {
+    await seedAuthor();
+    const db = getTestDb();
+    const article = createPost();
+    const page = createPost({
+      id: article.id,
+      slug: Slug.create('page-slug'),
+      type: PostType.PAGE,
+    });
+    // Use a fresh id to avoid clobbering the article on insert.
+    await db.insert(posts).values(toPersistence(article));
+    await db.insert(posts).values({
+      ...toPersistence(page),
+      uuid: '550e8400-e29b-41d4-a716-446655440001',
+      slug: 'page-only',
+    });
+    const sut = new DrizzleFetchPostSummariesQueryService(db);
+
+    const result = await sut.fetchPostSummaries({
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result.totalCount).toBe(1);
+    expect(result.posts.map((p) => p.id)).toEqual([article.id.getValue()]);
+  });
+
+  it('paginates with limit and offset and orders by releaseDate', async () => {
+    await seedAuthor();
+    const db = getTestDb();
+    const articles = createPosts(5).map((post, index) =>
+      createPost({
+        id: post.id,
+        slug: post.slug,
+        releaseDate: ReleaseDate.create(`2024-01-${10 + index}`),
+      })
+    );
+    for (const post of articles) {
+      await db.insert(posts).values(toPersistence(post));
+    }
+    const sut = new DrizzleFetchPostSummariesQueryService(db);
+
+    const ascPage1 = await sut.fetchPostSummaries({
+      page: 1,
+      pageSize: 2,
+      orderBy: 'asc',
+    });
+    const ascPage2 = await sut.fetchPostSummaries({
+      page: 2,
+      pageSize: 2,
+      orderBy: 'asc',
+    });
+    const descPage1 = await sut.fetchPostSummaries({
+      page: 1,
+      pageSize: 2,
+      orderBy: 'desc',
+    });
+
+    expect(ascPage1.totalCount).toBe(5);
+    expect(ascPage1.posts.map((p) => p.releaseDate)).toEqual([
+      '2024-01-10',
+      '2024-01-11',
+    ]);
+    expect(ascPage2.posts.map((p) => p.releaseDate)).toEqual([
+      '2024-01-12',
+      '2024-01-13',
+    ]);
+    expect(descPage1.posts.map((p) => p.releaseDate)).toEqual([
+      '2024-01-14',
+      '2024-01-13',
+    ]);
+  });
+
+  it('returns an empty page and zero total when no posts exist', async () => {
+    const sut = new DrizzleFetchPostSummariesQueryService(getTestDb());
+
+    const result = await sut.fetchPostSummaries({
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result).toEqual({ posts: [], totalCount: 0 });
+  });
+});

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.db.test.ts
@@ -40,7 +40,13 @@ describe('DrizzleFetchPostSummariesQueryService', () => {
   it('returns a page of ARTICLE summaries with total count', async () => {
     await seedAuthor();
     const db = getTestDb();
-    const articles = createPosts(3);
+    const articles = createPosts(3).map((post, index) =>
+      createPost({
+        id: post.id,
+        slug: post.slug,
+        releaseDate: ReleaseDate.create(`2024-01-${15 - index}`),
+      })
+    );
     for (const post of articles) {
       await db.insert(posts).values(toPersistence(post));
     }
@@ -136,6 +142,37 @@ describe('DrizzleFetchPostSummariesQueryService', () => {
       '2024-01-14',
       '2024-01-13',
     ]);
+  });
+
+  it('orders by uuid as a stable tiebreaker when releaseDate ties', async () => {
+    await seedAuthor();
+    const db = getTestDb();
+    const sharedDate = ReleaseDate.create('2024-01-10');
+    const articles = createPosts(4, { releaseDate: sharedDate });
+    for (const post of articles) {
+      await db.insert(posts).values(toPersistence(post));
+    }
+    const sut = new DrizzleFetchPostSummariesQueryService(db);
+
+    const page1 = await sut.fetchPostSummaries({
+      page: 1,
+      pageSize: 2,
+      orderBy: 'desc',
+    });
+    const page2 = await sut.fetchPostSummaries({
+      page: 2,
+      pageSize: 2,
+      orderBy: 'desc',
+    });
+
+    const expectedDescIds = articles
+      .map((post) => post.id.getValue())
+      .sort()
+      .reverse();
+    expect(page1.posts.map((p) => p.id)).toEqual(expectedDescIds.slice(0, 2));
+    expect(page2.posts.map((p) => p.id)).toEqual(expectedDescIds.slice(2, 4));
+    const combinedIds = [...page1.posts, ...page2.posts].map((p) => p.id);
+    expect(new Set(combinedIds).size).toBe(4);
   });
 
   it('returns an empty page and zero total when no posts exist', async () => {

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts
@@ -42,7 +42,7 @@ export class DrizzleFetchPostSummariesQueryService
           .from(posts)
           .leftJoin(authors, eq(posts.authorId, authors.uuid))
           .where(eq(posts.type, 'ARTICLE'))
-          .orderBy(direction(posts.releaseDate))
+          .orderBy(direction(posts.releaseDate), direction(posts.uuid))
           .limit(pageSize)
           .offset(offset),
         this.db

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts
@@ -1,0 +1,77 @@
+import { asc, count, desc, eq } from 'drizzle-orm';
+import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import type { Category } from '../../../../domain';
+import type {
+  FetchPostSummariesParams,
+  FetchPostSummariesQueryService,
+  FetchPostSummariesResult,
+} from '../../../../use-cases';
+import { RepositoryError } from '../../../shared';
+
+export class DrizzleFetchPostSummariesQueryService
+  implements FetchPostSummariesQueryService
+{
+  constructor(private readonly db: DrizzleClient) {}
+
+  async fetchPostSummaries(
+    params: FetchPostSummariesParams
+  ): Promise<FetchPostSummariesResult> {
+    const { page, pageSize, orderBy } = params;
+    const offset = (page - 1) * pageSize;
+    const direction = orderBy === 'asc' ? asc : desc;
+
+    try {
+      const [rows, totalRow] = await Promise.all([
+        this.db
+          .select({
+            uuid: posts.uuid,
+            title: posts.title,
+            excerpt: posts.excerpt,
+            imageUrl: posts.imageUrl,
+            slug: posts.slug,
+            category: posts.category,
+            releaseDate: posts.releaseDate,
+            authorUuid: authors.uuid,
+            authorName: authors.name,
+            authorAvatarUrl: authors.avatarUrl,
+          })
+          .from(posts)
+          .leftJoin(authors, eq(posts.authorId, authors.uuid))
+          .where(eq(posts.type, 'ARTICLE'))
+          .orderBy(direction(posts.releaseDate))
+          .limit(pageSize)
+          .offset(offset),
+        this.db
+          .select({ value: count() })
+          .from(posts)
+          .where(eq(posts.type, 'ARTICLE')),
+      ]);
+
+      return {
+        posts: rows.map((row) => ({
+          id: row.uuid,
+          title: row.title,
+          excerpt: row.excerpt || null,
+          imageUrl: row.imageUrl,
+          slug: `${row.uuid}/${row.slug}`,
+          category: row.category as Category,
+          author: row.authorUuid
+            ? {
+                id: row.authorUuid,
+                name: row.authorName ?? '',
+                avatarUrl: row.authorAvatarUrl,
+              }
+            : null,
+          releaseDate: row.releaseDate,
+        })),
+        totalCount: totalRow[0]?.value ?? 0,
+      };
+    } catch (error) {
+      throw new RepositoryError('Failed to fetch post summaries', error);
+    }
+  }
+}

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
@@ -1,0 +1,1 @@
+export { DrizzleFetchPostSummariesQueryService } from './fetchPostSummariesQueryService';


### PR DESCRIPTION
## Summary

### What changed?

- `apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts`: implements `FetchPostSummariesQueryService` with `db.select()` + `leftJoin(authors)` + `eq(posts.type, 'ARTICLE')` + `limit/offset` + a parallel `count()` query
- Updates the `query-services/drizzle/` barrel to re-export the new service
- 4 integration tests covering the happy path, pagination + ordering, PAGE-filter exclusion, and the empty-table case

### Why was this changed?

Issue #255 Phase 2. Second of the five Drizzle query services.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

```bash
pnpm --filter=blog typecheck
pnpm --filter=blog lint
pnpm --filter=blog test          # jsdom green
pnpm --filter=blog test:db       # 6 node-db tests pass
```

## Deployment

- [x] No special deployment requirements (DI still uses Prisma)

## Related Issues

Relates to #255

## Reviewer Notes

- I used a flat `select({ ... })` + `leftJoin` rather than the relational-query API (`db.query.posts.findMany({ with })`) because the summary payload needs only specific columns from both tables; the flat shape avoids overfetching and keeps `count()` straightforward.
- The slug returned to callers is `${uuid}/${slug}` — same composite format the Prisma version emits — so URL generation in the use case layer continues to work unchanged.