### PR TITLE
👷 Chore: #291 Upgrade Claude Code Action to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,57 +32,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Allow Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-5-20251101"
-
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-
-          # MCP server configuration for Figma-Context-MCP
-          mcp_config: |
-            {
-              "mcpServers": {
-                "Framelink Figma MCP": {
-                  "command": "npx",
-                  "args": [
-                    "-y",
-                    "figma-developer-mcp",
-                    "--figma-api-key=${{ secrets.FIGMA_API_KEY }}",
-                    "--stdio"
-                  ]
-                }
-              }
-            }
-
-          # Allow Figma MCP tools (required as per Claude Code docs)
-          allowed_tools: 'Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*),mcp__Framelink_Figma_MCP__*'
-
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          custom_instructions: |
-            Follow our coding standards
-            Ensure all new code has tests
-            Use TypeScript for new files
-
-            When Figma links are provided:
-            1. Use Figma MCP to fetch design data
-            2. Analyze components and layout
-            3. Generate corresponding implementation
-            4. Follow existing code patterns in the repository
-
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # CLI arguments passed to Claude Code (model, tools, etc.)
+          # Project standards are read automatically from CLAUDE.md
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"


### PR DESCRIPTION
## Summary

Upgrade the `Claude Code` GitHub Action workflow from the deprecated `@beta` to the GA `@v1`, and align its configuration with the v1 input model.

### What changed?

- Bump `anthropics/claude-code-action` from `@beta` to `@v1`
- Move `model` and `allowed_tools` into `claude_args` (`--model claude-sonnet-4-6`, `--allowedTools`)
- Switch the model to Sonnet (`claude-sonnet-4-6`) to conserve the Agent SDK credit
- Remove the Figma MCP config block and the `mcp__Framelink_Figma_MCP__*` tool allowance
- Drop the redundant `custom_instructions` (project standards are read automatically from `CLAUDE.md`)
- Keep `on:` triggers, the `@claude` `if:` gate, `permissions:`, and `additional_permissions` unchanged

### Why was this changed?

- `@beta` is deprecated and emits warnings; v1 unifies inputs into `prompt` / `claude_args` and auto-detects mode
- From 2026-06-15, Claude Code GitHub Actions usage bills against the new Agent SDK credit pool (Max 5x = $100/month), separate from interactive subscription limits, so model choice now affects credit consumption

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions or updates
- [ ] 🔒 Security improvements
- [ ] 📦 Dependency updates
- [x] 🏗️ Build/CI changes

## Affected Applications

- [ ] 📝 Blog app (`apps/blog/`)
- [ ] 💼 Portfolio app (`apps/portfolio/`)
- [ ] 🎨 UI package (`packages/ui/`)
- [ ] 🔧 Shared packages (`packages/`)
- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

This is a CI workflow configuration change with no application code impact.

### How to Test

1. Mention `@claude` in an issue or PR comment after merge
2. Confirm the workflow triggers and Claude responds
3. Confirm the run logs no longer emit the `@beta` deprecation warning

### Test Results

- [x] YAML validity confirmed locally (`ruby -ryaml`)

## Database Changes

- [x] No database changes

## Environment Variables

- [x] Existing environment variables modified

**Required environment variables:**

- `FIGMA_API_KEY` is no longer referenced by this workflow (Figma MCP removed). The secret itself is left in place and can be removed separately if unused elsewhere.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] Other (specify below)

**Deployment instructions:**

- Maintainers must claim the Agent SDK credit once during June (one-time opt-in in the Claude account), and optionally enable extra usage. Otherwise the action may stop mid-month after 2026-06-15, since Claude Code GitHub Actions now bills against the Agent SDK credit pool (Max 5x = $100/month).

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main

## Related Issues

Closes #291

## Additional Context

References: claude-code-action migration guide, Claude Code GitHub Actions docs, Agent SDK credit Help Center article.

## Reviewer Notes

- Confirm the `claude_args` quoting for `--allowedTools` is correct for the v1 CLI passthrough.
