### PR TITLE
✨ Feat: #255 Add Drizzle search-post-summaries query service

### DIFF
--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/index.ts
@@ -1,0 +1,1 @@
+export { DrizzleSearchPostSummariesQueryService } from './searchPostSummariesQueryService';

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/searchPostSummariesQueryService.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/searchPostSummariesQueryService.db.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import { PostType, Title } from '../../../../domain';
+import { createPost } from '../../../../use-cases/shared/testing/factories';
+import { createDrizzleAuthorRow } from '../../../shared';
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../../shared/testing/testDatabase';
+import { toPersistence } from '../../repositories/drizzle/mapper';
+import { DrizzleSearchPostSummariesQueryService } from './searchPostSummariesQueryService';
+
+async function seedAuthor() {
+  const db = getTestDb();
+  const author = createDrizzleAuthorRow();
+  await db.insert(authors).values({
+    uuid: author.uuid,
+    name: author.name,
+    avatarUrl: author.avatarUrl,
+    updatedAt: author.updatedAt,
+  });
+}
+
+async function insertArticle(
+  uuid: string,
+  title: string,
+  options: {
+    type?: PostType;
+  } = {}
+) {
+  const post = createPost({
+    title: Title.create(title),
+    type: options.type ?? PostType.ARTICLE,
+  });
+  await getTestDb()
+    .insert(posts)
+    .values({ ...toPersistence(post), uuid, slug: `slug-${uuid.slice(0, 4)}` });
+}
+
+describe('DrizzleSearchPostSummariesQueryService', () => {
+  beforeAll(async () => {
+    await truncateAllTables();
+  });
+
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  it('matches title case-insensitively (ILIKE)', async () => {
+    await seedAuthor();
+    await insertArticle(
+      '550e8400-e29b-41d4-a716-446655440010',
+      'TypeScript Tips'
+    );
+    await insertArticle('550e8400-e29b-41d4-a716-446655440011', 'react hooks');
+    const sut = new DrizzleSearchPostSummariesQueryService(getTestDb());
+
+    const result = await sut.searchPostSummaries({
+      query: 'TYPESCRIPT',
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result.totalCount).toBe(1);
+    expect(result.posts[0].title).toBe('TypeScript Tips');
+  });
+
+  it('treats % and _ in the query as literal characters via escapeLike', async () => {
+    await seedAuthor();
+    await insertArticle(
+      '550e8400-e29b-41d4-a716-446655440020',
+      'Profit jumped 50% in Q2'
+    );
+    await insertArticle(
+      '550e8400-e29b-41d4-a716-446655440021',
+      'Plain headline with no special chars'
+    );
+    const sut = new DrizzleSearchPostSummariesQueryService(getTestDb());
+
+    const literalMatch = await sut.searchPostSummaries({
+      query: '50%',
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+    expect(literalMatch.posts.map((post) => post.title)).toEqual([
+      'Profit jumped 50% in Q2',
+    ]);
+
+    const noWildcardOverreach = await sut.searchPostSummaries({
+      query: 'doesnotexist%',
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+    expect(noWildcardOverreach.totalCount).toBe(0);
+  });
+
+  it('excludes PAGE-type posts even when the title matches', async () => {
+    await seedAuthor();
+    await insertArticle(
+      '550e8400-e29b-41d4-a716-446655440030',
+      'Doc Page Heading',
+      { type: PostType.PAGE }
+    );
+    const sut = new DrizzleSearchPostSummariesQueryService(getTestDb());
+
+    const result = await sut.searchPostSummaries({
+      query: 'Doc',
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result).toEqual({ posts: [], totalCount: 0 });
+  });
+
+  it('returns an empty page when nothing matches', async () => {
+    const sut = new DrizzleSearchPostSummariesQueryService(getTestDb());
+
+    const result = await sut.searchPostSummaries({
+      query: 'anything',
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+    });
+
+    expect(result).toEqual({ posts: [], totalCount: 0 });
+  });
+});

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/searchPostSummariesQueryService.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/searchPostSummariesQueryService.ts
@@ -1,0 +1,85 @@
+import { and, asc, count, desc, eq, ilike } from 'drizzle-orm';
+import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
+import {
+  authors,
+  posts,
+} from '../../../../../../infrastructure/drizzle/schema';
+import type { Category } from '../../../../domain';
+import type {
+  SearchPostSummariesParams,
+  SearchPostSummariesQueryService,
+  SearchPostSummariesResult,
+} from '../../../../use-cases';
+import { RepositoryError } from '../../../shared';
+import { escapeLike } from '../../repositories/drizzle/escapeLike';
+
+export class DrizzleSearchPostSummariesQueryService
+  implements SearchPostSummariesQueryService
+{
+  constructor(private readonly db: DrizzleClient) {}
+
+  async searchPostSummaries(
+    params: SearchPostSummariesParams
+  ): Promise<SearchPostSummariesResult> {
+    const { query, page, pageSize, orderBy } = params;
+    const offset = (page - 1) * pageSize;
+    const direction = orderBy === 'asc' ? asc : desc;
+    // Escape % and _ so they match literally — preserves Prisma `contains`
+    // semantics now that we switched from `contains` to ILIKE.
+    const titlePattern = `%${escapeLike(query)}%`;
+    const whereClause = and(
+      eq(posts.type, 'ARTICLE'),
+      ilike(posts.title, titlePattern)
+    );
+
+    try {
+      const [rows, totalRow] = await Promise.all([
+        this.db
+          .select({
+            uuid: posts.uuid,
+            title: posts.title,
+            excerpt: posts.excerpt,
+            imageUrl: posts.imageUrl,
+            slug: posts.slug,
+            category: posts.category,
+            releaseDate: posts.releaseDate,
+            authorUuid: authors.uuid,
+            authorName: authors.name,
+            authorAvatarUrl: authors.avatarUrl,
+          })
+          .from(posts)
+          .leftJoin(authors, eq(posts.authorId, authors.uuid))
+          .where(whereClause)
+          .orderBy(direction(posts.releaseDate))
+          .limit(pageSize)
+          .offset(offset),
+        this.db.select({ value: count() }).from(posts).where(whereClause),
+      ]);
+
+      return {
+        posts: rows.map((row) => ({
+          id: row.uuid,
+          title: row.title,
+          excerpt: row.excerpt || null,
+          imageUrl: row.imageUrl,
+          slug: `${row.uuid}/${row.slug}`,
+          category: row.category as Category,
+          author: row.authorUuid
+            ? {
+                id: row.authorUuid,
+                name: row.authorName ?? '',
+                avatarUrl: row.authorAvatarUrl,
+              }
+            : null,
+          releaseDate: row.releaseDate,
+        })),
+        totalCount: totalRow[0]?.value ?? 0,
+      };
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to search post summaries with query: ${query}`,
+        error
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### What changed?

- `apps/blog/modules/post/adapters/output/query-services/drizzle/searchPostSummariesQueryService.ts`: implements `SearchPostSummariesQueryService` using `ilike(posts.title, '%' + escapeLike(query) + '%')`
- 4 integration tests including the wildcard-escape regression
- Additive only

### Why was this changed?

Issue #255 Phase 2. **Final** of the seven Tier-1 Drizzle adapter PRs. Prisma's `contains` treats `%` and `_` literally; ILIKE does not, so reusing the `escapeLike` helper (PR #281) is necessary to keep search results behavior-identical.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

```bash
pnpm --filter=blog typecheck
pnpm --filter=blog lint
pnpm --filter=blog test          # jsdom green
pnpm --filter=blog test:db       # 6 node-db tests pass (~4s)
```

## Deployment

- [x] No special deployment requirements (DI still uses Prisma)

## Related Issues

Relates to #255 — completes Tier-1 (Drizzle adapters). The next PR after merge will swap the DI bindings to the Drizzle implementations all at once, then a manual Amplify staging E2E, then final Prisma removal.

## Reviewer Notes

- The "treats % and _ as literal" test is the regression I care about most — it would have silently broken search for any title containing those characters had we used a naive `ilike(title, '%' + query + '%')`.
- Same `select` + `leftJoin` shape as `fetchPostSummariesQueryService` and `fetchPostSummariesByCategoryQueryService`; the only structural difference is the `ilike` predicate.