### PR TITLE
📝 Docs: #319 Brush up AI agent documentation

### DIFF
--- a/.claude/rules/hono-api-guidelines.md
+++ b/.claude/rules/hono-api-guidelines.md
@@ -1,0 +1,74 @@
+---
+paths: apps/blog/server/**/*.ts
+---
+
+# Hono API Server Guidelines
+
+Conventions for the Hono REST API integrated into the blog app. The server lives in
+`apps/blog/server/` and is wired into Next.js via `apps/blog/app/api/[[...route]]/route.ts`
+(`handle(app)` from `hono/vercel`, one export per HTTP method).
+
+## App Setup (`apps/blog/server/app.ts`)
+
+- The app is an `OpenAPIHono` (from `@hono/zod-openapi`) with `.basePath('/api')`.
+- Middleware order matters and is fixed:
+  1. `app.use('*', requestLogger)` — global logging.
+  2. `app.use('/<path>', apiKeyAuth)` — per-path auth for every protected route
+     (`/posts`, `/images`, `/revalidate`). New protected routes MUST be added here.
+  3. `app.route('/', <routes>)` — mount route groups.
+  4. `app.onError(errorHandler)` — registered last.
+- OpenAPI docs (`/api/doc.json`) and Swagger UI (`/api/doc`) are exposed only when
+  `NODE_ENV !== 'production'`. Keep that gate.
+- The `ApiKeyAuth` security scheme (`x-api-key` header) is registered once via
+  `app.openAPIRegistry.registerComponent(...)`.
+
+## Routes (`apps/blog/server/routes/`)
+
+Canonical example: `apps/blog/server/routes/post.ts`.
+
+- One file per resource; each file creates its own `new OpenAPIHono()` and is re-exported
+  from `apps/blog/server/routes/index.ts`.
+- Define routes with `createRoute()` including OpenAPI metadata: `method`, `path`,
+  `summary`, `security: [{ ApiKeyAuth: [] }]` (for protected routes), `request`
+  (when there is a body), and `responses` with a schema and description per status code.
+- Attach handlers with `<routes>.openapi(route, handler)`.
+- Handlers construct use cases via DI factory functions from
+  `apps/blog/infrastructure/di` (e.g. `createSyncPostsFromExternalUseCase()`)
+  and call `.execute()` — never instantiate adapters or repositories inline.
+- Read validated request bodies with `c.req.valid('json')`; validation comes from the
+  Zod schema declared in `request`.
+
+## Schemas (`apps/blog/server/schemas/`)
+
+- Import `z` from `@hono/zod-openapi` (not plain `zod`).
+- Naming: exported top-level schemas end in `ResponseSchema` / `RequestSchema`
+  (e.g. `SyncPostsResponseSchema`); internal building blocks are unexported
+  `PascalCase + Schema`.
+- Register exported schemas as OpenAPI components with `.openapi('<ComponentName>')`.
+- Reuse `ErrorResponseSchema` from `apps/blog/server/schemas/shared.ts` for every error
+  response — do not invent new error shapes.
+
+## Middleware & Errors (`apps/blog/server/middleware/`)
+
+- `apiKeyAuth` — compares the `x-api-key` header to `process.env.API_KEY`; throws
+  `HTTPException(401)` on mismatch.
+- `requestLogger` — logs request start/completion with method, path, status, duration.
+- `errorHandler` — maps `HTTPException` to its status; everything else (including domain
+  and repository errors) becomes `500 INTERNAL_SERVER_ERROR`. Response shape:
+  `{ "error": { "code", "message", "status", "timestamp" } }`.
+- To return a specific HTTP status from a handler, throw `HTTPException` — domain errors
+  are NOT mapped to statuses automatically.
+
+## Testing
+
+- Every route and middleware file has a co-located `*.test.ts` (Vitest).
+- Route tests mount the route group on a plain `new Hono()` and drive it with
+  `app.request('/posts', { method: 'PATCH' })`; DI factories are stubbed with
+  `vi.mock('../../infrastructure/di', ...)`.
+- Assert on `res.status` and `await res.json()`. Follow
+  `.claude/rules/unit-test-guidelines.md`.
+
+## Security
+
+- Every state-changing route MUST be behind `apiKeyAuth` (wired in `app.ts`).
+- Never log request bodies or PII in `requestLogger` or handlers.

