### PR TITLE
✨ Feat: #303 Add route protection and protected /settings with logout

### DIFF
--- a/apps/blog/app/settings/LogoutButton.test.tsx
+++ b/apps/blog/app/settings/LogoutButton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LogoutButton } from './LogoutButton';
+
+const { mockPush, mockSignOut } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockSignOut: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('../../infrastructure/auth/auth-client', () => ({
+  authClient: { signOut: mockSignOut },
+}));
+
+describe('LogoutButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('signs out and redirects to login', async () => {
+    mockSignOut.mockImplementation(
+      async (options?: { fetchOptions?: { onSuccess?: () => void } }) => {
+        options?.fetchOptions?.onSuccess?.();
+      }
+    );
+    const user = userEvent.setup();
+    render(<LogoutButton />);
+
+    await user.click(screen.getByRole('button', { name: 'ログアウト' }));
+
+    expect(mockSignOut).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/login');
+  });
+});

--- a/apps/blog/app/settings/LogoutButton.tsx
+++ b/apps/blog/app/settings/LogoutButton.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from 'ui';
+
+import { authClient } from '../../infrastructure/auth/auth-client';
+
+export function LogoutButton() {
+  const router = useRouter();
+
+  const handleLogout = () => {
+    authClient.signOut({
+      fetchOptions: {
+        onSuccess: () => {
+          router.push('/login');
+        },
+      },
+    });
+  };
+
+  return (
+    <Button color="dark" variant="outline" onClick={handleLogout}>
+      ログアウト
+    </Button>
+  );
+}

--- a/apps/blog/app/settings/layout.test.tsx
+++ b/apps/blog/app/settings/layout.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SettingsLayout from './layout';
+
+const { mockGetSession, mockRedirect } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockRedirect: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/auth/getSession', () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: mockRedirect,
+}));
+
+describe('SettingsLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to login when there is no session', async () => {
+    mockRedirect.mockImplementation(() => {
+      throw new Error('NEXT_REDIRECT');
+    });
+    mockGetSession.mockResolvedValue(null);
+
+    await expect(SettingsLayout({ children: <div /> })).rejects.toThrow(
+      'NEXT_REDIRECT'
+    );
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
+  });
+
+  it('renders children when a session exists', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } });
+
+    render(await SettingsLayout({ children: <div data-testid="content" /> }));
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+});

--- a/apps/blog/app/settings/layout.tsx
+++ b/apps/blog/app/settings/layout.tsx
@@ -1,0 +1,18 @@
+import { redirect } from 'next/navigation';
+
+import { getSession } from '../../infrastructure/auth/getSession';
+
+// Authoritative security boundary for the whole /settings subtree: a forged or
+// expired cookie passes the optimistic middleware but is rejected here.
+export default async function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+  if (!session) {
+    redirect('/login');
+  }
+
+  return <main className="min-h-dvh bg-base-white px-4 py-8">{children}</main>;
+}

--- a/apps/blog/app/settings/page.test.tsx
+++ b/apps/blog/app/settings/page.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SettingsPage from './page';
+
+const { mockGetSession, mockRedirect } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockRedirect: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/auth/getSession', () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock('./LogoutButton', () => ({
+  LogoutButton: () => <button type="button">ログアウト</button>,
+}));
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('displays the logged-in user email', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: 'user-1', email: 'admin@example.com' },
+    });
+
+    render(await SettingsPage());
+
+    expect(screen.getByText(/admin@example.com/)).toBeInTheDocument();
+  });
+
+  it('redirects to login when there is no session', async () => {
+    mockRedirect.mockImplementation(() => {
+      throw new Error('NEXT_REDIRECT');
+    });
+    mockGetSession.mockResolvedValue(null);
+
+    await expect(SettingsPage()).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
+  });
+});

--- a/apps/blog/app/settings/page.tsx
+++ b/apps/blog/app/settings/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+import { getSession } from '../../infrastructure/auth/getSession';
+import { LogoutButton } from './LogoutButton';
+
+export const metadata: Metadata = {
+  title: '設定',
+  robots: { index: false, follow: false },
+};
+
+export default async function SettingsPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[600px] flex-col items-start gap-6">
+      <div className="flex flex-col gap-condensed">
+        <h1 className="text-heading-3 leading-heading-3 font-bold text-base-black">
+          設定
+        </h1>
+        <p className="text-body-r-sm text-neutral-600">
+          {session.user.email} でログイン中
+        </p>
+      </div>
+      <LogoutButton />
+    </div>
+  );
+}

