### PR TITLE
🔧 Chore: Ignore local database backup directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ dist
 
 # Docker
 .docker/
+
+# Database backups (e.g. pre-migration pg_dump snapshots)
+.backups/


### PR DESCRIPTION
## Summary

### What changed?

- Add `.backups/` to `.gitignore`.

### Why was this changed?

Local pre-migration `pg_dump` snapshots (e.g. taken before applying the auth-table
migration to production) are written under `apps/blog/.backups/`. These are local
operational artifacts and must never be committed.

## Type of Change

- [x] 🏗️ Build/CI changes

## Affected Applications

- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

`.gitignore`-only change; verified with `git check-ignore apps/blog/.backups`.