### PR TITLE
🐛 Fix: #330 Propagate revalidation failures to the API response

### DIFF
--- a/apps/blog/server/lib/revalidation.test.ts
+++ b/apps/blog/server/lib/revalidation.test.ts
@@ -1,0 +1,65 @@
+import { revalidatePath } from 'next/cache';
+import { describe, expect, it, vi } from 'vitest';
+import { revalidateBlogPages, revalidateBlogPath } from './revalidation';
+
+const { errorMock } = vi.hoisted(() => ({
+  errorMock: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('../../modules/shared/logger', () => ({
+  logger: {
+    child: () => ({ error: errorMock, info: vi.fn() }),
+  },
+}));
+
+const mockRevalidatePath = vi.mocked(revalidatePath);
+
+describe('revalidateBlogPages', () => {
+  it('revalidates every blog page path', () => {
+    mockRevalidatePath.mockClear();
+
+    revalidateBlogPages();
+
+    const blogPageCount = 4;
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(blogPageCount);
+  });
+
+  it('logs and rethrows when revalidatePath fails', () => {
+    errorMock.mockClear();
+    const revalidationError = new Error('Revalidation failed');
+    mockRevalidatePath.mockImplementationOnce(() => {
+      throw revalidationError;
+    });
+
+    expect(() => revalidateBlogPages()).toThrow(revalidationError);
+    expect(errorMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('revalidateBlogPath', () => {
+  it('revalidates the given path', () => {
+    mockRevalidatePath.mockClear();
+    const path = '/blog/my-post';
+
+    revalidateBlogPath(path);
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith(path);
+  });
+
+  it('logs and rethrows when revalidatePath fails', () => {
+    errorMock.mockClear();
+    const revalidationError = new Error('Revalidation failed');
+    mockRevalidatePath.mockImplementationOnce(() => {
+      throw revalidationError;
+    });
+
+    expect(() => revalidateBlogPath('/blog/my-post')).toThrow(
+      revalidationError
+    );
+    expect(errorMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/blog/server/lib/revalidation.ts
+++ b/apps/blog/server/lib/revalidation.ts
@@ -18,6 +18,7 @@ export function revalidateBlogPages(): void {
     revalidationLogger.info('Revalidated all blog pages');
   } catch (error) {
     revalidationLogger.error({ error }, 'Failed to revalidate blog pages');
+    throw error;
   }
 }
 
@@ -27,5 +28,6 @@ export function revalidateBlogPath(path: string): void {
     revalidationLogger.info({ path }, 'Revalidated path');
   } catch (error) {
     revalidationLogger.error({ error, path }, 'Failed to revalidate path');
+    throw error;
   }
 }

--- a/apps/blog/server/routes/revalidation.test.ts
+++ b/apps/blog/server/routes/revalidation.test.ts
@@ -1,0 +1,103 @@
+import { Hono } from 'hono';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { describe, expect, it, vi } from 'vitest';
+import { errorHandler } from '../middleware/errorHandler';
+import { revalidationRoutes } from './revalidation';
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock('../../modules/shared/logger', () => ({
+  logger: {
+    child: () => ({ error: vi.fn(), info: vi.fn() }),
+  },
+}));
+
+const mockRevalidatePath = vi.mocked(revalidatePath);
+const mockRevalidateTag = vi.mocked(revalidateTag);
+
+function createApp() {
+  const app = new Hono();
+  app.route('/', revalidationRoutes);
+  app.onError(errorHandler);
+  return app;
+}
+
+function postRevalidate(app: Hono, body?: Record<string, string>) {
+  return app.request('/revalidate', {
+    method: 'POST',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe('revalidationRoutes', () => {
+  describe('POST /revalidate', () => {
+    it('revalidates all blog pages and returns revalidated true when no body is given', async () => {
+      mockRevalidatePath.mockClear();
+      const app = createApp();
+
+      const res = await postRevalidate(app);
+
+      const statusOk = 200;
+      expect(res.status).toBe(statusOk);
+      const body = await res.json();
+      expect(body.revalidated).toBe(true);
+    });
+
+    it('returns 500 with the shared error shape when revalidation fails', async () => {
+      mockRevalidatePath.mockImplementationOnce(() => {
+        throw new Error('Revalidation failed');
+      });
+      const app = createApp();
+
+      const res = await postRevalidate(app);
+
+      const statusInternalError = 500;
+      expect(res.status).toBe(statusInternalError);
+      const body = await res.json();
+      expect(body.error).toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        status: statusInternalError,
+      });
+    });
+
+    it('revalidates by tag when a tag is given', async () => {
+      mockRevalidateTag.mockClear();
+      const app = createApp();
+      const tag = 'posts';
+
+      const res = await postRevalidate(app, { tag });
+
+      const statusOk = 200;
+      expect(res.status).toBe(statusOk);
+      expect(mockRevalidateTag).toHaveBeenCalledWith(tag, 'max');
+    });
+
+    it('revalidates a specific path when a path is given', async () => {
+      mockRevalidatePath.mockClear();
+      const app = createApp();
+      const path = '/blog/my-post';
+
+      const res = await postRevalidate(app, { path });
+
+      const statusOk = 200;
+      expect(res.status).toBe(statusOk);
+      expect(mockRevalidatePath).toHaveBeenCalledWith(path);
+    });
+
+    it('returns 500 when revalidating a specific path fails', async () => {
+      mockRevalidatePath.mockImplementationOnce(() => {
+        throw new Error('Revalidation failed');
+      });
+      const app = createApp();
+
+      const res = await postRevalidate(app, { path: '/blog/my-post' });
+
+      const statusInternalError = 500;
+      expect(res.status).toBe(statusInternalError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/revalidate` always responded `{ revalidated: true }` because `lib/revalidation.ts` caught revalidation errors and only logged them. The OpenAPI-documented 500 response was unreachable, so callers (e.g. the Notion sync flow) could not detect failed revalidation and stale caches persisted silently.

### What changed?

- `revalidateBlogPages()` and `revalidateBlogPath()` keep their contextual error log but now rethrow, so failures propagate to `errorHandler` and produce the documented 500
- New tests: `apps/blog/server/routes/revalidation.test.ts` (success 200 for default/tag/path variants, failure → 500 with the shared error shape) and `apps/blog/server/lib/revalidation.test.ts` (logs then rethrows)

### Why was this changed?

- Swallowed errors made revalidation failures invisible; `.claude/rules/error-handling-guidelines.md` forbids catch-and-discard
- `revalidated: true` on failure is a false success signal to API consumers

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

### How to Test

1. `pnpm -F blog test` — see the two new test files
2. Force `revalidatePath` to throw and call `POST /api/revalidate` → 500 with `{ error: { code, message, status, timestamp } }`

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

API consumers that treated the endpoint as always-200 will now see 500 on real failures — that is the documented contract.

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #330

## Additional Context

Found in the 2026-07 repository audit (issue #330).

## Reviewer Notes

- The route handler is unchanged — propagation through `app.onError(errorHandler)` already yields the documented 500; tests register `errorHandler` to exercise that mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