--- a/.claude/rules/portfolio-i18n-guidelines.md
+++ b/.claude/rules/portfolio-i18n-guidelines.md
@@ -1,0 +1,63 @@
+---
+paths: apps/portfolio/**/*.{ts,tsx}
+---
+
+# Portfolio i18n Guidelines
+
+The portfolio app uses a **server-only dictionary loader**, NOT react-i18next. There is no
+translation hook; translations flow from server components to leaf components as typed props.
+
+## Configuration (`apps/portfolio/i18n/settings.ts`)
+
+- Supported languages: `ja` (fallback) and `en` — `languages = [fallbackLanguage, 'en']`.
+- Locale cookie: `NEXT_LOCALE` (`cookieName`).
+- Always normalize a raw route param with `resolveLanguage(lang)`; it falls back to `ja`
+  for unknown values.
+
+## Locale Detection (`apps/portfolio/middleware.ts`)
+
+- Detection priority: `NEXT_LOCALE` cookie → `Accept-Language` header → fallback `ja`.
+- Paths without a locale prefix redirect to `/${locale}${pathname}`; requests that already
+  carry a locale write it back to the cookie (skipping router prefetches).
+- The `matcher` excludes `api`, Next.js static assets, `images`, `videos`, `assets`.
+- This file stays `middleware.ts` (Next.js 16 renamed middleware to `proxy.ts`, but the
+  portfolio keeps the edge-runtime default for i18n) — do not rename it. See AGENTS.md.
+
+## Translations (`apps/portfolio/i18n/`)
+
+- One file per locale: `apps/portfolio/i18n/locales/ja/translation.json` and
+  `apps/portfolio/i18n/locales/en/translation.json`.
+- `dictionaries.ts` is `server-only`: `getDictionary(language)` dynamically imports the
+  locale JSON. `Dictionary` is `typeof en` — **the English file is the source of truth for
+  the type**, so every new key MUST be added to BOTH files with an identical shape.
+- JSON convention: top-level camelCase section objects (`hero`, `background`, `skill`,
+  `portfolio`, `contact`, `footer`, `metadata`) with flat string keys; one extra nesting
+  level for grouped items (e.g. `portfolio.webApp.title`).
+
+## Consuming Translations
+
+Canonical flow (`apps/portfolio/app/[lang]/page.tsx`):
+
+```typescript
+const { lang } = await params;                 // params is a Promise in Next.js 15+
+const language = resolveLanguage(lang);
+const dictionary = await getDictionary(language);
+
+<Hero dictionary={dictionary.hero} />
+```
+
+Leaf components receive a typed slice via indexed access, never the whole dictionary:
+
+```typescript
+type HeroDictionary = Dictionary['hero'];
+export function Hero({ dictionary }: { dictionary: HeroDictionary }) { /* ... */ }
+```
+
+- Do NOT add react-i18next / i18next or client-side translation hooks.
+- Sections map 1:1 to components in `apps/portfolio/components/contents/`.
+
+## Routing (`apps/portfolio/app/[lang]/`)
+
+- The dynamic segment is `[lang]` (not `[lng]`); `layout.tsx` provides
+  `generateStaticParams()` over `languages` and sets `<html lang={language}>`.
+- `generateMetadata` reads `dictionary.metadata` and sets `alternates.languages`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enabledMcpjsonServers": ["k2bg-design-system"],
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/clean-architecture-guidelines/SKILL.md
+++ b/.claude/skills/clean-architecture-guidelines/SKILL.md
@@ -70,9 +70,9 @@ src/
 │   ├── notion/
 │   │   ├── client.ts           # Notion API client
 │   │   └── types.ts            # Notion type definitions
-│   ├── prisma/
-│   │   ├── client.ts           # Prisma client
-│   │   └── schema.prisma
+│   ├── drizzle/
+│   │   ├── client.ts           # Drizzle client
+│   │   └── schema.ts           # Drizzle schema
 │   ├── logging/
 │   │   └── logger.ts           # Logger implementation
 │   └── config/
@@ -117,7 +117,7 @@ src/
 **Key Points:**
 - **Vertical Slicing**: Each business module (e.g., `post/`, `user/`, `comment/`) contains its own domain, use-cases, and adapters
   - ⚠️ **Naming Convention**: Avoid repeating module name in file names (e.g., `post/domain/entities/entity.ts` not `post.ts`)
-- **Shared Infrastructure**: Common technical foundations (Notion client, Prisma client, logger, config) live in `infrastructure/`
+- **Shared Infrastructure**: Common technical foundations (Notion client, Drizzle client, logger, config) live in `infrastructure/`
   - ⚠️ **Dependency Rule**: Domain and Use Cases must NEVER import from `infrastructure/`
   - ✅ Only `adapters/output/` can import from `infrastructure/`
 - Repository **interfaces** live in `modules/{module}/domain/repositories` (Output Ports)
@@ -130,7 +130,8 @@ src/
   - Feature-specific data retrieval (e.g., for specific pages)
   - Example: `PublishedPostsQueryService`, `PostSearchQueryService`
 - Repository **implementations** live in `modules/{module}/adapters/output/repositories`
-  - These implementations use `infrastructure/` clients (Notion, Prisma, etc.)
+  - These implementations use `infrastructure/` clients (Notion, Drizzle, etc.)
+  - Real example: `apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.ts`
 - Use Cases depend only on Domain (entities + repository interfaces)
 - Adapters depend on both Domain and Use Cases, never the reverse
 - Modules should be independent; cross-module dependencies require careful design

