### PR TITLE
✨ Feat: #303 Add admin login page and session retrieval

### DIFF
--- a/apps/blog/app/login/LoginForm.test.tsx
+++ b/apps/blog/app/login/LoginForm.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LoginForm } from './LoginForm';
+
+const { mockPush, mockToastError, mockSignInEmail } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockToastError: vi.fn(),
+  mockSignInEmail: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('../../infrastructure/auth/auth-client', () => ({
+  authClient: { signIn: { email: mockSignInEmail } },
+}));
+
+vi.mock('ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ui')>();
+  return {
+    ...actual,
+    useToast: () => ({ toast: { error: mockToastError, success: vi.fn() } }),
+  };
+});
+
+function renderLoginForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LoginForm />
+    </QueryClientProvider>
+  );
+}
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to the settings screen when sign-in succeeds', async () => {
+    mockSignInEmail.mockResolvedValue({ data: { user: {} }, error: null });
+    const user = userEvent.setup();
+    renderLoginForm();
+
+    await user.type(
+      screen.getByLabelText('メールアドレス'),
+      'admin@example.com'
+    );
+    await user.type(screen.getByLabelText('パスワード'), 'password123');
+    await user.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/settings'));
+    expect(mockSignInEmail).toHaveBeenCalledWith({
+      email: 'admin@example.com',
+      password: 'password123',
+    });
+  });
+
+  it('shows an error and does not redirect when credentials are invalid', async () => {
+    mockSignInEmail.mockResolvedValue({
+      data: null,
+      error: { message: 'Invalid email or password' },
+    });
+    const user = userEvent.setup();
+    renderLoginForm();
+
+    await user.type(
+      screen.getByLabelText('メールアドレス'),
+      'admin@example.com'
+    );
+    await user.type(screen.getByLabelText('パスワード'), 'wrong-password');
+    await user.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('blocks submission and shows a validation error when fields are empty', async () => {
+    const user = userEvent.setup();
+    renderLoginForm();
+
+    await user.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    expect(
+      await screen.findByText('メールアドレスを入力してください')
+    ).toBeInTheDocument();
+    expect(mockSignInEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/blog/app/login/LoginForm.tsx
+++ b/apps/blog/app/login/LoginForm.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { Button, Form, useToast } from 'ui';
+
+import { authClient } from '../../infrastructure/auth/auth-client';
+import { type LoginInput, loginSchema } from './loginSchema';
+
+export function LoginForm() {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: '', password: '' },
+    mode: 'onChange',
+  });
+
+  const mutation = useMutation({
+    mutationKey: ['login'],
+    mutationFn: async ({ email, password }: LoginInput) => {
+      // signIn.email resolves with { error } instead of throwing, so surface
+      // failures explicitly to trigger onError.
+      const { error } = await authClient.signIn.email({ email, password });
+      if (error) {
+        throw new Error(error.message ?? 'login failed');
+      }
+    },
+    onSuccess: () => {
+      router.push('/settings');
+    },
+    onError: () => {
+      toast.error('メールアドレスまたはパスワードが正しくありません', {
+        closeButton: true,
+      });
+    },
+  });
+
+  return (
+    <div className="flex w-full max-w-[400px] flex-col gap-6 rounded-lg border border-base-light bg-white p-8">
+      <div className="flex flex-col gap-condensed">
+        <h1 className="text-heading-3 leading-heading-3 font-bold text-base-black">
+          ログイン
+        </h1>
+        <p className="text-body-r-sm text-neutral-600">
+          管理画面にログインします
+        </p>
+      </div>
+      <form
+        noValidate
+        className="flex flex-col gap-6"
+        onSubmit={handleSubmit((credentials) => mutation.mutate(credentials))}
+      >
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-normal">
+            <Form.Control error={!!errors.email}>
+              <Form.Label htmlFor="email">メールアドレス</Form.Label>
+              <Form.Input
+                {...register('email')}
+                type="email"
+                id="email"
+                placeholder="you@example.com"
+                autoComplete="email"
+              />
+              {errors.email?.message && (
+                <Form.HelperText>{errors.email.message}</Form.HelperText>
+              )}
+            </Form.Control>
+          </div>
+          <div className="flex flex-col gap-normal">
+            <Form.Control error={!!errors.password}>
+              <Form.Label htmlFor="password">パスワード</Form.Label>
+              <Form.Input
+                {...register('password')}
+                type="password"
+                id="password"
+                autoComplete="current-password"
+              />
+              {errors.password?.message && (
+                <Form.HelperText>{errors.password.message}</Form.HelperText>
+              )}
+            </Form.Control>
+          </div>
+        </div>
+        <Button
+          type="submit"
+          color="main"
+          size="lg"
+          className="w-full"
+          disabled={mutation.isPending}
+        >
+          ログイン
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/blog/app/login/loginSchema.test.ts
+++ b/apps/blog/app/login/loginSchema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { loginSchema } from './loginSchema';
+
+describe('loginSchema', () => {
+  it('accepts a valid email and password', () => {
+    const result = loginSchema.safeParse({
+      email: 'admin@example.com',
+      password: 'password123',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    {
+      scenario: 'empty email',
+      input: { email: '', password: 'password123' },
+      expectedMessage: 'メールアドレスを入力してください',
+    },
+    {
+      scenario: 'malformed email',
+      input: { email: 'not-an-email', password: 'password123' },
+      expectedMessage: '有効なメールアドレスを入力してください',
+    },
+    {
+      scenario: 'empty password',
+      input: { email: 'admin@example.com', password: '' },
+      expectedMessage: 'パスワードを入力してください',
+    },
+  ])('rejects $scenario', ({ input, expectedMessage }) => {
+    expect(() => loginSchema.parse(input)).toThrow(expectedMessage);
+  });
+});

--- a/apps/blog/app/login/loginSchema.ts
+++ b/apps/blog/app/login/loginSchema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export type LoginInput = z.infer<typeof loginSchema>;
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください')
+    .email('有効なメールアドレスを入力してください'),
+  password: z.string().min(1, 'パスワードを入力してください'),
+});

--- a/apps/blog/app/login/page.test.tsx
+++ b/apps/blog/app/login/page.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import LoginPage from './page';
+
+const { mockGetSession, mockRedirect } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockRedirect: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/auth/getSession', () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock('./LoginForm', () => ({
+  LoginForm: () => <div data-testid="login-form" />,
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to the settings screen when a session exists', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } });
+
+    await LoginPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith('/settings');
+  });
+
+  it('renders the login form when there is no session', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    render(await LoginPage());
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(screen.getByTestId('login-form')).toBeInTheDocument();
+  });
+});

