### PR TITLE
✨ Feat: #255 Add Drizzle fetch-post-summaries-by-category query service

### DIFF
--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesByCategoryQueryService.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesByCategoryQueryService.db.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import { Category, PostType } from '../../../../domain';
+import { createPost } from '../../../../use-cases/shared/testing/factories';
+import { createDrizzleAuthorRow } from '../../../shared';
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../../shared/testing/testDatabase';
+import { toPersistence } from '../../repositories/drizzle/mapper';
+import { DrizzleFetchPostSummariesByCategoryQueryService } from './fetchPostSummariesByCategoryQueryService';
+
+async function seedAuthor() {
+  const db = getTestDb();
+  const author = createDrizzleAuthorRow();
+  await db.insert(authors).values({
+    uuid: author.uuid,
+    name: author.name,
+    avatarUrl: author.avatarUrl,
+    updatedAt: author.updatedAt,
+  });
+  return author;
+}
+
+async function insertPost(post: ReturnType<typeof createPost>) {
+  await getTestDb().insert(posts).values(toPersistence(post));
+}
+
+describe('DrizzleFetchPostSummariesByCategoryQueryService', () => {
+  beforeAll(async () => {
+    await truncateAllTables();
+  });
+
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  it('returns only articles in the requested category with total count', async () => {
+    await seedAuthor();
+    await insertPost(
+      createPost({
+        id: createPost().id,
+        category: Category.ENGINEERING,
+      })
+    );
+    // Different uuid + slug for the second article
+    await getTestDb()
+      .insert(posts)
+      .values({
+        ...toPersistence(createPost({ category: Category.ENGINEERING })),
+        uuid: '550e8400-e29b-41d4-a716-446655440002',
+        slug: 'eng-2',
+      });
+    await getTestDb()
+      .insert(posts)
+      .values({
+        ...toPersistence(createPost({ category: Category.DESIGN })),
+        uuid: '550e8400-e29b-41d4-a716-446655440003',
+        slug: 'design-1',
+      });
+    const sut = new DrizzleFetchPostSummariesByCategoryQueryService(
+      getTestDb()
+    );
+
+    const result = await sut.fetchPostSummariesByCategory({
+      category: Category.ENGINEERING,
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result.totalCount).toBe(2);
+    expect(result.posts).toHaveLength(2);
+    expect(
+      result.posts.every((post) => post.category === Category.ENGINEERING)
+    ).toBe(true);
+  });
+
+  it('excludes PAGE-type posts even when the category matches', async () => {
+    await seedAuthor();
+    await getTestDb()
+      .insert(posts)
+      .values(
+        toPersistence(
+          createPost({ category: Category.ENGINEERING, type: PostType.PAGE })
+        )
+      );
+    const sut = new DrizzleFetchPostSummariesByCategoryQueryService(
+      getTestDb()
+    );
+
+    const result = await sut.fetchPostSummariesByCategory({
+      category: Category.ENGINEERING,
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result).toEqual({ posts: [], totalCount: 0 });
+  });
+
+  it('returns an empty page when the category has no posts', async () => {
+    await seedAuthor();
+    await getTestDb()
+      .insert(posts)
+      .values(toPersistence(createPost({ category: Category.ENGINEERING })));
+    const sut = new DrizzleFetchPostSummariesByCategoryQueryService(
+      getTestDb()
+    );
+
+    const result = await sut.fetchPostSummariesByCategory({
+      category: Category.LIFE_STYLE,
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result).toEqual({ posts: [], totalCount: 0 });
+  });
+});

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesByCategoryQueryService.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesByCategoryQueryService.ts
@@ -1,0 +1,81 @@
+import { and, asc, count, desc, eq } from 'drizzle-orm';
+import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import type { Category } from '../../../../domain';
+import type {
+  FetchPostSummariesByCategoryParams,
+  FetchPostSummariesByCategoryQueryService,
+  FetchPostSummariesByCategoryResult,
+} from '../../../../use-cases';
+import { RepositoryError } from '../../../shared';
+
+export class DrizzleFetchPostSummariesByCategoryQueryService
+  implements FetchPostSummariesByCategoryQueryService
+{
+  constructor(private readonly db: DrizzleClient) {}
+
+  async fetchPostSummariesByCategory(
+    params: FetchPostSummariesByCategoryParams
+  ): Promise<FetchPostSummariesByCategoryResult> {
+    const { category, page, pageSize, orderBy } = params;
+    const offset = (page - 1) * pageSize;
+    const direction = orderBy === 'asc' ? asc : desc;
+    const whereClause = and(
+      eq(posts.type, 'ARTICLE'),
+      eq(posts.category, category)
+    );
+
+    try {
+      const [rows, totalRow] = await Promise.all([
+        this.db
+          .select({
+            uuid: posts.uuid,
+            title: posts.title,
+            excerpt: posts.excerpt,
+            imageUrl: posts.imageUrl,
+            slug: posts.slug,
+            category: posts.category,
+            releaseDate: posts.releaseDate,
+            authorUuid: authors.uuid,
+            authorName: authors.name,
+            authorAvatarUrl: authors.avatarUrl,
+          })
+          .from(posts)
+          .leftJoin(authors, eq(posts.authorId, authors.uuid))
+          .where(whereClause)
+          .orderBy(direction(posts.releaseDate))
+          .limit(pageSize)
+          .offset(offset),
+        this.db.select({ value: count() }).from(posts).where(whereClause),
+      ]);
+
+      return {
+        posts: rows.map((row) => ({
+          id: row.uuid,
+          title: row.title,
+          excerpt: row.excerpt || null,
+          imageUrl: row.imageUrl,
+          slug: `${row.uuid}/${row.slug}`,
+          category: row.category as Category,
+          author: row.authorUuid
+            ? {
+                id: row.authorUuid,
+                name: row.authorName ?? '',
+                avatarUrl: row.authorAvatarUrl,
+              }
+            : null,
+          releaseDate: row.releaseDate,
+        })),
+        totalCount: totalRow[0]?.value ?? 0,
+      };
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to fetch post summaries by category: ${category}`,
+        error
+      );
+    }
+  }
+}

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
@@ -1,0 +1,1 @@
+export { DrizzleFetchPostSummariesByCategoryQueryService } from './fetchPostSummariesByCategoryQueryService';


### PR DESCRIPTION
## Summary

### What changed?

- `apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesByCategoryQueryService.ts`: implements `FetchPostSummariesByCategoryQueryService` with `and(eq(type, 'ARTICLE'), eq(category, ...))` + leftJoin(authors) + pagination + parallel `count()`
- 3 integration tests
- Additive only

### Why was this changed?

Issue #255 Phase 2. Third of the five Drizzle query services. Same shape as `fetchPostSummariesQueryService` but with an extra `category` predicate.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

```bash
pnpm --filter=blog typecheck
pnpm --filter=blog lint
pnpm --filter=blog test          # jsdom green
pnpm --filter=blog test:db       # 5 node-db tests pass
```

## Deployment

- [x] No special deployment requirements (DI still uses Prisma)

## Related Issues

Relates to #255

## Reviewer Notes

- I left the `category` cast (`row.category as Category`) in the mapped output because Drizzle returns the column as `string` (the enum literal type isn't narrowed when selected via `select({ ... })`). The cast is safe — the column is the same PG enum the `Category` union mirrors.