### PR TITLE
📝 Docs: #321 Add Drizzle persistence and error-handling agent rules

### DIFF
--- a/.claude/rules/drizzle-guidelines.md
+++ b/.claude/rules/drizzle-guidelines.md
@@ -1,0 +1,81 @@
+---
+paths: apps/blog/**/drizzle/**/*.ts
+---
+
+# Drizzle Persistence Layer Guidelines
+
+Conventions for the blog app's persistence layer: the single-file schema, the client
+singleton, and the Drizzle adapters under `modules/<module>/adapters/output/`.
+
+> **Scope note:** these are target conventions for new and changed code. Existing
+> violations are tracked in dedicated issues — do NOT refactor them as part of
+> unrelated changes.
+
+## Schema (`apps/blog/infrastructure/drizzle/schema.ts`)
+
+- Single authored schema file. The separate snapshot under
+  `apps/blog/infrastructure/drizzle/migrations/` is drizzle-kit output — never edit it
+  by hand.
+- Naming mirrors the pre-existing production database and is intentionally diff-stable
+  (#255). Keep it: PascalCase table string literals (`pgTable('Post', ...)`) with
+  camelCase plural TS exports (`posts`), and explicit named FK constraints.
+- Column casing is mixed for historical reasons. New columns MUST follow the casing of
+  the surrounding table (app tables mostly camelCase; auth tables owned by better-auth
+  are snake_case) — do not "normalize" existing names.
+- Declare relations with `relations()` next to the tables involved.
+- `apps/blog/drizzle.config.ts` is `strict` + `verbose` with a `tablesFilter`
+  allow-list. Adding a table requires adding it to the filter; do not loosen the config.
+
+## Client (`apps/blog/infrastructure/drizzle/client.ts`)
+
+- App code uses the `getDrizzleClient()` singleton; `createDrizzleClient()` /
+  `resetDrizzleClient()` are for tests only.
+- Repositories and query services receive `DrizzleClient` via constructor injection —
+  never create ad-hoc connections or import the client deep inside a function.
+- The postgres-js options are Lambda-safe (`max: 1`, module-scoped reuse). Do not raise
+  the pool size or move the client out of module scope.
+
+## Repositories vs. Query Services (CQRS split)
+
+- **Repositories** (`modules/<module>/adapters/output/repositories/drizzle/`) serve
+  commands and return domain entities. Canonical:
+  `apps/blog/modules/post/adapters/output/repositories/drizzle/postRepository.ts` —
+  rows go through the co-located `mapper.ts` (`toDomain` / `toPersistence`), misses
+  return `null`, writes use `insert().onConflictDoUpdate()` upserts, and every method
+  wraps failures in `RepositoryError`.
+- **Query services** (`modules/<module>/adapters/output/query-services/drizzle/`) serve
+  reads and return plain DTOs. Canonical:
+  `apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesByCategoryQueryService.ts`
+  — `select()` projections with `leftJoin`, plus a parallel `count()` query for
+  pagination (no N+1).
+- Never cross the split: a query service MUST NOT return domain entities or raw rows;
+  a repository MUST NOT return DTOs.
+
+## Transactions
+
+- Any operation writing multiple rows or tables MUST run inside `db.transaction`.
+  Canonical:
+  `apps/blog/modules/post/adapters/output/repositories/drizzle/postBatchRepository.ts`.
+
+## Mapping — MUST NOT
+
+- No silent enum fallbacks: a `switch` mapping a DB string to a domain enum MUST throw
+  `MappingError` in its `default:` branch, never coerce unknown values to a default
+  member.
+- No unchecked casts from row values to domain types (e.g. `row.category as Category`)
+  — narrow through an explicit mapping function that validates the value.
+- No presentation concerns in persistence: URL/path composition (e.g.
+  `` `${uuid}/${slug}` ``) belongs to the domain or presentation layer, not a mapper or
+  query service.
+- Represent absent values consistently: one canonical representation per field (the
+  entity's value-object empty state, or `null` in DTOs) — never a mix of `''` / `null`
+  per call site.
+
+## Verification
+
+- Schema change: edit `schema.ts` → `pnpm -F blog db:generate` → review the generated
+  SQL → `pnpm -F blog db:migrate` → `pnpm -F blog db:verify` (ephemeral-container
+  round-trip; must end with an empty diff) before pushing.
+- Adapter-only change: `pnpm -F blog typecheck && pnpm -F blog lint && pnpm -F blog test`.
+- Never run `db:up` / docker compose from a git worktree, and never run destructive
+  migration commands against production (see `AGENTS.md`, Database section).

--- a/.claude/rules/error-handling-guidelines.md
+++ b/.claude/rules/error-handling-guidelines.md
@@ -1,0 +1,83 @@
+---
+paths: apps/blog/modules/**/*.ts, apps/blog/app/**/*.tsx, apps/blog/server/middleware/*.ts
+---
+
+# Error Handling Guidelines (Blog App)
+
+Errors are layered and translated at each boundary — never leaked raw across layers:
+
+```
+DomainError (domain invariants)
+  → RepositoryError / ExternalSourceError / MappingError (adapters wrap infrastructure)
+    → UseCaseError / SyncError (use cases wrap orchestration failures)
+      → HTTPException (Hono API) | UseCaseError-discriminated notFound() (pages)
+```
+
+> **Scope note:** these are target conventions for new and changed code. Existing
+> violations are tracked in dedicated issues — do NOT refactor them as part of
+> unrelated changes.
+
+## Domain Errors (`modules/<module>/domain/errors/errors.ts`)
+
+Canonical: `apps/blog/modules/post/domain/errors/errors.ts`.
+
+- Each module defines a `DomainError extends Error` base; concrete errors extend it —
+  never extend `Error` directly.
+- The base MUST set `this.name = this.constructor.name` and call
+  `Object.setPrototypeOf(this, new.target.prototype)` so `instanceof` and error names
+  survive transpilation. Do not hardcode name strings per subclass.
+- Domain errors express business rule violations only (invalid value object, invariant
+  breach, illegal state transition). Infrastructure failures are NOT domain errors.
+
+## Adapter Errors (`modules/<module>/adapters/shared/errors.ts`)
+
+Canonical: `apps/blog/modules/post/adapters/shared/errors.ts` (`RepositoryError`,
+`ExternalSourceError`, `MappingError`).
+
+- Adapters MUST wrap every raw driver / fetch / SDK failure in one of these types and
+  preserve the original error as `cause` — never re-throw a raw infrastructure error.
+- Adapters MUST NOT throw domain-typed errors for infrastructure failures (e.g. an
+  email SDK failure is an adapter error, not a `DomainError` subclass).
+- External integrations (Notion, Instagram, Cloudinary, SES) wrap in
+  `ExternalSourceError` (or a dedicated `RepositoryError` subclass) and may log before
+  throwing; mapping failures throw `MappingError`.
+
+## Use-Case Errors (`modules/<module>/use-cases/shared/errors.ts`)
+
+Canonical: `apps/blog/modules/post/use-cases/shared/errors.ts` (`UseCaseError`,
+`PostNotFoundError`, `SyncError`).
+
+- Use cases translate lower-layer failures into `UseCaseError` subclasses when they
+  carry application meaning (not found, invalid pagination); otherwise let the error
+  propagate.
+- MUST NOT swallow errors: no empty `catch {}` and no catch-and-return that discards
+  the cause without logging. If a per-item failure is tolerated in a batch, log the
+  error before recording the failure.
+
+## API Boundary (`apps/blog/server/middleware/errorHandler.ts`)
+
+- `errorHandler` maps `HTTPException` to its status; every other error becomes
+  `500 INTERNAL_SERVER_ERROR`. To return an intentional status from a route handler,
+  throw `HTTPException`. Details: `.claude/rules/hono-api-guidelines.md`.
+
+## Next.js Page Boundary (`apps/blog/app/`)
+
+Canonical: `apps/blog/app/search/page.tsx` and
+`apps/blog/app/category/[category]/page.tsx`.
+
+- When a page-level fetch fails, discriminate before reacting: `UseCaseError` →
+  `logger.warn` (expected application failure); anything else → `logger.error`
+  (unexpected/infrastructure failure). Only then fall back (`notFound()`).
+- MUST NOT use a blanket `.catch(() => notFound())` — it masks outages and mapping
+  bugs as 404s and hides the cause from logs.
+- `generateMetadata` MUST handle errors symmetrically with its page component: the
+  same call gets the same discrimination, not a different (or missing) catch.
+- Rendering errors are caught by the global boundaries (`apps/blog/app/error.tsx`,
+  `apps/blog/app/not-found.tsx`) — do not add per-page try/catch around rendering.
+
+## Verification
+
+- `pnpm -F blog typecheck && pnpm -F blog lint && pnpm -F blog test`.
+- Error mapping and discrimination are behavior — cover them in co-located
+  `*.test.ts(x)` per `.claude/rules/unit-test-guidelines.md` (e.g. assert an adapter
+  wraps a failing driver call in `RepositoryError` with `cause` preserved).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,8 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
   only after the PR is merged, with a backup taken first.
 - Never run `db:up` / docker compose from a git worktree — the relative bind mount forks
   the Postgres data directory and the dev DB appears wiped.
+- Detailed persistence conventions (schema, client, repositories vs. query services,
+  transactions, mapping): `.claude/rules/drizzle-guidelines.md`.
 
 ## Coding Style & Naming Conventions
 
@@ -208,6 +210,8 @@ export const postSchema = z.object({ id: z.string(), title: z.string() })
   (`modules/<module>/adapters/shared/errors.ts`) instead of leaking raw driver errors.
 - In the Hono API, `errorHandler` maps `HTTPException` to its status; any other error
   becomes 500 — throw `HTTPException` from handlers for intentional statuses.
+- Detailed error taxonomy (domain → adapter → use-case → API/page boundaries):
+  `.claude/rules/error-handling-guidelines.md`.
 
 ## Testing Guidelines
 


### PR DESCRIPTION
## Summary

Adds two new path-scoped agent rules that document quality-critical conventions for the blog app, derived from an audit of the actual codebase patterns.

### What changed?

- New rule `.claude/rules/drizzle-guidelines.md` — persistence-layer conventions: legacy-locked schema naming, client singleton + constructor injection, the repositories vs. query-services (CQRS) split, transaction requirements, mapping MUST-NOTs (no silent enum fallbacks, no unchecked casts, no URL composition in persistence), and the embedded schema-change verification workflow (`db:generate` → review SQL → `db:migrate` → `db:verify`).
- New rule `.claude/rules/error-handling-guidelines.md` — the four-layer error taxonomy (`DomainError` → adapter errors → `UseCaseError` → API/page boundaries) with canonical file references, wrapping rules (preserve `cause`, never re-throw raw errors), no silent `catch {}`, and the Next.js page-boundary discrimination pattern.
- `AGENTS.md` — two pointer bullets linking the new rules from the Database and Validation & Error Handling sections.

### Why was this changed?

- The Drizzle persistence layer and the error-handling architecture had zero documented conventions — the two largest agent-documentation gaps where correctness bugs actually originate (audit found raw error re-throws, silent enum coercion, and outages masked as 404s).
- Rules prescribe target conventions with an explicit scope note; existing code violations are intentionally NOT fixed here — they are tracked as follow-up issues #322, #323, #324, #325 which reference these rules as their spec.

## Type of Change

- [x] 📝 Documentation update

## Affected Applications

- [ ] 📝 Blog app (`apps/blog/`)
- [ ] 💼 Portfolio app (`apps/portfolio/`)
- [ ] 🎨 UI package (`packages/ui/`)
- [ ] 🔧 Shared packages (`packages/`)
- [ ] 🏗️ Build configuration (Turborepo, configs)

(Agent documentation only — no application code changes.)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

Documentation-only change; correctness is enforced by the existing `docs:check` guard.

### How to Test

1. Run `pnpm docs:check` — validates all referenced paths exist, no version pins, no removed-tech mentions.
2. Confirm the new rules load for their path scopes (frontmatter `paths:` globs follow the same format as `.claude/rules/code-style.md`).

### Test Results

- [x] All existing tests pass (`pnpm test`) — not affected (no code changes)
- [x] Linting passes (`pnpm lint`) — not affected (markdown only)
- `pnpm docs:check` passes (17 files scanned).

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Screenshots/Videos

N/A (documentation only)

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings
- [x] Performance impact considered

## Related Issues

Closes #321
Relates to #322, #323, #324, #325 (follow-up code fixes specced by these rules)

## Additional Context

Every MUST/MUST-NOT in the rules corresponds to a pattern or violation verified in the codebase during the audit — no speculative conventions. Both rules carry a scope note instructing agents not to refactor existing violations during unrelated tasks.

## Reviewer Notes

- Check that the canonical file references match your understanding of the intended patterns (e.g. `postRepository.ts` + `mapper.ts` as the repository canon, `app/search/page.tsx` as the page-boundary canon).
- The error rule's multi-glob `paths:` frontmatter covers `modules/**`, `app/**`, and `server/middleware/*` — flag if that scope feels too broad.

### For Reviewers

Please ensure:

- [ ] Code quality and maintainability
- [ ] Test coverage is adequate
- [ ] Breaking changes are clearly documented
- [ ] Performance implications are considered
- [ ] Security implications are considered