--- a/apps/blog/app/login/page.tsx
+++ b/apps/blog/app/login/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+import { getSession } from '../../infrastructure/auth/getSession';
+import { LoginForm } from './LoginForm';
+
+export const metadata: Metadata = {
+  title: 'ログイン',
+  robots: { index: false, follow: false },
+};
+
+export default async function LoginPage() {
+  const session = await getSession();
+  if (session) {
+    redirect('/settings');
+  }
+
+  return (
+    <main className="flex min-h-dvh items-center justify-center bg-base-white p-4">
+      <LoginForm />
+    </main>
+  );
+}

--- a/apps/blog/infrastructure/auth/auth-client.ts
+++ b/apps/blog/infrastructure/auth/auth-client.ts
@@ -1,0 +1,5 @@
+import { createAuthClient } from 'better-auth/react';
+
+// Same-origin: the client targets /api/auth/* on the current host, so no
+// baseURL is needed.
+export const authClient = createAuthClient();

--- a/apps/blog/infrastructure/auth/getSession.ts
+++ b/apps/blog/infrastructure/auth/getSession.ts
@@ -1,0 +1,9 @@
+import { headers } from 'next/headers';
+
+import { auth } from './auth';
+
+// Server-side authoritative session read for server components (login redirect,
+// settings layout gate).
+export async function getSession() {
+  return auth.api.getSession({ headers: await headers() });
+}


### PR DESCRIPTION
## Summary

Second slice (**I2**) of blog admin authentication (#303), building on the I1 foundation
(#305). Adds the `/login` screen, the better-auth React client, and a server-side
`getSession` helper. Implements the Figma login design (node 1133-1913) by reusing the
existing `ui` form components and design tokens — no ad-hoc styling.

### What changed?

- `infrastructure/auth/auth-client.ts` — `createAuthClient()` (same-origin, targets `/api/auth/*`).
- `infrastructure/auth/getSession.ts` — server-side authoritative session read
  (`auth.api.getSession`); reused by the settings gate in I3.
- `app/login/loginSchema.ts` — Zod email/password schema (mirrors `contactSchema`).
- `app/login/LoginForm.tsx` (`'use client'`) — RHF + Zod + React Query `useMutation`
  calling `authClient.signIn.email`; error toast on invalid credentials; `router.push('/settings')`
  on success. Built from `ui` `Form.*` + `Button color="main" size="lg"` to match the design.
- `app/login/page.tsx` — Server Component; `noindex` metadata; redirects already-authenticated
  visitors to `/settings`; centered full-screen layout (no site chrome).
- `app/login/LoginForm.test.tsx` — component tests (success redirect / invalid-credentials error /
  empty-form validation). No MSW; the auth client and router are mocked.

### Why was this changed?

The operator needs a login screen to reach the protected settings console. Authentication
mechanics stay owned by better-auth; this slice only adds the UI and the session-read helper.
Covers **UC1** (login success), **UC2** (invalid login), **UC5** (retrieve session).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

### How to Test

1. `pnpm -F blog dev`, open `/login`.
2. Submit empty → validation errors; no auth call.
3. Wrong credentials → error toast, no redirect.
4. Valid credentials (seed an admin locally) → redirected to `/settings` (404 until I3, expected).
5. Visiting `/login` while authenticated → redirected to `/settings`.

### Test Results

- `pnpm -F blog typecheck` ✓
- `pnpm -F blog lint` ✓
- `pnpm -F blog test` — 922 passed (incl. 3 new `LoginForm` tests) ✓

## Notes

Closes one task of #303 (I2). The `/settings` redirect target lands in I3
(route protection + settings page). Admin provisioning is I4.