### PR TITLE
✨ Feat: #303 Add first-administrator seed script

### DIFF
--- a/apps/blog/.env.example
+++ b/apps/blog/.env.example
@@ -7,6 +7,15 @@ API_KEY=
 # Database
 DATABASE_URL=
 
+# Auth (better-auth)
+BETTER_AUTH_SECRET=
+BETTER_AUTH_URL=
+
+# Admin seed (one-off provisioning: pnpm -F blog db:seed:admin)
+ADMIN_EMAIL=
+ADMIN_PASSWORD=
+ADMIN_NAME=
+
 # Logging
 LOG_LEVEL=info
 

--- a/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../modules/post/adapters/shared/testing/testDatabase';
+import { users } from '../drizzle/schema';
+import { auth } from './auth';
+import { provisionAdminUser } from './provisionAdminUser';
+
+function createAdminInput(overrides: Partial<Parameters<typeof provisionAdminUser>[0]> = {}) {
+  return {
+    email: 'admin@example.com',
+    password: 'changeme123',
+    name: 'Administrator',
+    ...overrides,
+  };
+}
+
+describe('provisionAdminUser', () => {
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  it('creates a single administrator with a linked credential account', async () => {
+    const sut = provisionAdminUser;
+    const input = createAdminInput();
+
+    const result = await sut(input);
+
+    expect(result.status).toBe('created');
+    const storedUsers = await getTestDb().select().from(users);
+    expect(storedUsers).toHaveLength(1);
+    expect(storedUsers[0]?.email).toBe(input.email);
+  });
+
+  it('provisions an administrator that can sign in with the seeded credentials', async () => {
+    const sut = provisionAdminUser;
+    const input = createAdminInput();
+    await sut(input);
+
+    const signIn = await auth.api.signInEmail({
+      body: { email: input.email, password: input.password },
+    });
+
+    expect(signIn.user.email).toBe(input.email);
+  });
+
+  it('returns already-exists and creates no duplicate when run twice', async () => {
+    const sut = provisionAdminUser;
+    const input = createAdminInput();
+    await sut(input);
+
+    const result = await sut(input);
+
+    expect(result.status).toBe('already-exists');
+    const storedUsers = await getTestDb().select().from(users);
+    expect(storedUsers).toHaveLength(1);
+  });
+
+  it('throws when the password is shorter than the minimum length', async () => {
+    const sut = provisionAdminUser;
+    const input = createAdminInput({ password: 'short' });
+
+    await expect(sut(input)).rejects.toThrow(
+      'Admin password must be at least 8 characters'
+    );
+  });
+});

--- a/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
@@ -77,6 +77,17 @@ describe('provisionAdminUser', () => {
     expect(signIn.user.email).toBe(input.email);
   });
 
