### PR TITLE
🐛 Fix: #333 Apply sub-provider color in AffiliateEmb

### DIFF
--- a/apps/blog/components/markdown/AffiliateEmb.test.tsx
+++ b/apps/blog/components/markdown/AffiliateEmb.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AffiliateType } from '../../modules/affiliate/domain';
+import { AffiliateEmb } from './AffiliateEmb';
+
+const { mockFetchAffiliate, mockFetchAffiliatesByIds } = vi.hoisted(() => ({
+  mockFetchAffiliate: vi.fn(),
+  mockFetchAffiliatesByIds: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/di/affiliate', () => ({
+  createFetchAffiliateUseCase: () => ({ execute: mockFetchAffiliate }),
+  createFetchAffiliatesByIdsUseCase: () => ({
+    execute: mockFetchAffiliatesByIds,
+  }),
+}));
+
+vi.mock('../cloudinary-image/CloudinaryImage', () => ({
+  CloudinaryImage: () => <div data-testid="cloudinary-image" />,
+}));
+
+describe('AffiliateEmb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the sub-provider link with its configured provider color', async () => {
+    const subProviderColor = '#BF0000';
+    mockFetchAffiliate.mockResolvedValue({
+      affiliate: {
+        id: 'product-1',
+        name: 'Test Product',
+        type: AffiliateType.PRODUCT,
+        targetUrl: 'https://example.com/product',
+        provider: 'Amazon',
+        providerColor: '#FF9900',
+        subProviderIds: ['sub-1'],
+        imageProvider: 'Amazon',
+        imageSourceUrl: 'https://example.com/images/product.jpg',
+        imageWidth: 200,
+        imageHeight: 200,
+      },
+    });
+    mockFetchAffiliatesByIds.mockResolvedValue({
+      affiliates: new Map([
+        [
+          'sub-1',
+          {
+            id: 'sub-1',
+            name: 'Test SubProvider',
+            type: AffiliateType.SUB_PROVIDER,
+            targetUrl: 'https://example.com/subprovider',
+            provider: 'Rakuten',
+            providerColor: subProviderColor,
+          },
+        ],
+      ]),
+    });
+
+    render(await AffiliateEmb({ id: 'product-1' }));
+
+    const subProviderLink = screen.getByRole('link', { name: 'Rakuten' });
+    expect(subProviderLink).toHaveStyle({ backgroundColor: subProviderColor });
+  });
+});

--- a/apps/blog/components/markdown/AffiliateEmb.tsx
+++ b/apps/blog/components/markdown/AffiliateEmb.tsx
@@ -93,7 +93,7 @@ async function fetchSubProviders(
         linkText: subProvider.provider,
         linkUrl: subProvider.targetUrl,
         color:
-          subProvider.type === AffiliateType.PRODUCT
+          subProvider.type === AffiliateType.SUB_PROVIDER
             ? subProvider.providerColor
             : '',
       };


### PR DESCRIPTION
## Summary

The sub-provider buttons in affiliate embeds never rendered their CMS-configured color: the guard in `fetchSubProviders` compared `subProvider.type === AffiliateType.PRODUCT`, but the DTOs returned by `fetchAffiliatesByIds` for sub-provider IDs always have `type === AffiliateType.SUB_PROVIDER` (see `toSubProviderOutput` in `modules/affiliate/use-cases/shared/affiliateOutputMapper.ts`), so the branch was unreachable and `color` was always `''`.

### What changed?

- `apps/blog/components/markdown/AffiliateEmb.tsx`: guard now checks `AffiliateType.SUB_PROVIDER`, so `providerColor` flows through
- New `AffiliateEmb.test.tsx`: renders the async server component with mocked DI factories (same pattern as `app/settings/page.test.tsx`) and asserts the sub-provider link receives the configured background color

### Why was this changed?

- The `providerColor` configured in Notion was silently ignored for every sub-provider button

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

### How to Test

1. `pnpm -F blog test -- AffiliateEmb`
2. Render a post with a PRODUCT affiliate that has sub-providers — buttons show their configured colors

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #333

## Additional Context

Found in the 2026-07 repository audit (issue #333). The type-level narrowing keeps working because `providerColor` exists on the `SUB_PROVIDER` DTO variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