--- a/apps/blog/proxy.test.ts
+++ b/apps/blog/proxy.test.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { proxy } from './proxy';
+
+const { mockGetSessionCookie } = vi.hoisted(() => ({
+  mockGetSessionCookie: vi.fn(),
+}));
+
+vi.mock('better-auth/cookies', () => ({
+  getSessionCookie: mockGetSessionCookie,
+}));
+
+describe('proxy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to login when the session cookie is absent', () => {
+    mockGetSessionCookie.mockReturnValue(null);
+    const request = new NextRequest(new URL('http://localhost/settings'));
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/login');
+  });
+
+  it('allows the request when the session cookie is present', () => {
+    mockGetSessionCookie.mockReturnValue('session-token');
+    const request = new NextRequest(new URL('http://localhost/settings'));
+
+    const response = proxy(request);
+
+    expect(response.headers.get('location')).toBeNull();
+  });
+});

--- a/apps/blog/proxy.ts
+++ b/apps/blog/proxy.ts
@@ -1,0 +1,18 @@
+import { getSessionCookie } from 'better-auth/cookies';
+import { type NextRequest, NextResponse } from 'next/server';
+
+// Next.js 16 renamed `middleware` to `proxy` (nodejs runtime). Optimistic
+// redirect based on session-cookie presence only — this is an optimization, not
+// the security boundary. app/settings/layout.tsx performs the authoritative
+// getSession check that rejects forged or expired cookies.
+export function proxy(request: NextRequest) {
+  if (!getSessionCookie(request)) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/settings/:path*'],
+};


### PR DESCRIPTION
## Summary

Fourth slice (**I3**) of blog admin authentication (#303), building on I1 (#305) and
I2 (#307). Adds the two-layer route protection for `/settings` and a minimal protected
page with logout.

### What changed?

- `apps/blog/proxy.ts` — **optimistic redirect** (Next.js 16 `proxy`, nodejs runtime):
  redirects requests without a session cookie to `/login` (`getSessionCookie`),
  `matcher: ['/settings/:path*']`. This is an optimization, not the security boundary.
- `app/settings/layout.tsx` — **authoritative gate** (the real security boundary):
  server-side `getSession`; `redirect('/login')` when there is no valid session. A
  forged/expired cookie passes the proxy but is rejected here.
- `app/settings/page.tsx` — minimal protected page showing the logged-in identity
  (`session.user.email`); `noindex` metadata.
- `app/settings/LogoutButton.tsx` (`'use client'`) — `authClient.signOut()` then
  redirect to `/login`.
- Tests: `proxy.test.ts`, `app/settings/{layout,page,LogoutButton}.test.tsx`.

### Why was this changed?

Only the authenticated operator may reach the settings console. The proxy gives a cheap
redirect for the common case; the layout's server-side session check is the actual
security boundary (per `apps/blog/specs/auth.md`). Covers **UC3** (logout) and **UC4**
(protect settings), plus UC5 identity display.

### Note on `proxy.ts` vs `middleware.ts`

Next.js 16 deprecated `middleware.ts` in favor of `proxy.ts` (function `middleware`→`proxy`,
nodejs runtime). The auth check only reads the session cookie, so nodejs is fine.
(`apps/portfolio` keeps `middleware.ts` because its i18n routing needs the edge runtime,
which `proxy` does not support.)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security improvements

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

### How to Test

1. `pnpm -F blog dev` pointed at a DB with a seeded user.
2. Logged out, open `/settings` → redirected to `/login` (proxy).
3. Log in, open `/settings` → identity shown.
4. Log out → back to `/login`; reopening `/settings` redirects again.
5. A tampered/expired session cookie still gets rejected by the layout, not just the proxy.

### Test Results

- `pnpm -F blog typecheck` ✓
- `pnpm -F blog lint` ✓
- `pnpm -F blog test` — 935 passed (incl. 7 new I3 tests) ✓

## Notes

Closes one task of #303 (I3). Remaining: I4 (admin seed) and I5 (manual sync UI on `/settings`).