+  it('refuses to provision a second administrator with a different email', async () => {
+    const sut = provisionAdminUser;
+    await sut(createAdminInput());
+
+    await expect(
+      sut(createAdminInput({ email: 'second@example.com' }))
+    ).rejects.toThrow('refusing to provision a second administrator');
+    const storedUsers = await getTestDb().select().from(users);
+    expect(storedUsers).toHaveLength(1);
+  });
+
   it('throws when the password is shorter than the minimum length', async () => {
     const sut = provisionAdminUser;
     const input = createAdminInput({ password: 'short' });

--- a/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
@@ -88,6 +88,15 @@ describe('provisionAdminUser', () => {
     expect(storedUsers).toHaveLength(1);
   });
 
+  it('throws and creates no user when the admin email is invalid', async () => {
+    const sut = provisionAdminUser;
+    const input = createAdminInput({ email: 'admin' });
+
+    await expect(sut(input)).rejects.toThrow('valid email address');
+    const storedUsers = await getTestDb().select().from(users);
+    expect(storedUsers).toHaveLength(0);
+  });
+
   it('throws when the password is shorter than the minimum length', async () => {
     const sut = provisionAdminUser;
     const input = createAdminInput({ password: 'short' });

--- a/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.db.test.ts
@@ -58,6 +58,25 @@ describe('provisionAdminUser', () => {
     expect(storedUsers).toHaveLength(1);
   });
 
+  it('repairs an administrator left without a credential account by an interrupted run', async () => {
+    const sut = provisionAdminUser;
+    const input = createAdminInput();
+    const context = await auth.$context;
+    await context.internalAdapter.createUser({
+      email: input.email,
+      name: input.name,
+      emailVerified: false,
+    });
+
+    const result = await sut(input);
+
+    expect(result.status).toBe('created');
+    const signIn = await auth.api.signInEmail({
+      body: { email: input.email, password: input.password },
+    });
+    expect(signIn.user.email).toBe(input.email);
+  });
+
   it('throws when the password is shorter than the minimum length', async () => {
     const sut = provisionAdminUser;
     const input = createAdminInput({ password: 'short' });

--- a/apps/blog/infrastructure/auth/provisionAdminUser.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { auth } from './auth';
 
 // better-auth's default emailAndPassword.minPasswordLength. internalAdapter
@@ -33,8 +35,11 @@ export async function provisionAdminUser(
   input: ProvisionAdminInput
 ): Promise<ProvisionAdminResult> {
   const email = input.email.trim().toLowerCase();
-  if (!email) {
-    throw new Error('Admin email is required');
+  // Validate before creating the singleton: better-auth's signInEmail rejects
+  // invalid emails, so an unverified bad address would lock out the admin and
+  // the single-administrator guard would block reseeding a corrected one.
+  if (!z.string().email().safeParse(email).success) {
+    throw new Error('Admin email must be a valid email address');
   }
   if (input.password.length < MINIMUM_PASSWORD_LENGTH) {
     throw new Error(

--- a/apps/blog/infrastructure/auth/provisionAdminUser.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.ts
@@ -19,7 +19,13 @@ interface ProvisionAdminResult {
  * Create the first administrator. Public sign-up is disabled
  * (`disableSignUp: true`), so we provision through the auth context exactly as
  * better-auth's own admin plugin does: createUser + provider-owned password
- * hash + credential account link. Idempotent — re-running is a no-op.
+ * hash + credential account link.
+ *
+ * Idempotent and self-healing: an admin counts as provisioned only once a
+ * credential account exists, so a bare User row left by an interrupted run is
+ * repaired on re-run. A successful run therefore always yields a sign-in-capable
+ * admin, even though the adapter spans createUser/linkAccount without a single
+ * transaction.
  *
  * @see apps/blog/specs/auth.md (first-administrator provisioning)
  */
@@ -38,9 +44,28 @@ export async function provisionAdminUser(
 
   const context = await auth.$context;
 
-  const existing = await context.internalAdapter.findUserByEmail(email);
-  if (existing) {
+  const existing = await context.internalAdapter.findUserByEmail(email, {
+    includeAccounts: true,
+  });
+  const hasCredential = existing?.accounts.some(
+    (account) => account.providerId === 'credential'
+  );
+  if (existing && hasCredential) {
     return { status: 'already-exists', userId: existing.user.id };
+  }
+
+  // Hash before createUser so a hashing failure never leaves a credential-less
+  // User row behind.
+  const hashedPassword = await context.password.hash(input.password);
+
+  if (existing) {
+    await context.internalAdapter.linkAccount({
+      accountId: existing.user.id,
+      providerId: 'credential',
+      password: hashedPassword,
+      userId: existing.user.id,
+    });
+    return { status: 'created', userId: existing.user.id };
   }
 
   const user = await context.internalAdapter.createUser({
@@ -48,8 +73,6 @@ export async function provisionAdminUser(
     name: input.name,
     emailVerified: false,
   });
-
-  const hashedPassword = await context.password.hash(input.password);
   await context.internalAdapter.linkAccount({
     accountId: user.id,
     providerId: 'credential',

--- a/apps/blog/infrastructure/auth/provisionAdminUser.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.ts
@@ -54,6 +54,17 @@ export async function provisionAdminUser(
     return { status: 'already-exists', userId: existing.user.id };
   }
 
+  // Single-administrator model: there is no public sign-up, so every User is a
+  // seeded admin. Refuse to provision another one with a different email — the
+  // settings gate only checks for a session, so a second account would also get
+  // admin access.
+  const totalUsers = await context.adapter.count({ model: 'user' });
+  if (totalUsers > (existing ? 1 : 0)) {
+    throw new Error(
+      'An administrator already exists; refusing to provision a second administrator'
+    );
+  }
+
   // Hash before createUser so a hashing failure never leaves a credential-less
   // User row behind.
   const hashedPassword = await context.password.hash(input.password);

--- a/apps/blog/infrastructure/auth/provisionAdminUser.ts
+++ b/apps/blog/infrastructure/auth/provisionAdminUser.ts
@@ -1,0 +1,61 @@
+import { auth } from './auth';
+
+// better-auth's default emailAndPassword.minPasswordLength. internalAdapter
+// bypasses the sign-up route's own validation, so we re-check it here.
+const MINIMUM_PASSWORD_LENGTH = 8;
+
+interface ProvisionAdminInput {
+  email: string;
+  password: string;
+  name: string;
+}
+
+interface ProvisionAdminResult {
+  status: 'created' | 'already-exists';
+  userId: string;
+}
+
+/**
+ * Create the first administrator. Public sign-up is disabled
+ * (`disableSignUp: true`), so we provision through the auth context exactly as
+ * better-auth's own admin plugin does: createUser + provider-owned password
+ * hash + credential account link. Idempotent — re-running is a no-op.
+ *
+ * @see apps/blog/specs/auth.md (first-administrator provisioning)
+ */
+export async function provisionAdminUser(
+  input: ProvisionAdminInput
+): Promise<ProvisionAdminResult> {
+  const email = input.email.trim().toLowerCase();
+  if (!email) {
+    throw new Error('Admin email is required');
+  }
+  if (input.password.length < MINIMUM_PASSWORD_LENGTH) {
+    throw new Error(
+      `Admin password must be at least ${MINIMUM_PASSWORD_LENGTH} characters`
+    );
+  }
+
+  const context = await auth.$context;
+
+  const existing = await context.internalAdapter.findUserByEmail(email);
+  if (existing) {
+    return { status: 'already-exists', userId: existing.user.id };
+  }
+
+  const user = await context.internalAdapter.createUser({
+    email,
+    name: input.name,
+    emailVerified: false,
+  });
+
+  const hashedPassword = await context.password.hash(input.password);
+  await context.internalAdapter.linkAccount({
+    accountId: user.id,
+    providerId: 'credential',
+    password: hashedPassword,
+    userId: user.id,
+  });
+
+  return { status: 'created', userId: user.id };
+}

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -22,6 +22,7 @@
     "db:verify:down": "docker stop k2bg-branding-blog-postgres-verify >/dev/null 2>&1 || true",
     "db:baseline": "node ./scripts/baseline-drizzle-migration.mjs",
     "db:migrate": "pnpm db:baseline && drizzle-kit migrate",
+    "db:seed:admin": "tsx ./scripts/seed-admin-user.ts",
     "db:pull": "drizzle-kit pull",
     "db:generate": "drizzle-kit generate",
     "db:check": "drizzle-kit check",

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -88,6 +88,7 @@
     "tailwind-config": "workspace:*",
     "tailwindcss": "^4.0.9",
     "test-utils": "workspace:*",
-    "tsconfig": "workspace:*"
+    "tsconfig": "workspace:*",
+    "tsx": "^4.20.6"
   }
 }

--- a/apps/blog/scripts/seed-admin-user.ts
+++ b/apps/blog/scripts/seed-admin-user.ts
@@ -15,13 +15,13 @@ async function main(): Promise<void> {
     );
   }
 
-  // Never log the password.
+  // Never log the password or the email (PII): status only.
   const result = await provisionAdminUser({ email, password, name });
   if (result.status === 'already-exists') {
-    console.log(`Administrator already exists: ${email} (no changes)`);
+    console.log('Administrator already exists; no changes');
     return;
   }
-  console.log(`Administrator created: ${email}`);
+  console.log('Administrator provisioned');
 }
 
 main()

--- a/apps/blog/scripts/seed-admin-user.ts
+++ b/apps/blog/scripts/seed-admin-user.ts
@@ -1,0 +1,36 @@
+import { resetDrizzleClient } from '../infrastructure/drizzle/client';
+import { provisionAdminUser } from '../infrastructure/auth/provisionAdminUser';
+
+// One-off operator script: provisions the first administrator from environment
+// variables. No public sign-up exists; see apps/blog/specs/auth.md.
+// Usage: ADMIN_EMAIL=… ADMIN_PASSWORD=… DATABASE_URL=… pnpm -F blog db:seed:admin
+async function main(): Promise<void> {
+  const email = process.env.ADMIN_EMAIL;
+  const password = process.env.ADMIN_PASSWORD;
+  const name = process.env.ADMIN_NAME ?? 'Administrator';
+
+  if (!email || !password) {
+    throw new Error(
+      'ADMIN_EMAIL and ADMIN_PASSWORD environment variables are required'
+    );
+  }
+
+  // Never log the password.
+  const result = await provisionAdminUser({ email, password, name });
+  if (result.status === 'already-exists') {
+    console.log(`Administrator already exists: ${email} (no changes)`);
+    return;
+  }
+  console.log(`Administrator created: ${email}`);
+}
+
+main()
+  .catch((error) => {
+    console.error(
+      error instanceof Error ? error.message : 'Failed to seed administrator'
+    );
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await resetDrizzleClient();
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      tsx:
+        specifier: ^4.20.6
+        version: 4.22.0
 
   apps/portfolio:
     dependencies:


### PR DESCRIPTION
## Summary

Implements **I4 — First administrator provisioning** of #303. Public sign-up is disabled
(`emailAndPassword.disableSignUp: true`), so this adds a one-off operator-run seed script that
creates the first administrator from environment variables.

### What changed?

- Add `provisionAdminUser` (`apps/blog/infrastructure/auth/provisionAdminUser.ts`) — provisions the
  first admin through the better-auth context exactly as better-auth's own admin plugin does:
  `internalAdapter.createUser` + provider-owned `password.hash` + credential `linkAccount`.
  Idempotent (re-running returns `already-exists`), validates a minimum password length.
- Add CLI wrapper `apps/blog/scripts/seed-admin-user.ts` and the `db:seed:admin` script
  (`tsx ./scripts/seed-admin-user.ts`). Reads `ADMIN_EMAIL` / `ADMIN_PASSWORD` / `ADMIN_NAME`,
  fails fast on missing creds, never logs the password, closes the DB pool on exit.
- Add `tsx` devDependency (separate `📦 Deps` commit) so the script can reuse the configured
  TypeScript `auth` instance directly.
- Document `ADMIN_*` and the previously-missing `BETTER_AUTH_*` vars in `.env.example`.

### Why was this changed?

The operator needs to log into the protected `/settings` console, but there is no public sign-up by
design. A seed script is the spec'd provisioning path, keeping password hashing provider-owned.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📦 Dependency updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed

### How to Test

1. `pnpm -F blog test:db` — runs `provisionAdminUser.db.test.ts` (Testcontainers).
2. Against a local DB: `pnpm -F blog db:up && pnpm -F blog db:migrate`, then
   `ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=changeme123 DATABASE_URL=… pnpm -F blog db:seed:admin`.
3. Re-run the seed → logs `already-exists` (idempotent).

### Test Results

- [x] New tests pass (4 tests: creates admin, admin can sign in, idempotent re-run, rejects short password)
- [x] Linting passes (`pnpm -F blog lint`)
- [x] Type checking passes (`pnpm -F blog typecheck`)

Manual: seed run created 1 `User` + 1 credential `Account`; second run was a no-op; seeded admin can
sign in via `auth.api.signInEmail`.

## Database Changes

- [x] No database changes

No schema/migration changes — the auth tables already exist (I1). This adds an operator seed script
only.

## Environment Variables

- [x] New environment variables added (documented below)

**Required environment variables:**

- `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `ADMIN_NAME` — credentials for the one-off admin seed.
- `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` — already used by the auth instance; now documented in
  `.env.example`.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] Other (specify below)

Run `pnpm -F blog db:seed:admin` once (with `ADMIN_*` set) after deploy to provision the first admin.
Per project policy, run production provisioning only after this PR is merged.

## Documentation

- [x] No documentation changes needed

## Related Issues

Relates to #303

## Reviewer Notes

- The seed goes through `auth.$context` (`internalAdapter` / `password.hash`) rather than
  `auth.api.signUpEmail`, because `disableSignUp: true` hard-blocks the public sign-up endpoint. This
  mirrors better-auth's own admin-plugin `createUser`.
