### PR TITLE
🔥 Remove: #253 Remove webpack flag and legacy SVG handler to enable Turbopack production builds

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -93,14 +93,6 @@ const config = {
       },
     ],
   },
-  webpack(config) {
-    config.module.rules.push({
-      test: /\.svg/,
-      type: 'asset/resource',
-    });
-
-    return config;
-  },
 };
 
 export default config;

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes #253

## Changes

- Removed `-- webpack` flag from blog build script; production builds now use Turbopack by default
- Removed legacy `webpack()` SVG config from `next.config.mjs` (no SVG imports in blog app; Turbopack handles static assets natively)
- The primary Prisma + Turbopack blocker is no longer relevant as the app has migrated to Drizzle ORM

## Manual Validation Required

- End-to-end testing on AWS Amplify (Lambda) to confirm Turbopack production build deploys and runs correctly

Generated with [Claude Code](https://claude.ai/code)