### PR TITLE
📝 Docs: #302 Land Auth module spec and decision records

### DIFF
--- a/apps/blog/specs/README.md
+++ b/apps/blog/specs/README.md
@@ -16,6 +16,7 @@ The repository follows a code-first documentation model:
 | [`post.md`](./post.md)               | Post lifecycle, publication rules, queries, and sync boundaries |
 | [`media.md`](./media.md)             | Media asset rules and retrieval operations                      |
 | [`affiliate.md`](./affiliate.md)     | Affiliate link types, provider rules, and retrieval operations  |
+| [`auth.md`](./auth.md)               | Blog settings authentication and access policy                  |
 | [`contact.md`](./contact.md)         | Contact form submission and confirmation email behavior         |
 | [`social-feed.md`](./social-feed.md) | Social media feed retrieval and display rules                   |
 | [`decisions/`](./decisions/)         | Architecture decision records                                   |

--- a/apps/blog/specs/auth.md
+++ b/apps/blog/specs/auth.md
@@ -1,0 +1,179 @@
+# Auth Spec
+
+> **Status: Planned (design doc).** Unlike the other module specs, which describe shipped behavior
+> (as-built), this document specifies a feature that is not yet implemented (as-designed). No auth
+> code, middleware, or `/api/auth` route exists yet. See [`decisions/0001`](./decisions/0001-use-better-auth.md).
+
+## Purpose
+
+The Auth module protects the blog settings screen. Authentication mechanics are delegated to better-auth; the application owns access policy, route protection, the `admin` role concept, and first administrator provisioning.
+
+## Problem & Outcome
+
+- **User:** The single operator (admin).
+- **Problem:** The operator needs to run blog operations that the external content source does not cover — manual sync triggers and their status, affiliate / media management, and site / publication settings — through a UI, without touching code or API keys. That UI must be reachable only by the operator.
+- **Desired outcome:** A protected settings console that only the authenticated operator can reach.
+- **Success signal:** The operator can log in and reach `/settings`; unauthenticated visitors are redirected to `/login`; public read paths carry no added auth cost (existing Hono `x-api-key` routes unchanged).
+- **Non-goals:** Public sign-up, password reset / change, email verification, and per-role enforcement beyond the v1 `admin` concept (see Scope).
+- **First protected slice (recommended):** Auth should ship alongside at least one real settings feature so it does not guard an empty shell. Recommended first surface: a **manual sync trigger UI** over the existing API-key sync routes (`SyncPostsFromExternal`, `SyncHeroImages`). The broader console (affiliate / media management, site settings) follows as separate work.
+
+## Scope
+
+In scope:
+
+- Log in with email and password.
+- Log out.
+- Retrieve current session.
+- Protect `/settings/:path*`.
+- Redirect unauthenticated visitors to `/login`.
+- Provision the first administrator outside public sign-up.
+
+Out of scope:
+
+- Public sign-up.
+- Password reset.
+- Password change.
+- Email verification.
+- Per-role authorization enforcement beyond the v1 `admin` concept.
+
+## Terms
+
+| Term          | Definition                                                                  | Code identifier                   |
+| ------------- | --------------------------------------------------------------------------- | --------------------------------- |
+| User          | Authenticatable account owned by better-auth; not the same as post `Author` | `User` better-auth schema         |
+| Session       | Logged-in session for exactly one user                                      | `Session` better-auth schema      |
+| Account       | Credential record linked to a user                                          | `Account` better-auth schema      |
+| Verification  | Token records owned by better-auth; unused flows in v1                      | `Verification` better-auth schema |
+| Role          | Authorization level; only `admin` in v1                                     | application-owned concept         |
+| Access Policy | Settings pages require a valid session                                      | route protection                  |
+
+## Rules
+
+- The settings screen requires a valid session.
+- Visitors without a valid session are redirected to `/login`.
+- Authenticated administrators can access settings pages.
+- The v1 user model is single administrator, but the `Role` concept is kept for future expansion.
+- There is no public sign-up.
+- First administrator provisioning is an operator action.
+- Credentials, password hashing, and session lifecycle are owned by better-auth.
+- better-auth uses its Drizzle adapter for auth persistence.
+
+## Technical Design
+
+### Routing
+
+better-auth is mounted on a dedicated Next.js route handler:
+
+```text
+app/api/auth/[...all]/route.ts
+```
+
+This is separate from the existing Hono catch-all route:
+
+```text
+app/api/[[...route]]/route.ts
+```
+
+Next.js route precedence sends `/api/auth/*` to better-auth and leaves all other `/api/*` paths to Hono.
+
+Existing Hono API-key routes such as `/api/posts`, `/api/images`, and `/api/revalidate` are unaffected.
+
+### Route Protection
+
+Two protection layers are required:
+
+| Layer               | Location                                       | Responsibility                                                       |
+| ------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
+| Optimistic redirect | `middleware.ts` matcher for `/settings/:path*` | Cheaply redirect to `/login` when the session cookie is absent       |
+| Authoritative gate  | `app/settings/layout.tsx` server component     | Call `getSession`; redirect to `/login` when no valid session exists |
+
+The middleware is an optimization. The server-side layout check is the security boundary.
+
+### Persistence
+
+better-auth owns the auth tables through its Drizzle adapter.
+
+| Table          | Purpose                                 |
+| -------------- | --------------------------------------- |
+| `User`         | Authenticatable accounts                |
+| `Session`      | Active sessions                         |
+| `Account`      | Credentials per user                    |
+| `Verification` | Verification tokens for unused v1 flows |
+
+Implementation notes:
+
+- Auth tables are generated into `infrastructure/drizzle/schema.ts`.
+- `drizzle.config.ts` includes the auth tables in `tablesFilter`.
+- Table names use PascalCase to match existing `Author` and `Post` tables.
+
+### Provisioning
+
+The first administrator is created by a one-off seed script that calls better-auth's `signUp` API with initial credentials from environment variables. This keeps password hashing provider-owned.
+
+### Mapping
+
+- DB to Auth and Auth to DB conversions are owned by better-auth's Drizzle adapter.
+- The application should not add hand-written auth persistence mappers.
+- Session to UI display data is the only application-level mapping for v1.
+
+## Use Cases
+
+### UC1 - Log in
+
+Given a visitor submits a registered email and correct password  
+When the login form is submitted  
+Then a session is created and the visitor is taken to the settings screen.
+
+### UC2 - Reject invalid login
+
+Given a visitor submits an unknown email or incorrect password  
+When the login form is submitted  
+Then an error message is shown and no session is created.
+
+### UC3 - Log out
+
+Given an authenticated administrator  
+When they log out  
+Then the session is destroyed and they are returned to the login screen.
+
+### UC4 - Protect settings
+
+Given a visitor has no valid session  
+When they open a settings page  
+Then they are redirected to the login screen.
+
+Given an authenticated administrator  
+When they open a settings page  
+Then access is allowed.
+
+Given a visitor holds an expired or forged session cookie  
+When they open a settings page  
+Then the optimistic middleware lets the request through (cookie is present), but the server-side layout's `getSession` finds no valid session and redirects to `/login`.
+
+This case is the reason the authoritative check lives in the server component, not the middleware: the middleware only inspects cookie presence, so the layout is the security boundary.
+
+### UC5 - Retrieve current session
+
+Given an authenticated administrator is on a settings page  
+When the page renders  
+Then the logged-in user's display information is available.
+
+## Contracts
+
+| Operation   | Boundary                       | Request            | Response / Result                  | Errors                  |
+| ----------- | ------------------------------ | ------------------ | ---------------------------------- | ----------------------- |
+| Log in      | `POST /api/auth/sign-in/email` | email and password | session cookie / redirect behavior | invalid credentials     |
+| Log out     | `POST /api/auth/sign-out`      | current session    | session revoked                    | unauthenticated request |
+| Get session | `GET /api/auth/get-session`    | session cookie     | user/session data or null          | provider errors         |
+
+Compatibility:
+
+- better-auth is mounted under `/api/auth/*`.
+- Existing Hono `/api/*` routes remain separate.
+- Published Hono API docs and `x-api-key` protected routes are unchanged.
+
+## Test Expectations
+
+- Acceptance tests cover login success, login failure, logout, protected-route redirect, and session display.
+- Integration tests exercise route protection and better-auth handler behavior.
+- Security checks verify credentials are not logged and settings pages use a server-side authoritative session check.

