### PR TITLE
✨ Feat: #255 Add Drizzle fetch-all-slugs query service

### DIFF
--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchAllSlugsQueryService.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchAllSlugsQueryService.db.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import { PostType, ReleaseDate } from '../../../../domain';
+import { createPost } from '../../../../use-cases/shared/testing/factories';
+import { createDrizzleAuthorRow } from '../../../shared';
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../../shared/testing/testDatabase';
+import { toPersistence } from '../../repositories/drizzle/mapper';
+import { DrizzleFetchAllSlugsQueryService } from './fetchAllSlugsQueryService';
+
+async function seedAuthor() {
+  const db = getTestDb();
+  const author = createDrizzleAuthorRow();
+  await db.insert(authors).values({
+    uuid: author.uuid,
+    name: author.name,
+    avatarUrl: author.avatarUrl,
+    updatedAt: author.updatedAt,
+  });
+}
+
+describe('DrizzleFetchAllSlugsQueryService', () => {
+  beforeAll(async () => {
+    await truncateAllTables();
+  });
+
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  it('returns id + slug for every ARTICLE in releaseDate order', async () => {
+    await seedAuthor();
+    const db = getTestDb();
+    const post1 = createPost({
+      releaseDate: ReleaseDate.create('2024-01-10'),
+    });
+    await db.insert(posts).values(toPersistence(post1));
+    await db.insert(posts).values({
+      ...toPersistence(
+        createPost({ releaseDate: ReleaseDate.create('2024-01-15') })
+      ),
+      uuid: '550e8400-e29b-41d4-a716-446655440002',
+      slug: 'second-article',
+    });
+    const sut = new DrizzleFetchAllSlugsQueryService(db);
+
+    const ascResult = await sut.fetchAllSlugs({ orderBy: 'asc' });
+    const descResult = await sut.fetchAllSlugs({ orderBy: 'desc' });
+
+    expect(ascResult.map((row) => row.slug)).toEqual([
+      post1.slug.getValue(),
+      'second-article',
+    ]);
+    expect(descResult.map((row) => row.slug)).toEqual([
+      'second-article',
+      post1.slug.getValue(),
+    ]);
+  });
+
+  it('excludes PAGE-type posts', async () => {
+    await seedAuthor();
+    await getTestDb()
+      .insert(posts)
+      .values(toPersistence(createPost({ type: PostType.PAGE })));
+    const sut = new DrizzleFetchAllSlugsQueryService(getTestDb());
+
+    const result = await sut.fetchAllSlugs({ orderBy: 'desc' });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when there are no posts', async () => {
+    const sut = new DrizzleFetchAllSlugsQueryService(getTestDb());
+
+    const result = await sut.fetchAllSlugs({ orderBy: 'desc' });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchAllSlugsQueryService.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchAllSlugsQueryService.ts
@@ -1,0 +1,31 @@
+import { asc, desc, eq } from 'drizzle-orm';
+import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
+import { posts } from '../../../../../../infrastructure/drizzle/schema';
+import type {
+  FetchAllSlugsParams,
+  FetchAllSlugsQueryService,
+  SlugRecord,
+} from '../../../../use-cases';
+import { RepositoryError } from '../../../shared';
+
+export class DrizzleFetchAllSlugsQueryService
+  implements FetchAllSlugsQueryService
+{
+  constructor(private readonly db: DrizzleClient) {}
+
+  async fetchAllSlugs(params: FetchAllSlugsParams): Promise<SlugRecord[]> {
+    const direction = params.orderBy === 'asc' ? asc : desc;
+
+    try {
+      const rows = await this.db
+        .select({ uuid: posts.uuid, slug: posts.slug })
+        .from(posts)
+        .where(eq(posts.type, 'ARTICLE'))
+        .orderBy(direction(posts.releaseDate));
+
+      return rows.map((row) => ({ id: row.uuid, slug: row.slug }));
+    } catch (error) {
+      throw new RepositoryError('Failed to fetch all slugs', error);
+    }
+  }
+}

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
@@ -1,0 +1,1 @@
+export { DrizzleFetchAllSlugsQueryService } from './fetchAllSlugsQueryService';


### PR DESCRIPTION
## Summary

### What changed?

- `apps/blog/modules/post/adapters/output/query-services/drizzle/fetchAllSlugsQueryService.ts`: returns every ARTICLE's `(uuid, slug)` ordered by `releaseDate`
- 3 integration tests
- Additive only

### Why was this changed?

Issue #255 Phase 2. Fourth of the five Drizzle query services. Used by Next.js `generateStaticParams` for `/blog/[uuid]/[slug]` pages, so the return shape (`{ id, slug }`) is preserved exactly.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

```bash
pnpm --filter=blog typecheck
pnpm --filter=blog lint
pnpm --filter=blog test          # jsdom green
pnpm --filter=blog test:db       # 5 node-db tests pass
```

## Deployment

- [x] No special deployment requirements (DI still uses Prisma)

## Related Issues

Relates to #255