--- a/.claude/skills/clean-architecture-guidelines/references/clean-architecture.md
+++ b/.claude/skills/clean-architecture-guidelines/references/clean-architecture.md
@@ -333,40 +333,45 @@ export interface PostDetail {
 
 #### Query Service Implementation (Adapter)
 
-```typescript
-// modules/post/adapters/output/services/prismaPostQueryService.ts
-import { PostQueryService, PostSummary } from '../../../domain/services/postQueryService';
+Real example: `apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts`
 
-export class PrismaPostQueryService implements PostQueryService {
-  constructor(private readonly prisma: PrismaClient) {}
+```typescript
+// modules/post/adapters/output/query-services/drizzle/postQueryService.ts
+import { count, desc, eq } from 'drizzle-orm';
+import { PostQueryService, PostSummary } from '../../../../domain/services/postQueryService';
+
+export class DrizzlePostQueryService implements PostQueryService {
+  constructor(private readonly db: DrizzleClient) {}
 
   async findPublishedPosts(options: PaginationOptions): Promise<PostSummary[]> {
     // Direct query optimized for reading (no domain entity mapping)
-    const posts = await this.prisma.post.findMany({
-      where: { status: 'PUBLISHED' },
-      select: {
-        id: true,
-        title: true,
-        excerpt: true,
-        publishedAt: true,
-        category: true,
-        author: { select: { name: true, avatarUrl: true } },
-      },
-      orderBy: { publishedAt: 'desc' },
-      skip: options.offset,
-      take: options.limit,
-    });
+    const rows = await this.db
+      .select({
+        id: posts.uuid,
+        title: posts.title,
+        excerpt: posts.excerpt,
+        publishedAt: posts.releaseDate,
+        category: posts.category,
+        authorName: authors.name,
+        authorAvatarUrl: authors.avatarUrl,
+      })
+      .from(posts)
+      .leftJoin(authors, eq(posts.authorId, authors.uuid))
+      .where(eq(posts.status, 'PUBLISHED'))
+      .orderBy(desc(posts.releaseDate))
+      .limit(options.limit)
+      .offset(options.offset);
 
-    return posts;  // Already in view model shape
+    return rows.map(toPostSummary); // Map rows into the view model shape
   }
 
   async getCategoryStats(): Promise<CategoryStats[]> {
     // Aggregation query - not possible with entity-based repository
-    return await this.prisma.post.groupBy({
-      by: ['category'],
-      _count: { id: true },
-      where: { status: 'PUBLISHED' },
-    });
+    return await this.db
+      .select({ category: posts.category, count: count() })
+      .from(posts)
+      .where(eq(posts.status, 'PUBLISHED'))
+      .groupBy(posts.category);
   }
 }
 ```
@@ -509,9 +514,10 @@ describe('GetPublishedPostsUseCase', () => {
 });
 
 // Integration Test - Adapter (test with real infrastructure)
-describe('PrismaPostRepository', () => {
+// Real example: apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.db.test.ts
+describe('DrizzlePostRepository', () => {
   it('saves and retrieves post correctly', async () => {
-    const sut = new PrismaPostRepository(testPrismaClient);
+    const sut = new DrizzlePostRepository(getTestDb());
     const post = Post.createDraft('Test', 'Content');
 
     await sut.save(post);

--- a/.claude/skills/clean-architecture-guidelines/references/domain-driven-design.md
+++ b/.claude/skills/clean-architecture-guidelines/references/domain-driven-design.md
@@ -319,21 +319,21 @@ export class PostPublishingService {
   }
 }
 
-// modules/post/adapters/output/services/prismaSlugChecker.ts
+// modules/post/adapters/output/services/drizzleSlugChecker.ts
 // Implementation in Adapter layer
+import { and, eq, ne } from 'drizzle-orm';
 import { SlugUniquenessChecker } from '../../../domain/services/slugUniquenessChecker';
 
-export class PrismaSlugUniquenessChecker implements SlugUniquenessChecker {
-  constructor(private readonly prisma: PrismaClient) {}
+export class DrizzleSlugUniquenessChecker implements SlugUniquenessChecker {
+  constructor(private readonly db: DrizzleClient) {}
 
   async isUnique(slug: Slug, excludePostId?: PostId): Promise<boolean> {
-    const existing = await this.prisma.post.findFirst({
-      where: {
-        slug: slug.getValue(),
-        ...(excludePostId && { id: { not: excludePostId.getValue() } }),
-      },
+    const existing = await this.db.query.posts.findFirst({
+      where: excludePostId
+        ? and(eq(posts.slug, slug.getValue()), ne(posts.uuid, excludePostId.getValue()))
+        : eq(posts.slug, slug.getValue()),
     });
-    return existing === null;
+    return existing === undefined;
   }
 }
 ```
@@ -544,28 +544,29 @@ export interface PostRepository {
   delete(id: PostId): Promise<void>;
 }
 
-// modules/post/adapters/output/repositories/prisma.ts
+// modules/post/adapters/output/repositories/drizzle/postRepository.ts
 // Implementation in ADAPTER layer
-import { PostRepository } from '../../../domain/repositories/repository';
-import { PostMapper } from '../mappers/mapper';
+// Real example: apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.ts
+import { eq } from 'drizzle-orm';
+import { PostRepository } from '../../../../domain/repositories/repository';
+import { toDomain, toPersistence } from './mapper';
 
-class PrismaPostRepository implements PostRepository {
-  constructor(private prisma: PrismaClient) {}
+class DrizzlePostRepository implements PostRepository {
+  constructor(private readonly db: DrizzleClient) {}
 
   async findById(id: PostId) {
-    const record = await this.prisma.post.findUnique({
-      where: { id: id.getValue() }
+    const row = await this.db.query.posts.findFirst({
+      where: eq(posts.uuid, id.getValue()),
     });
-    return record ? PostMapper.toDomain(record) : null;
+    return row ? toDomain(row) : null;
   }
 
   async save(post: Post) {
-    const data = PostMapper.toPersistence(post);
-    await this.prisma.post.upsert({
-      where: { id: data.id },
-      create: data,
-      update: data,
-    });
+    const data = toPersistence(post);
+    await this.db
+      .insert(posts)
+      .values(data)
+      .onConflictDoUpdate({ target: posts.uuid, set: data });
   }
 }
 

--- a/.claude/skills/k2bg-storybook-docs/SKILL.md
+++ b/.claude/skills/k2bg-storybook-docs/SKILL.md
@@ -66,7 +66,7 @@ Verify the following for the target component:
 ```typescript
 // packages/ui/src/components/[ComponentName]/[ComponentName].stories.tsx
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import ComponentName from '.';
 
 const meta = {

--- a/.claude/skills/k2bg-storybook-docs/SKILL.md
+++ b/.claude/skills/k2bg-storybook-docs/SKILL.md
@@ -15,10 +15,9 @@ This skill assists with creating and updating Storybook documentation for the `p
 
 ### Storybook Configuration
 
-- **Version**: Storybook 10.0.6
+- **Version**: Storybook 10.x (see `packages/ui/package.json` for the exact version)
 - **Format**: CSF3 (Component Story Format 3)
-- **Framework**: `@storybook/react-webpack5`
-- **Compiler**: SWC with React 19
+- **Framework**: `@storybook/react-vite` (Vite builder)
 
 ### i18n Configuration
 
@@ -50,7 +49,7 @@ Verify the following for the target component:
 
 1. Component path (e.g., `packages/ui/src/components/Button/`)
 2. Main component props (variant, color, size, etc.)
-3. External libraries used (@radix-ui, clsx, etc.)
+3. External libraries used (@base-ui/react, clsx, etc.)
 4. Presence of sub-components (e.g., Avatar.Image, Avatar.Fallback)
 ```
 
@@ -193,7 +192,7 @@ export const Default: Story = {
           "reason": "Core React library for component functionality"
         },
         {
-          "package": "@radix-ui/react-[component]",
+          "package": "@base-ui/react",
           "version": "^1.0.0",
           "reason": "Provides accessible primitives and [specific features]"
         },
@@ -210,8 +209,8 @@ export const Default: Story = {
           "description": "Official WCAG documentation on accessibility requirements"
         },
         {
-          "linkText": "Radix UI [Component] Documentation",
-          "url": "https://www.radix-ui.com/primitives/docs/components/[component]",
+          "linkText": "Base UI [Component] Documentation",
+          "url": "https://base-ui.com/react/components/[component]",
           "description": "Official documentation for the underlying primitive component"
         }
       ]
@@ -260,7 +259,7 @@ export const Default: Story = {
           "reason": "コンポーネント機能のためのコアReactライブラリ"
         },
         {
-          "package": "@radix-ui/react-[component]",
+          "package": "@base-ui/react",
           "version": "^1.0.0",
           "reason": "アクセシブルなプリミティブと[特定機能]を提供"
         },
@@ -277,8 +276,8 @@ export const Default: Story = {
           "description": "アクセシビリティ要件に関する公式WCAGドキュメント"
         },
         {
-          "linkText": "Radix UI [Component]ドキュメント",
-          "url": "https://www.radix-ui.com/primitives/docs/components/[component]",
+          "linkText": "Base UI [Component]ドキュメント",
+          "url": "https://base-ui.com/react/components/[component]",
           "description": "基礎となるプリミティブコンポーネントの公式ドキュメント"
         }
       ]
@@ -414,11 +413,11 @@ All `accessibility` sections must include:
 }
 ```
 
-**Radix UI packages:**
+**Base UI package:**
 
 ```json
 {
-  "package": "@radix-ui/react-[component]",
+  "package": "@base-ui/react",
   "version": "^1.x.x", // Get exact version from package.json
   "reason": "Provides accessible [component] primitives and [specific features]"
 }
@@ -479,13 +478,13 @@ Before finalizing translation files, verify each value:
 
 **Library-Agnostic Component Descriptions**
 
-- **CRITICAL**: Do NOT mention specific library names (Radix UI, Tailwind CSS, etc.) in `description` or `overview` sections
+- **CRITICAL**: Do NOT mention specific library names (Base UI, Tailwind CSS, etc.) in `description` or `overview` sections
 - Focus on what the component does, not what it's built with
 - Describe functionality, behavior, and purpose in universal terms
 - Examples of FORBIDDEN mentions in description/overview:
-  - ❌ "Built on Radix UI primitives"
+  - ❌ "Built on Base UI primitives"
   - ❌ "Uses Tailwind CSS for styling"
-  - ❌ "Powered by @radix-ui/react-avatar"
+  - ❌ "Powered by @base-ui/react"
   - ❌ "Styled with Tailwind utility classes"
 - Examples of CORRECT descriptions:
   - ✅ "Displays user profile images with fallback support"
@@ -753,7 +752,7 @@ pnpm build-storybook
 - [Storybook CSF3 Documentation](https://storybook.js.org/docs/react/api/csf)
 - [Storybook Autodocs](https://storybook.js.org/docs/react/writing-docs/autodocs)
 - [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)
-- [Radix UI Documentation](https://www.radix-ui.com/primitives/docs/overview/introduction)
+- [Base UI Documentation](https://base-ui.com/react/overview/quick-start)
 
 ## Execution Commands
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -70,7 +70,7 @@
 
 - [ ] No database changes
 - [ ] Database migration included
-- [ ] Prisma schema updated
+- [ ] Drizzle schema updated
 - [ ] Seed data updated
 
 **Migration details:**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,25 @@ jobs:
       - name: Type check
         run: pnpm typecheck
 
+  docs-check:
+    name: Agent Docs Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Verify agent documentation references
+        run: node scripts/check-docs.mjs
+
   icon-map:
     name: Icon Map Sync
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Run docs checker tests
+        run: node --test scripts/check-docs.test.mjs
+
       - name: Verify agent documentation references
         run: node scripts/check-docs.mjs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,12 +72,15 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
 - Structure: `server/app.ts` (app setup/routing), `server/routes/` (`createRoute()` + OpenAPI
   metadata), `server/schemas/` (Zod request/response), `server/middleware/` (apiKeyAuth,
   errorHandler, requestLogger).
+- Detailed conventions: `.claude/rules/hono-api-guidelines.md` (Claude Code auto-loads it;
+  other agents can read it directly).
 
 ### Portfolio App
 
-- i18next for internationalization (English/Japanese).
+- Server-only dictionary-based internationalization (Japanese/English) — no react-i18next.
+  Detailed conventions: `.claude/rules/portfolio-i18n-guidelines.md`.
 - Middleware-based language detection and routing (`apps/portfolio/middleware.ts`); dynamic
-  language routing with Next.js.
+  language routing with Next.js (`app/[lang]/`).
 - Next.js 16 renamed `middleware.ts` to `proxy.ts`, but the portfolio deliberately keeps
   `middleware.ts` because i18n locale detection requires the edge runtime — do not rename it.
   Use `proxy.ts` only when adding new middleware to the blog app.
@@ -93,9 +96,20 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
 ## Database (Blog App) — Drizzle
 
 - Use **Drizzle ORM** (`drizzle-orm` / `drizzle-kit`) for database operations.
-- Commands: `pnpm -F blog db:pull`, `db:generate`, `db:check` (drizzle-kit).
-- Keep the Drizzle schema in sync with the existing PostgreSQL schema.
-- Do not run destructive migration commands against production.
+- Schema lives in `apps/blog/infrastructure/drizzle/schema.ts`; migrations in
+  `apps/blog/infrastructure/drizzle/migrations/`; config in `apps/blog/drizzle.config.ts`.
+- Repositories and query services receive the client (`getDrizzleClient()` from
+  `apps/blog/infrastructure/drizzle/client.ts`) via constructor injection — never create
+  ad-hoc connections.
+- Commands (`pnpm -F blog ...`): `db:up` (local Postgres via Docker), `db:migrate` (apply
+  migrations), `db:pull` / `db:generate` / `db:check` (drizzle-kit), `db:verify`
+  (full round-trip against a disposable Postgres).
+- Schema change workflow: edit `schema.ts` → `db:generate` → review the SQL → `db:migrate`;
+  run `db:verify` before pushing.
+- Do not run destructive migration commands against production; run production migrations
+  only after the PR is merged, with a backup taken first.
+- Never run `db:up` / docker compose from a git worktree — the relative bind mount forks
+  the Postgres data directory and the dev DB appears wiped.
 
 ## Coding Style & Naming Conventions
 
@@ -188,6 +202,12 @@ export const postSchema = z.object({ id: z.string(), title: z.string() })
 ```
 
 - Wrap data-fetching in try/catch; use React error boundaries for components.
+- Domain errors live per module in `modules/<module>/domain/errors/errors.ts` (base class
+  `DomainError`; e.g. `PostAlreadyPublishedError` in the post module).
+- Adapters wrap infrastructure failures in `RepositoryError`
+  (`modules/<module>/adapters/shared/errors.ts`) instead of leaking raw driver errors.
+- In the Hono API, `errorHandler` maps `HTTPException` to its status; any other error
+  becomes 500 — throw `HTTPException` from handlers for intentional statuses.
 
 ## Testing Guidelines
 
@@ -203,11 +223,16 @@ export const postSchema = z.object({ id: z.string(), title: z.string() })
 ## Internationalization (Portfolio App)
 
 ```typescript
-import { useTranslation } from 'react-i18next';
-const { t } = useTranslation('common'); // namespace-based translations
+const { lang } = await params;
+const language = resolveLanguage(lang);
+const dictionary = await getDictionary(language); // server-only loader (i18n/dictionaries.ts)
 ```
 
-Middleware-based language detection with dynamic Next.js routing.
+Locale detection lives in `apps/portfolio/middleware.ts` (cookie → Accept-Language →
+fallback `ja`); routes are nested under `app/[lang]/`. Add new translation keys to BOTH
+locale files (`apps/portfolio/i18n/locales/{ja,en}/translation.json`). Detailed
+conventions: `.claude/rules/portfolio-i18n-guidelines.md`. (react-i18next is used only by
+the Storybook docs in `packages/ui`.)
 
 ## Environment Variables
 
@@ -245,7 +270,7 @@ See `turbo.json` for the complete env list. Critical variables:
 - Location: UI Storybook in `packages/ui/.storybook` with the Vite builder (`@storybook/react-vite`).
 - Stories: `src/**/*.stories.@(js|jsx|ts|tsx)` and MDX docs; static assets under `packages/ui/public`.
 - Local: `pnpm -F ui storybook` (port 6006). Build: `pnpm -F ui build-storybook` →
-  `packages/ui/storybook-static`.
+  `packages/ui/storybook-static` (build output). <!-- docs-check-ignore -->
 - Visual tests: `pnpm -F ui chromatic` (requires `CHROMATIC_PROJECT_TOKEN`).
 - CI: `.github/workflows/chromatic.yml` uploads on push with `onlyChanged: true`;
   review/approve diffs in Chromatic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,18 @@ See `turbo.json` for the complete env list. Critical variables:
 - Avoid storing tokens in code or stories; prefer `.env` and runtime config.
 - Never log PII; ensure authentication wraps protected Hono routes (`x-api-key`).
 
+## Documentation Rules (Agent Docs)
+
+Rules for editing `AGENTS.md`, `CLAUDE.md`, and `.claude/**` documentation:
+
+- Never pin exact dependency versions in docs (write "Storybook 10.x" or nothing) —
+  `package.json` is the source of truth.
+- Code examples must reference real repository files by path, not invented ones.
+- Shared cross-agent rules live only in `AGENTS.md`; deep dives go to `.claude/rules/`
+  (path-scoped) or `.claude/skills/` (on-demand), with a one-line pointer from `AGENTS.md`.
+- Run `pnpm docs:check` after editing agent docs — it verifies referenced paths exist and
+  guards against re-introducing removed tech (`scripts/check-docs.mjs`); CI runs it too.
+
 ## Commit & Pull Request Guidelines
 
 - Commits: gitmoji + Type format with issue reference — `<gitmoji> <Type>: #<issue> <Subject>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,11 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
 ### Portfolio App
 
 - i18next for internationalization (English/Japanese).
-- Middleware-based language detection and routing (`proxy.ts`); dynamic language routing
-  with Next.js.
+- Middleware-based language detection and routing (`apps/portfolio/middleware.ts`); dynamic
+  language routing with Next.js.
+- Next.js 16 renamed `middleware.ts` to `proxy.ts`, but the portfolio deliberately keeps
+  `middleware.ts` because i18n locale detection requires the edge runtime — do not rename it.
+  Use `proxy.ts` only when adding new middleware to the blog app.
 
 ### Key Integrations
 
@@ -108,8 +111,10 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
 - Utility files: **camelCase** (`generateHtmlTemplate.ts`).
 - Entity/domain files: **PascalCase** (`Entity.ts`, `Repository.ts`).
 - Config files: **lowercase** (`globals.css`, `middleware.ts`).
-- Component directories: **kebab-case** (`article-heading/`); domain/module directories:
-  **camelCase** (`useCases/`). `packages/ui` `*.module.css` keys must be lowerCamelCase.
+- Component directories: **kebab-case** in apps (`apps/blog/components/article-heading/`);
+  **PascalCase** in `packages/ui` (`packages/ui/src/components/Avatar/`); domain/module
+  directories: **camelCase** (`useCases/`). `packages/ui` `*.module.css` keys must be
+  lowerCamelCase.
 
 ### Component Patterns
 
@@ -237,7 +242,7 @@ See `turbo.json` for the complete env list. Critical variables:
 
 ## Storybook & Chromatic
 
-- Location: UI Storybook in `packages/ui/.storybook` with Webpack + SWC.
+- Location: UI Storybook in `packages/ui/.storybook` with the Vite builder (`@storybook/react-vite`).
 - Stories: `src/**/*.stories.@(js|jsx|ts|tsx)` and MDX docs; static assets under `packages/ui/public`.
 - Local: `pnpm -F ui storybook` (port 6006). Build: `pnpm -F ui build-storybook` →
   `packages/ui/storybook-static`.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format": "turbo run format",
     "check": "biome check .",
     "check:write": "biome check --write .",
+    "docs:check": "node scripts/check-docs.mjs",
     "storybook": "turbo run storybook",
     "build-storybook": "turbo run build-storybook",
     "chromatic": "turbo run chromatic",

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -7,25 +7,13 @@
  *    the docs (AI agents tend to reproduce legacy examples from training data).
  *
  * Append `docs-check-ignore` (e.g. in an HTML comment) to a line to exempt it.
+ *
+ * Co-located tests: scripts/check-docs.test.mjs
+ * (run with `node --test scripts/check-docs.test.mjs`).
  */
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
-
-function markdownFilesUnder(directory) {
-  return readdirSync(join(repositoryRoot, directory), { recursive: true })
-    .filter((entry) => entry.endsWith('.md'))
-    .map((entry) => join(directory, entry));
-}
-
-const documentationFiles = [
-  'AGENTS.md',
-  'CLAUDE.md',
-  ...markdownFilesUnder('.claude/rules'),
-  ...markdownFilesUnder('.claude/skills'),
-];
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const PATH_PATTERN = /`((?:apps|packages|scripts|\.claude|\.github)\/[^`\s]+)`/g;
 const GLOB_OR_PLACEHOLDER = /[*{}<>[\]]/;
@@ -58,24 +46,25 @@ const VERSION_PIN_GUARD = {
 
 const DENYLIST = [...REMOVED_TECH_GUARDS, VERSION_PIN_GUARD];
 
-const failures = [];
+/**
+ * Scan one document's content and return failure messages.
+ * `pathExists` is injected so the scan logic stays testable without disk fixtures.
+ */
+export function findDocumentationProblems(content, { fileLabel, pathExists }) {
+  const failures = [];
 
-for (const documentationFile of documentationFiles) {
-  const content = readFileSync(join(repositoryRoot, documentationFile), 'utf8');
-  const lines = content.split('\n');
-
-  lines.forEach((line, index) => {
+  content.split('\n').forEach((line, index) => {
     if (line.includes(IGNORE_MARKER)) {
       return;
     }
-    const location = `${documentationFile}:${index + 1}`;
+    const location = `${fileLabel}:${index + 1}`;
 
     for (const match of line.matchAll(PATH_PATTERN)) {
       const referencedPath = match[1].replace(/[.,;:]+$/, '');
       if (GLOB_OR_PLACEHOLDER.test(referencedPath)) {
         continue;
       }
-      if (!existsSync(join(repositoryRoot, referencedPath))) {
+      if (!pathExists(referencedPath)) {
         failures.push(`${location}: referenced path does not exist: ${referencedPath}`);
       }
     }
@@ -86,14 +75,52 @@ for (const documentationFile of documentationFiles) {
       }
     }
   });
+
+  return failures;
 }
 
-if (failures.length > 0) {
-  console.error(`docs:check failed with ${failures.length} problem(s):\n`);
-  for (const failure of failures) {
-    console.error(`  ${failure}`);
+export function collectDocumentationFiles(repositoryRoot) {
+  function markdownFilesUnder(directory) {
+    return readdirSync(join(repositoryRoot, directory), { recursive: true })
+      .filter((entry) => entry.endsWith('.md'))
+      .map((entry) => join(directory, entry));
   }
-  process.exit(1);
+
+  return [
+    'AGENTS.md',
+    'CLAUDE.md',
+    ...markdownFilesUnder('.claude/rules'),
+    ...markdownFilesUnder('.claude/skills'),
+  ];
 }
 
-console.log(`docs:check passed (${documentationFiles.length} files scanned)`);
+function runCheck() {
+  const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+  const documentationFiles = collectDocumentationFiles(repositoryRoot);
+
+  const failures = documentationFiles.flatMap((documentationFile) =>
+    findDocumentationProblems(
+      readFileSync(join(repositoryRoot, documentationFile), 'utf8'),
+      {
+        fileLabel: documentationFile,
+        pathExists: (referencedPath) => existsSync(join(repositoryRoot, referencedPath)),
+      }
+    )
+  );
+
+  if (failures.length > 0) {
+    console.error(`docs:check failed with ${failures.length} problem(s):\n`);
+    for (const failure of failures) {
+      console.error(`  ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`docs:check passed (${documentationFiles.length} files scanned)`);
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  runCheck();
+}

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Verify that agent documentation (AGENTS.md, CLAUDE.md, .claude/**) does not rot:
+ * 1. Backtick-quoted repo paths must exist on disk.
+ * 2. Exact product version pins must not appear (package.json is the source of truth).
+ * 3. Legacy-tech guard: tech that was migrated away from this repo must not re-enter
+ *    the docs (AI agents tend to reproduce legacy examples from training data).
+ *
+ * Append `docs-check-ignore` (e.g. in an HTML comment) to a line to exempt it.
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function markdownFilesUnder(directory) {
+  return readdirSync(join(repositoryRoot, directory), { recursive: true })
+    .filter((entry) => entry.endsWith('.md'))
+    .map((entry) => join(directory, entry));
+}
+
+const documentationFiles = [
+  'AGENTS.md',
+  'CLAUDE.md',
+  ...markdownFilesUnder('.claude/rules'),
+  ...markdownFilesUnder('.claude/skills'),
+];
+
+const PATH_PATTERN = /`((?:apps|packages|scripts|\.claude|\.github)\/[^`\s]+)`/g;
+const GLOB_OR_PLACEHOLDER = /[*{}<>[\]]/;
+const IGNORE_MARKER = 'docs-check-ignore';
+
+/**
+ * Re-introduction guard for tech removed from this repo.
+ * Add an entry whenever a migration retires a library or tool.
+ */
+const REMOVED_TECH_GUARDS = [
+  {
+    pattern: /\bprisma\b/i,
+    reason: 'Legacy tech: Prisma was replaced by Drizzle (#255) — use Drizzle in examples',
+  },
+  {
+    pattern: /radix/i,
+    reason: 'Legacy tech: Radix UI was replaced by Base UI (#254) — use @base-ui/react',
+  },
+  {
+    pattern: /react-webpack5|@swc\/core/,
+    reason: 'Legacy tech: Storybook Webpack/SWC builder was replaced by Vite (#310)',
+  },
+];
+
+const VERSION_PIN_GUARD = {
+  pattern:
+    /\b(?:Storybook|Next\.js|React|TypeScript|Node|pnpm|Vite|Tailwind)\s+v?\d+\.\d+\.\d+\b/,
+  reason: 'No exact version pins in docs — package.json is the source of truth',
+};
+
+const DENYLIST = [...REMOVED_TECH_GUARDS, VERSION_PIN_GUARD];
+
+const failures = [];
+
+for (const documentationFile of documentationFiles) {
+  const content = readFileSync(join(repositoryRoot, documentationFile), 'utf8');
+  const lines = content.split('\n');
+
+  lines.forEach((line, index) => {
+    if (line.includes(IGNORE_MARKER)) {
+      return;
+    }
+    const location = `${documentationFile}:${index + 1}`;
+
+    for (const match of line.matchAll(PATH_PATTERN)) {
+      const referencedPath = match[1].replace(/[.,;:]+$/, '');
+      if (GLOB_OR_PLACEHOLDER.test(referencedPath)) {
+        continue;
+      }
+      if (!existsSync(join(repositoryRoot, referencedPath))) {
+        failures.push(`${location}: referenced path does not exist: ${referencedPath}`);
+      }
+    }
+
+    for (const { pattern, reason } of DENYLIST) {
+      if (pattern.test(line)) {
+        failures.push(`${location}: ${reason} (matched ${pattern})`);
+      }
+    }
+  });
+}
+
+if (failures.length > 0) {
+  console.error(`docs:check failed with ${failures.length} problem(s):\n`);
+  for (const failure of failures) {
+    console.error(`  ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`docs:check passed (${documentationFiles.length} files scanned)`);

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { findDocumentationProblems } from './check-docs.mjs';
+
+function runChecker(content, { existingPaths = [] } = {}) {
+  return findDocumentationProblems(content, {
+    fileLabel: 'DOC.md',
+    pathExists: (referencedPath) => existingPaths.includes(referencedPath),
+  });
+}
+
+describe('findDocumentationProblems', () => {
+  describe('referenced path existence', () => {
+    it('reports a backtick-quoted repo path that does not exist', () => {
+      const content = 'See `apps/blog/missing.ts` for details.';
+
+      const failures = runChecker(content);
+
+      assert.equal(failures.length, 1);
+      assert.match(failures[0], /DOC\.md:1/);
+      assert.match(failures[0], /apps\/blog\/missing\.ts/);
+    });
+
+    it('accepts a backtick-quoted repo path that exists', () => {
+      const content = 'See `apps/blog/server/app.ts` for details.';
+
+      const failures = runChecker(content, {
+        existingPaths: ['apps/blog/server/app.ts'],
+      });
+
+      assert.deepEqual(failures, []);
+    });
+
+    it('strips trailing punctuation before checking the path', () => {
+      const content = 'Config lives in `packages/ui/package.json`.';
+
+      const failures = runChecker(content, {
+        existingPaths: ['packages/ui/package.json'],
+      });
+
+      assert.deepEqual(failures, []);
+    });
+
+    it('skips glob patterns and placeholders instead of flagging them', () => {
+      const content = [
+        'Watch `apps/blog/server/**/*.ts` files.',
+        'Locales live in `apps/portfolio/i18n/locales/{ja,en}/translation.json`.',
+        'Errors live in `apps/blog/modules/<module>/domain/errors/errors.ts`.',
+        'Routes use `apps/portfolio/app/[lang]/page.tsx`.',
+      ].join('\n');
+
+      const failures = runChecker(content);
+
+      assert.deepEqual(failures, []);
+    });
+
+    it('ignores paths outside the known repo prefixes', () => {
+      const content = 'The handler is `app/api/[[...route]]/route.ts` in the blog app.';
+
+      const failures = runChecker(content);
+
+      assert.deepEqual(failures, []);
+    });
+
+    it('reports the correct line number for a failure on a later line', () => {
+      const content = 'First line is fine.\nSee `scripts/missing.mjs` here.';
+
+      const failures = runChecker(content);
+
+      assert.equal(failures.length, 1);
+      assert.match(failures[0], /DOC\.md:2/);
+    });
+  });
+
+  describe('docs-check-ignore escape hatch', () => {
+    it('skips every check on a line carrying the ignore marker', () => {
+      const content =
+        'Output goes to `packages/ui/storybook-static` (build output). <!-- docs-check-ignore -->';
+
+      const failures = runChecker(content);
+
+      assert.deepEqual(failures, []);
+    });
+  });
+
+  describe('legacy tech re-introduction guard', () => {
+    const legacyTechCases = [
+      { name: 'Prisma', line: 'Use the Prisma client for persistence.' },
+      { name: 'Radix UI', line: 'Built on @radix-ui/react-avatar primitives.' },
+      {
+        name: 'Storybook Webpack builder',
+        line: "import type { Meta } from '@storybook/react-webpack5';",
+      },
+    ];
+
+    for (const { name, line } of legacyTechCases) {
+      it(`flags removed tech: ${name}`, () => {
+        const failures = runChecker(line);
+
+        assert.equal(failures.length, 1);
+        assert.match(failures[0], /Legacy tech/);
+      });
+    }
+
+    it('does not flag current tech mentions', () => {
+      const content = 'Use Drizzle ORM and @base-ui/react with the Vite builder.';
+
+      const failures = runChecker(content);
+
+      assert.deepEqual(failures, []);
+    });
+  });
+
+  describe('version pin guard', () => {
+    it('flags an exact product version pin', () => {
+      const content = '- **Version**: Storybook 10.0.6';
+
+      const failures = runChecker(content);
+
+      assert.equal(failures.length, 1);
+      assert.match(failures[0], /version pins/);
+    });
+
+    it('allows major-only version mentions', () => {
+      const content = 'Storybook 10.x with React 19 on Node 20.';
+
+      const failures = runChecker(content);
+
+      assert.deepEqual(failures, []);
+    });
+
+    it('allows semver ranges inside JSON dependency examples', () => {
+      const content = '"package": "react", "version": "^19.0.0"';
+
+      const failures = runChecker(content);
+
+      assert.deepEqual(failures, []);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Brush up the AI agent documentation (`AGENTS.md`, `CLAUDE.md`, `.claude/**`) so agents work from accurate, rot-resistant docs. An audit found stale tech references (Prisma, Radix UI, Webpack builder, react-i18next), an internal `proxy.ts`/`middleware.ts` contradiction, missing subsystem conventions, and no mechanism to keep docs in sync with the repo.

### What changed?

- Fixed stale references: Prisma→Drizzle examples in `clean-architecture-guidelines` (anchored to real repo files), Radix UI→Base UI and Webpack→Vite builder in `k2bg-storybook-docs`, removed the Storybook version pin, fixed `proxy.ts`→`middleware.ts` with a "do not rename" rationale note, and clarified component-directory casing (kebab-case in apps, PascalCase in `packages/ui`)
- Rewrote the AGENTS.md i18n section to match reality (server-only dictionary loader, not react-i18next) and expanded the Drizzle workflow and domain-error guidance
- Added path-scoped rules: `.claude/rules/hono-api-guidelines.md` (`apps/blog/server/**`) and `.claude/rules/portfolio-i18n-guidelines.md` (`apps/portfolio/**`), with pointers from AGENTS.md
- Added `scripts/check-docs.mjs` (`pnpm docs:check`): verifies referenced repo paths exist, blocks exact version pins, and guards against re-introduction of removed tech (Prisma, Radix UI, Webpack builder); wired into CI as a lightweight job
- Moved `enabledMcpjsonServers: ["k2bg-design-system"]` into shared `.claude/settings.json` and added a "Documentation Rules" policy section to AGENTS.md

### Why was this changed?

- Incorrect docs propagate wrong patterns (e.g. Prisma examples) into agent-generated code
- The new check script already caught two real issues while this PR was being prepared (a leftover `@storybook/react-webpack5` import in a template and a nonexistent-path reference)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [x] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ⚡ Performance improvements
- [ ] 🧪 Test additions or updates
- [ ] 🔒 Security improvements
- [ ] 📦 Dependency updates
- [x] 🏗️ Build/CI changes

## Affected Applications

- [ ] 📝 Blog app (`apps/blog/`)
- [ ] 💼 Portfolio app (`apps/portfolio/`)
- [ ] 🎨 UI package (`packages/ui/`)
- [ ] 🔧 Shared packages (`packages/`)
- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing completed
- [x] No tests needed (documentation and a standalone check script; the script is exercised directly and in CI)

### How to Test

1. Run `pnpm docs:check` — it should pass (15 files scanned)
2. Temporarily add a nonexistent backticked path like `apps/blog/nope.ts` to AGENTS.md and re-run to see it fail
3. Verify the `Agent Docs Check` job runs on this PR

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [ ] New tests pass
- [ ] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes
- [ ] Database migration included
- [ ] Drizzle schema updated
- [ ] Seed data updated

## Environment Variables

- [x] No environment variable changes
- [ ] New environment variables added (documented below)
- [ ] Existing environment variables modified

## Screenshots/Videos

Not applicable (documentation and tooling only).

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)
- [ ] Storybook stories added/updated
- [ ] TypeScript types documented
- [ ] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings
- [ ] Responsive design tested (if applicable)
- [ ] Accessibility tested (if applicable)
- [x] Performance impact considered

## Related Issues

Closes #319

## Additional Context

Documentation policy going forward is captured in the new AGENTS.md "Documentation Rules" section: no exact version pins, examples must reference real repo paths, shared rules live only in AGENTS.md, and `pnpm docs:check` runs after doc edits.

## Reviewer Notes

- `scripts/check-docs.mjs`: the path-extraction regex and the legacy-tech guard list (`REMOVED_TECH_GUARDS`) — sanity-check the false-positive escape hatch (`docs-check-ignore`)
- `.claude/rules/portfolio-i18n-guidelines.md`: confirms the app has no react-i18next; please flag if any consumer still relies on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