--- a/apps/blog/specs/decisions/0001-use-better-auth.md
+++ b/apps/blog/specs/decisions/0001-use-better-auth.md
@@ -1,0 +1,36 @@
+# 0001 Use better-auth for blog admin authentication
+
+## Status
+
+Accepted
+
+## Context
+
+The blog needs authentication for the settings screen. The application should not own password hashing, credential storage, or session lifecycle mechanics unless there is a strong reason to do so.
+
+The v1 product model is a single administrator, but the implementation should keep a path toward multiple users and role-based authorization.
+
+## Decision
+
+Use better-auth with email/password authentication for the blog settings screen.
+
+better-auth owns:
+
+- credential storage,
+- password hashing,
+- session issue/read/revoke behavior,
+- `User`, `Session`, `Account`, and `Verification` tables.
+
+The application owns:
+
+- protected route policy,
+- unauthenticated redirect behavior,
+- the `admin` role concept,
+- first administrator provisioning.
+
+## Consequences
+
+- Authentication mechanics are delegated to a dedicated provider.
+- `/api/auth/*` is separate from the existing Hono `/api/*` routes.
+- The application must keep route protection explicit at both middleware and server-rendered settings boundaries.
+- Public sign-up, password reset, password change, and email verification remain out of scope for v1.

--- a/apps/blog/specs/decisions/0002-keep-user-and-author-separate.md
+++ b/apps/blog/specs/decisions/0002-keep-user-and-author-separate.md
@@ -1,0 +1,29 @@
+# 0002 Keep User and Author separate
+
+## Status
+
+Accepted
+
+## Context
+
+Two concepts use overlapping language across modules:
+
+- `User` is an authenticatable account owned by better-auth (see [0001](./0001-use-better-auth.md)).
+- `Author` is post byline / content metadata in the Post module.
+
+They look related — both represent "a person" — so there is pressure to merge them into one model
+or share an id. Merging would couple the public content domain to the authentication domain and leak
+auth concerns (sessions, credentials) into post rendering.
+
+## Decision
+
+Keep `User` and `Author` as separate concepts in separate modules. Do not merge them, and do not share
+or cross-reference their ids. `Author` lives in the Post domain as content metadata; `User` lives in the
+Auth domain as an authenticatable account.
+
+## Consequences
+
+- The Post domain stays independent of the Auth domain; public read paths carry no auth coupling.
+- The glossary records this collision permanently (`User` / `Author` row) so the distinction is traceable.
+- If a future feature needs to link an author to an account, it must be an explicit, additional mapping —
+  not an implicit identity reuse — and should be recorded as a new decision.

