### PR TITLE
📝 Docs: #294 Add Codex review guidelines and agent roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,32 @@
 - Environment variables are required for builds (see `turbo.json` env list). Place app-specific secrets in `apps/*/.env.local` and never commit them.
 - Avoid storing tokens in code or stories; prefer `.env` and runtime config.
 
+## Codex Review Guidelines
+
+Codex posts only P0/P1 issues. Apply these rules when reviewing a pull request:
+
+- **Missing tests (P1):** New or changed logic without co-located `*.test.ts(x)`
+  coverage. Follow `.claude/rules/unit-test-guidelines.md` (behavior-focused tests,
+  AAA structure, `sut` naming, no custom loops — use `it.each`).
+- **Clean Architecture violations (P1):** Wrong dependency direction or layer-boundary
+  crossings in the blog app's `domain` / `use-cases` / `adapters` slices.
+  See the `clean-architecture-guidelines` skill.
+- **Security / secrets (P0):** PII in logs, API keys or secrets leaked into code or
+  stories, missing authentication on Hono routes/`x-api-key` checks.
+- **Type safety (P1):** `any` overuse and unjustified type casts. Flag abbreviated
+  identifiers (use full names — `dictionary` not `dict`, `language` not `lang`)
+  where Biome does not already catch them.
+
+Defer formatting/style nits already enforced by Biome; do not duplicate lint output.
+
+## Codex Usage & Roles
+
+- **Codex = primary reviewer.** Automatic review runs on every PR. Use
+  `@codex review` to re-review after pushing changes (Codex does not re-review
+  unless asked), and `@codex fix the P1 issue` for small, scoped corrections.
+- **Claude (`@claude` / local Claude Code) = primary implementer** for feature work.
+- Keep the two agents from overlapping: do not ask both to implement the same PR.
+
 ## Storybook & Chromatic
 
 - Location: UI Storybook in `packages/ui/.storybook` with Webpack + SWC.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,3 +160,4 @@ Remember: A story name might not reflect the property name correctly, so always 
 - All packages are 100% TypeScript
 - Use pnpm for package management (configured as package manager)
 - Turborepo handles build caching and task orchestration
+- After pushing fixes that address Codex PR feedback, post a top-level `@codex review` comment — Codex does not re-review unless explicitly asked. See `AGENTS.md` (Codex Usage).


### PR DESCRIPTION
## Summary

### What changed?

- `AGENTS.md`: added a `Codex Review Guidelines` section (P0/P1 categories: missing tests,
  Clean Architecture violations, security/secrets, type safety) and a `Codex Usage & Roles`
  section (Codex = primary reviewer, Claude = primary implementer).
- `CLAUDE.md`: added a note to post a top-level `@codex review` comment after pushing fixes,
  since Codex does not re-review unless explicitly asked.

### Why was this changed?

The Codex Cloud connector already reviews PRs, but the repo documented no review focus or
agent-role conventions. This keeps Codex reviews on high-priority issues and prevents Codex
and Claude from overlapping on the same PR.

## Type of Change

- [x] 📝 Documentation update

## Affected Applications

- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [x] No tests needed (documentation only)

### How to Test

1. Read `AGENTS.md` and confirm the `Codex Review Guidelines` and `Codex Usage & Roles` sections render correctly.
2. Read `CLAUDE.md` Development Notes and confirm the `@codex review` convention is present.

### Test Results

- [x] Linting passes (`pnpm lint`)

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main

## Related Issues

Closes #294

## Reviewer Notes

Follow-up (outside this repo): the ChatGPT.com Codex settings still need to be configured
manually — enable "Automatic reviews", select the review model (`gpt-5.5-codex`, effort
high), and set a minimal Cloud environment setup script (`pnpm install` + `test-utils`
build, no secrets). These cannot be committed to the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
