### PR TITLE
🐛 Fix: #329 Fail closed and default-deny API key auth

### DIFF
--- a/.claude/rules/hono-api-guidelines.md
+++ b/.claude/rules/hono-api-guidelines.md
@@ -13,8 +13,10 @@ Conventions for the Hono REST API integrated into the blog app. The server lives
 - The app is an `OpenAPIHono` (from `@hono/zod-openapi`) with `.basePath('/api')`.
 - Middleware order matters and is fixed:
   1. `app.use('*', requestLogger)` — global logging.
-  2. `app.use('/<path>', apiKeyAuth)` — per-path auth for every protected route
-     (`/posts`, `/images`, `/revalidate`). New protected routes MUST be added here.
+  2. `app.use('*', ...)` — default-deny auth guard: every path runs through
+     `apiKeyAuth` unless it is listed in `PUBLIC_PATHS`. New routes are protected by
+     default; only add a path to `PUBLIC_PATHS` when it must be reachable without a
+     key (e.g. the OpenAPI docs).
   3. `app.route('/', <routes>)` — mount route groups.
   4. `app.onError(errorHandler)` — registered last.
 - OpenAPI docs (`/api/doc.json`) and Swagger UI (`/api/doc`) are exposed only when
@@ -51,6 +53,7 @@ Canonical example: `apps/blog/server/routes/post.ts`.
 ## Middleware & Errors (`apps/blog/server/middleware/`)
 
 - `apiKeyAuth` — compares the `x-api-key` header to `process.env.API_KEY`; throws
+  `HTTPException(500)` if `API_KEY` is not configured (fail-closed) and
   `HTTPException(401)` on mismatch.
 - `requestLogger` — logs request start/completion with method, path, status, duration.
 - `errorHandler` — maps `HTTPException` to its status; everything else (including domain
@@ -70,5 +73,7 @@ Canonical example: `apps/blog/server/routes/post.ts`.
 
 ## Security
 
-- Every state-changing route MUST be behind `apiKeyAuth` (wired in `app.ts`).
+- Auth is default-deny: every route is behind `apiKeyAuth` unless explicitly listed in
+  `PUBLIC_PATHS` (`app.ts`). Do not add a route to `PUBLIC_PATHS` unless it must be
+  publicly reachable.
 - Never log request bodies or PII in `requestLogger` or handlers.

--- a/apps/blog/server/app.test.ts
+++ b/apps/blog/server/app.test.ts
@@ -106,6 +106,13 @@ describe('OpenAPIHono app composition', () => {
       const statusOk = 200;
       expect(res.status).toBe(statusOk);
     });
+
+    it('rejects an unmounted path without an API key (default-deny before routing)', async () => {
+      const res = await app.request('/api/does-not-exist', { method: 'GET' });
+
+      const statusUnauthorized = 401;
+      expect(res.status).toBe(statusUnauthorized);
+    });
   });
 
   describe('route mounting', () => {

--- a/apps/blog/server/app.ts
+++ b/apps/blog/server/app.ts
@@ -13,10 +13,15 @@ app.openAPIRegistry.registerComponent('securitySchemes', 'ApiKeyAuth', {
   name: 'x-api-key',
 });
 
+const PUBLIC_PATHS = ['/api/doc', '/api/doc.json'];
+
 app.use('*', requestLogger);
-app.use('/posts', apiKeyAuth);
-app.use('/images', apiKeyAuth);
-app.use('/revalidate', apiKeyAuth);
+app.use('*', async (c, next) => {
+  if (PUBLIC_PATHS.includes(c.req.path)) {
+    return next();
+  }
+  return apiKeyAuth(c, next);
+});
 
 app.route('/', postRoutes);
 app.route('/', mediaRoutes);

--- a/apps/blog/server/middleware/apiKeyAuth.test.ts
+++ b/apps/blog/server/middleware/apiKeyAuth.test.ts
@@ -52,4 +52,19 @@ describe('apiKeyAuth', () => {
     const statusUnauthorized = 401;
     expect(res.status).toBe(statusUnauthorized);
   });
+
+  describe('when the server API key is not configured', () => {
+    it.each<{ description: string; headers: HeadersInit }>([
+      { description: 'with a header', headers: { 'x-api-key': validApiKey } },
+      { description: 'without a header', headers: {} },
+    ])('returns 500 $description', async ({ headers }) => {
+      delete process.env.API_KEY;
+      const app = createApp();
+
+      const res = await app.request('/test', { headers });
+
+      const statusInternalServerError = 500;
+      expect(res.status).toBe(statusInternalServerError);
+    });
+  });
 });

--- a/apps/blog/server/middleware/apiKeyAuth.ts
+++ b/apps/blog/server/middleware/apiKeyAuth.ts
@@ -2,8 +2,15 @@ import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
 
 export const apiKeyAuth = createMiddleware(async (c, next) => {
+  const configuredApiKey = process.env.API_KEY;
+  if (!configuredApiKey) {
+    throw new HTTPException(500, {
+      message: 'API authentication is not configured',
+    });
+  }
+
   const apiKey = c.req.header('x-api-key');
-  if (apiKey !== process.env.API_KEY) {
+  if (apiKey !== configuredApiKey) {
     throw new HTTPException(401, { message: 'Invalid or missing API key' });
   }
   await next();


### PR DESCRIPTION
## Summary

Fixes the fail-open API key authentication: when `API_KEY` was unset in the environment, `apiKey !== process.env.API_KEY` compared `undefined !== undefined` and let every request through, exposing `PATCH /api/posts`, `PATCH /api/images`, and `POST /api/revalidate` without authentication.

### What changed?

- `apiKeyAuth` now fails closed: if `API_KEY` is not configured, it throws `HTTPException(500)` before any comparison
- Auth registration in `server/app.ts` is now default-deny: `apiKeyAuth` applies to `'*'`, with an explicit `PUBLIC_PATHS` allowlist (`/api/doc`, `/api/doc.json`) — new routes are protected by default
- Tests: unset-`API_KEY` cases (with/without header → 500) and a default-deny test (unmounted path → 401 before routing)
- `.claude/rules/hono-api-guidelines.md` updated to describe the default-deny model

### Why was this changed?

- A deployment missing `API_KEY` silently published all state-changing endpoints; misconfiguration must fail loudly (see `.claude/rules/error-handling-guidelines.md`)
- Per-route auth opt-in relied on remembering to add each new route to `app.ts`; default-deny turns that vigilance into a mechanism

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security improvements
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

### How to Test

1. `pnpm -F blog test` — see `apps/blog/server/middleware/apiKeyAuth.test.ts` and `apps/blog/server/app.test.ts`
2. Unset `API_KEY` locally and request any `/api/*` route → 500 `API authentication is not configured`
3. With `API_KEY` set, `GET /api/doc.json` (non-production) works without a key; any other path without `x-api-key` → 401

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

Behavior change is intentional: deployments without `API_KEY` now reject all API requests (500) instead of accepting them unauthenticated.

## Deployment Notes

- [x] No special deployment requirements

Confirm `API_KEY` is set in every deployed environment before merging — environments relying on the fail-open behavior will start rejecting requests.

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

`.claude/rules/hono-api-guidelines.md` (`pnpm docs:check` passes).

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #329

## Additional Context

Found in the 2026-07 repository audit (issue #329).

## Reviewer Notes

- `PUBLIC_PATHS` uses `c.req.path`, which includes the `/api` basePath — verified by the app-level tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