--- a/apps/blog/specs/decisions/README.md
+++ b/apps/blog/specs/decisions/README.md
@@ -9,8 +9,8 @@ Use a decision record when the team needs to remember why a meaningful technical
 Use a four-digit sequence and a short kebab-case title:
 
 ```text
-0001-short-decision-title.md
-0002-another-decision-title.md
+0001-use-better-auth.md
+0002-keep-user-and-author-separate.md
 ```
 
 If the sequence reaches `9999`, continue with `10000`. The prefix is for stable ordering, not a hard limit.

--- a/apps/blog/specs/glossary.md
+++ b/apps/blog/specs/glossary.md
@@ -28,6 +28,7 @@ The operation list for each module is owned by that module spec's Contracts sect
 | Post        | `Post`                                 |
 | Media       | `Media`                                |
 | Affiliate   | `Affiliate` union                      |
+| Auth        | `User`, `Session` owned by better-auth |
 | Contact     | `Contact`                              |
 | Social Feed | `SocialPost`                           |
 
@@ -35,6 +36,7 @@ The operation list for each module is owned by that module spec's Contracts sect
 
 | Name              | Contexts            | Resolution                                                                                                                                                                     |
 | ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `User` / `Author` | Auth / Post         | `User` is an authenticatable account. `Author` is post metadata and must not be merged with `User`. See [`decisions/0002`](./decisions/0002-keep-user-and-author-separate.md). |
 | `PostId`          | Post / Social Feed  | Post `PostId` is UUID-based. Social Feed `PostId` wraps an external provider string.                                                                                           |
 | `MediaType`       | Media / Social Feed | Media supports `IMAGE` and `VIDEO`. Social Feed also supports `CAROUSEL_ALBUM`. Keep the enums separate.                                                                       |
 | `Name`            | Affiliate / Contact | Affiliate `Name` is display text for an affiliate item. Contact `Name` is the submitter's name.                                                                                |

