### PR TITLE
✨ Feat: #303 Add manual sync trigger UI on settings

### DIFF
--- a/apps/blog/app/settings/SyncTriggers.test.tsx
+++ b/apps/blog/app/settings/SyncTriggers.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SyncTriggers } from './SyncTriggers';
+
+const { mockToastSuccess, mockToastError, mockSyncPosts, mockSyncHeroImages } =
+  vi.hoisted(() => ({
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+    mockSyncPosts: vi.fn(),
+    mockSyncHeroImages: vi.fn(),
+  }));
+
+vi.mock('./syncActions', () => ({
+  syncPostsAction: mockSyncPosts,
+  syncHeroImagesAction: mockSyncHeroImages,
+}));
+
+vi.mock('ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ui')>();
+  return {
+    ...actual,
+    useToast: () => ({
+      toast: { success: mockToastSuccess, error: mockToastError },
+    }),
+  };
+});
+
+function renderSyncTriggers() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SyncTriggers />
+    </QueryClientProvider>
+  );
+}
+
+describe('SyncTriggers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a success toast with the synced count when posts sync succeeds', async () => {
+    mockSyncPosts.mockResolvedValue({ syncedPosts: [], count: 5 });
+    const user = userEvent.setup();
+    renderSyncTriggers();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Notionから記事を同期' })
+    );
+
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        '記事を同期しました（5件）',
+        expect.anything()
+      )
+    );
+  });
+
+  it('shows an error toast when posts sync fails', async () => {
+    mockSyncPosts.mockRejectedValue(new Error('Sync failed'));
+    const user = userEvent.setup();
+    renderSyncTriggers();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Notionから記事を同期' })
+    );
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+  });
+
+  it('reports the failed count when hero images sync partially fails', async () => {
+    mockSyncHeroImages.mockResolvedValue({
+      uploadedImages: [],
+      count: 4,
+      failedCount: 1,
+    });
+    const user = userEvent.setup();
+    renderSyncTriggers();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Cloudinaryから画像を同期' })
+    );
+
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        '画像を同期しました（4件、失敗1件）',
+        expect.anything()
+      )
+    );
+  });
+
+  it('disables the posts button while the sync is pending', async () => {
+    const neverResolves = new Promise(() => undefined);
+    mockSyncPosts.mockReturnValue(neverResolves);
+    const user = userEvent.setup();
+    renderSyncTriggers();
+
+    const button = screen.getByRole('button', { name: 'Notionから記事を同期' });
+    await user.click(button);
+
+    await waitFor(() => expect(button).toBeDisabled());
+  });
+});