--- a/apps/blog/specs/post.md
+++ b/apps/blog/specs/post.md
@@ -66,13 +66,14 @@ Out of scope:
 > **Aspirational — not yet invoked.** These transition operations (`publish`, `archive`, `softDelete`,
 > `restore`) and their guards are modeled on `Post` but no application workflow calls them today. Post
 > status is set by mapping from the external content source during sync; there is no command use case and
-> no editing UI. The transitions become active when the settings console gains post-management UI.
-> Until then, treat this table as the intended rule set, not active behavior.
+> no editing UI. The transitions become active when the settings console (see [`auth.md`](./auth.md))
+> gains post-management UI. Until then, treat this table as the intended rule set, not active behavior.
 
 ### Aggregate
 
 `Post` is the aggregate root and the only entry point. `Author` is a separate aggregate referenced by
-id (`AuthorId`); the post never holds an `Author` object.
+id (`AuthorId`); the post never holds an `Author` object. See
+[`decisions/0002`](./decisions/0002-keep-user-and-author-separate.md).
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary

Land the Auth module specification and its decision records into `apps/blog/specs/`, completing the
documentation half of the auth work (Issue #302).

### What changed?

- Added `apps/blog/specs/auth.md` — the Auth module spec (8-section format). It is an **as-designed**
  document (Status: Planned): no auth code, `middleware.ts`, `/login`, or `/settings` exists yet.
- Added `apps/blog/specs/decisions/0001-use-better-auth.md` and
  `0002-keep-user-and-author-separate.md`.
- Restored the references removed in #301 to avoid dangling links while these files were held back:
  - `glossary.md` — Auth row (Module Terms) and the `User` / `Author` collision row (→ `decisions/0002`).
  - `README.md` — the `auth.md` row in the Structure table.
  - `post.md` — the `auth.md` note in the status table and the `decisions/0002` reference in Aggregate.
  - `decisions/README.md` — restored the real naming examples.

### Why was this changed?

- These docs were authored alongside #300/#301 but intentionally deferred. Landing them establishes
  the agreed auth design and decision context before implementation (#303), and restores internal
  link consistency in the specs directory.

## Type of Change

- [x] 📝 Documentation update

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

Documentation-only change; no runtime code touched.

### Test Results

- [x] Linting passes (`pnpm lint`)

All restored relative links resolve to existing files (`auth.md`, `decisions/0001`, `decisions/0002`).

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

## Related Issues

Closes #302

Implementation is tracked separately in #303 (auth is as-designed here, not yet built).

## Reviewer Notes

- `auth.md` describes planned behavior, not shipped behavior — review it as a design doc.