--- a/apps/blog/app/settings/SyncTriggers.tsx
+++ b/apps/blog/app/settings/SyncTriggers.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { Button, useToast } from 'ui';
+
+import { syncHeroImagesAction, syncPostsAction } from './syncActions';
+
+export function SyncTriggers() {
+  const { toast } = useToast();
+
+  const syncPosts = useMutation({
+    mutationKey: ['sync-posts'],
+    mutationFn: syncPostsAction,
+    onSuccess: (result) => {
+      toast.success(`記事を同期しました（${result.count}件）`, {
+        closeButton: true,
+      });
+    },
+    onError: () => {
+      toast.error('記事の同期に失敗しました。もう一度お試しください', {
+        closeButton: true,
+      });
+    },
+  });
+
+  const syncHeroImages = useMutation({
+    mutationKey: ['sync-hero-images'],
+    mutationFn: syncHeroImagesAction,
+    onSuccess: (result) => {
+      const message =
+        result.failedCount > 0
+          ? `画像を同期しました（${result.count}件、失敗${result.failedCount}件）`
+          : `画像を同期しました（${result.count}件）`;
+      toast.success(message, { closeButton: true });
+    },
+    onError: () => {
+      toast.error('画像の同期に失敗しました。もう一度お試しください', {
+        closeButton: true,
+      });
+    },
+  });
+
+  return (
+    <section className="flex w-full flex-col gap-normal">
+      <h2 className="text-heading-4 leading-heading-4 font-bold text-base-black">
+        手動同期
+      </h2>
+      <p className="text-body-r-sm text-neutral-600">
+        外部ソースから記事と画像を取り込みます。
+      </p>
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <Button
+          color="dark"
+          variant="outline"
+          onClick={() => syncPosts.mutate()}
+          disabled={syncPosts.isPending}
+        >
+          Notionから記事を同期
+        </Button>
+        <Button
+          color="dark"
+          variant="outline"
+          onClick={() => syncHeroImages.mutate()}
+          disabled={syncHeroImages.isPending}
+        >
+          Cloudinaryから画像を同期
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/blog/app/settings/page.test.tsx
+++ b/apps/blog/app/settings/page.test.tsx
@@ -20,6 +20,10 @@ vi.mock('./LogoutButton', () => ({
   LogoutButton: () => <button type="button">ログアウト</button>,
 }));
 
+vi.mock('./SyncTriggers', () => ({
+  SyncTriggers: () => <div>SyncTriggers</div>,
+}));
+
 describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/blog/app/settings/page.tsx
+++ b/apps/blog/app/settings/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 
 import { getSession } from '../../infrastructure/auth/getSession';
 import { LogoutButton } from './LogoutButton';
+import { SyncTriggers } from './SyncTriggers';
 
 export const metadata: Metadata = {
   title: '設定',
@@ -17,7 +18,7 @@ export default async function SettingsPage() {
 
   return (
     <div className="mx-auto flex w-full max-w-[600px] flex-col items-start gap-6">
-      <div className="flex flex-col gap-condensed">
+      <div className="flex flex-col gap-normal">
         <h1 className="text-heading-3 leading-heading-3 font-bold text-base-black">
           設定
         </h1>
@@ -25,6 +26,7 @@ export default async function SettingsPage() {
           {session.user.email} でログイン中
         </p>
       </div>
+      <SyncTriggers />
       <LogoutButton />
     </div>
   );

--- a/apps/blog/app/settings/syncActions.test.ts
+++ b/apps/blog/app/settings/syncActions.test.ts
@@ -1,0 +1,152 @@
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  SyncHeroImagesOutput,
+  SyncPostsFromExternalOutput,
+} from '../../modules/post/use-cases';
+
+const { mockGetSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/auth/getSession', () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock('../../infrastructure/di', () => ({
+  createSyncPostsFromExternalUseCase: vi.fn(),
+  createSyncHeroImagesUseCase: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+import { revalidatePath } from 'next/cache';
+import {
+  createSyncHeroImagesUseCase,
+  createSyncPostsFromExternalUseCase,
+} from '../../infrastructure/di';
+import { syncHeroImagesAction, syncPostsAction } from './syncActions';
+
+const mockCreateSyncPostsUseCase = vi.mocked(
+  createSyncPostsFromExternalUseCase
+);
+const mockCreateSyncHeroImagesUseCase = vi.mocked(createSyncHeroImagesUseCase);
+
+function stubSyncPostsWith(
+  execute: Mock<() => Promise<SyncPostsFromExternalOutput>>
+) {
+  mockCreateSyncPostsUseCase.mockReturnValue({
+    execute,
+  } as unknown as ReturnType<typeof createSyncPostsFromExternalUseCase>);
+}
+
+function stubSyncHeroImagesWith(
+  execute: Mock<() => Promise<SyncHeroImagesOutput>>
+) {
+  mockCreateSyncHeroImagesUseCase.mockReturnValue({
+    execute,
+  } as unknown as ReturnType<typeof createSyncHeroImagesUseCase>);
+}
+
+const activeSession = { user: { id: 'user-1', email: 'admin@example.com' } };
+
+describe('syncPostsAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the use case result when the session is valid', async () => {
+    const syncResult = {
+      syncedPosts: [],
+      count: 3,
+    } satisfies SyncPostsFromExternalOutput;
+    mockGetSession.mockResolvedValue(activeSession);
+    stubSyncPostsWith(vi.fn().mockResolvedValue(syncResult));
+
+    const result = await syncPostsAction();
+
+    expect(result).toEqual(syncResult);
+  });
+
+  it('revalidates blog pages after a successful sync', async () => {
+    mockGetSession.mockResolvedValue(activeSession);
+    stubSyncPostsWith(vi.fn().mockResolvedValue({ syncedPosts: [], count: 0 }));
+
+    await syncPostsAction();
+
+    expect(revalidatePath).toHaveBeenCalled();
+  });
+
+  it('rejects without running the use case when there is no session', async () => {
+    const execute = vi.fn().mockResolvedValue({ syncedPosts: [], count: 0 });
+    mockGetSession.mockResolvedValue(null);
+    stubSyncPostsWith(execute);
+
+    await expect(syncPostsAction()).rejects.toThrow('Unauthorized');
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('propagates use case errors', async () => {
+    mockGetSession.mockResolvedValue(activeSession);
+    stubSyncPostsWith(vi.fn().mockRejectedValue(new Error('Sync failed')));
+
+    await expect(syncPostsAction()).rejects.toThrow('Sync failed');
+  });
+});
+
+describe('syncHeroImagesAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the use case result when the session is valid', async () => {
+    const syncResult = {
+      uploadedImages: [],
+      count: 2,
+      failedCount: 1,
+    } satisfies SyncHeroImagesOutput;
+    mockGetSession.mockResolvedValue(activeSession);
+    stubSyncHeroImagesWith(vi.fn().mockResolvedValue(syncResult));
+
+    const result = await syncHeroImagesAction();
+
+    expect(result).toEqual(syncResult);
+  });
+
+  it('revalidates blog pages after a successful sync', async () => {
+    mockGetSession.mockResolvedValue(activeSession);
+    stubSyncHeroImagesWith(
+      vi
+        .fn()
+        .mockResolvedValue({ uploadedImages: [], count: 0, failedCount: 0 })
+    );
+
+    await syncHeroImagesAction();
+
+    expect(revalidatePath).toHaveBeenCalled();
+  });
+
+  it('rejects without running the use case when there is no session', async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValue({ uploadedImages: [], count: 0, failedCount: 0 });
+    mockGetSession.mockResolvedValue(null);
+    stubSyncHeroImagesWith(execute);
+
+    await expect(syncHeroImagesAction()).rejects.toThrow('Unauthorized');
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('propagates use case errors', async () => {
+    mockGetSession.mockResolvedValue(activeSession);
+    stubSyncHeroImagesWith(
+      vi.fn().mockRejectedValue(new Error('Upload failed'))
+    );
+
+    await expect(syncHeroImagesAction()).rejects.toThrow('Upload failed');
+  });
+});

--- a/apps/blog/app/settings/syncActions.ts
+++ b/apps/blog/app/settings/syncActions.ts
@@ -1,0 +1,65 @@
+'use server';
+
+import { getSession } from '../../infrastructure/auth/getSession';
+import {
+  createSyncHeroImagesUseCase,
+  createSyncPostsFromExternalUseCase,
+} from '../../infrastructure/di';
+import { logger } from '../../modules/shared/logger';
+import { revalidateBlogPages } from '../../server/lib/revalidation';
+
+const syncLogger = logger.child({ module: 'settings-sync' });
+
+// Server Actions are publicly callable POST endpoints, so the protected
+// settings page guard is not enough: each action re-checks the session itself.
+// @see apps/blog/specs/auth.md
+async function requireSession() {
+  const session = await getSession();
+  if (!session) {
+    throw new Error('Unauthorized');
+  }
+}
+
+export async function syncPostsAction() {
+  await requireSession();
+
+  try {
+    const result = await createSyncPostsFromExternalUseCase().execute();
+    revalidateBlogPages();
+    syncLogger.info(
+      { action: 'syncPostsAction', count: result.count },
+      'Synced posts from external source'
+    );
+    return result;
+  } catch (err) {
+    syncLogger.error(
+      { err, action: 'syncPostsAction' },
+      'Failed to sync posts'
+    );
+    throw err;
+  }
+}
+
+export async function syncHeroImagesAction() {
+  await requireSession();
+
+  try {
+    const result = await createSyncHeroImagesUseCase().execute();
+    revalidateBlogPages();
+    syncLogger.info(
+      {
+        action: 'syncHeroImagesAction',
+        count: result.count,
+        failedCount: result.failedCount,
+      },
+      'Synced hero images'
+    );
+    return result;
+  } catch (err) {
+    syncLogger.error(
+      { err, action: 'syncHeroImagesAction' },
+      'Failed to sync hero images'
+    );
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Final slice of issue #303 — **I5: manual sync trigger UI**. Adds a manual content-sync trigger UI to the protected `/settings`, so that (per `auth.md`) the auth feature ships guarding a real first feature rather than an empty shell.

### What changed?

- Added a "Manual sync" section to `/settings` (`SyncTriggers.tsx`) with two buttons (`Notionから記事を同期` / `Cloudinaryから画像を同期`). Each has its own `useMutation`, shows the synced count (and failed count for images) via a toast on success, and is disabled while pending.
- Added `syncActions.ts` (`'use server'`) with `syncPostsAction` / `syncHeroImagesAction`. Each action re-checks `getSession()`, runs `createSyncPostsFromExternalUseCase` / `createSyncHeroImagesUseCase`, then calls `revalidateBlogPages()`.
- Reuses the React Query + Server Action pattern from `ContactForm`.

### Why was this changed?

The existing `PATCH /api/posts` (SyncPostsFromExternal) and `PATCH /api/images` (SyncHeroImages) are Hono routes protected by `x-api-key`, which cannot be exposed to the browser. Running the same use-case logic from a **better-auth session-guarded Server Action** lets the operator trigger syncs from the UI without exposing the API key and while preserving the Clean Architecture dependency direction. The existing `x-api-key` routes are left unchanged.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed

### How to Test

1. Run `pnpm -F blog dev`, log in as admin, and open `/settings`.
2. Click the two buttons in the "Manual sync" section — they disable while pending and show a count toast on completion.
3. Hit `/settings` while logged out → redirected to `/login` (existing I3 protection still holds).

### Test Results

- [x] New tests pass (`app/settings`, 17 tests green)
- [x] Linting passes
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Security

- Server Actions are publicly callable POST endpoints, so each action re-validates `getSession()` rather than relying on the page guard (the authoritative session check from `auth.md`).
- Credentials / PII are not logged.

## Related Issues

Relates to #303 (slice I5)

## Reviewer Notes

- Trigger mechanism: Server Action invoking the use cases directly (no HTTP self-fetch / no API_KEY exposure).
- I4 (first administrator provisioning seed script) is a separate slice and is intentionally not part of this PR.