### PR TITLE
🔒 Fix: #332 Remove unused amazonaws.com image allowances

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -31,7 +31,7 @@ const securityHeaders = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://platform.twitter.com https://*.hcaptcha.com https://hcaptcha.com https://fundingchoicesmessages.google.com https://*.adtrafficquality.google https://adtrafficquality.google",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' https://res.cloudinary.com https://*.amazonaws.com https://images.unsplash.com https://*.cdninstagram.com https://pbs.twimg.com https://pagead2.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google data:",
+      "img-src 'self' https://res.cloudinary.com https://images.unsplash.com https://*.cdninstagram.com https://pbs.twimg.com https://pagead2.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google data:",
       "font-src 'self'",
       "connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.googletagmanager.com https://*.hcaptcha.com https://hcaptcha.com https://api.cloudinary.com https://www.instagram.com https://pagead2.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google https://fundingchoicesmessages.google.com",
       'frame-src https://*.hcaptcha.com https://hcaptcha.com https://platform.twitter.com https://syndication.twitter.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google https://www.google.com',
@@ -71,11 +71,6 @@ const config = {
   },
   images: {
     remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: '**.amazonaws.com',
-        port: '',
-      },
       {
         protocol: 'https',
         hostname: 'images.unsplash.com',


### PR DESCRIPTION
## Summary

`images.remotePatterns` allowed `**.amazonaws.com`, so `/_next/image` would fetch, optimize, and serve images from **any** S3 bucket — an open image proxy spending our compute/bandwidth and able to serve third-party content from our domain.

Investigation showed the wildcard is unused at runtime: every browser-rendered image goes through the shared `CloudinaryImage` component, which always builds its `src` from `res.cloudinary.com` (`getOptimizedImageUrl`). Notion's S3 attachment URLs only flow server-side into `cloudinary.uploader.upload(sourceUrl)` during sync (`sync-hero-images` → `CloudinaryImageRepository`) — they never reach `next/image` or the browser. The only other `next/image` sources are a local asset and Instagram CDN (already covered by `**.cdninstagram.com`).

### What changed?

- Removed the `**.amazonaws.com` entry from `images.remotePatterns` in `apps/blog/next.config.mjs`
- Removed `https://*.amazonaws.com` from the CSP `img-src` directive (same evidence: no rendered image uses it)

### Why was this changed?

- The wildcard turned the image optimizer into an open proxy (issue #332); the pattern was dead configuration, so removal beats pinning

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security improvements

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

Config-only removal of a dead allowance; no code path changes. Existing image-rendering tests still pass.

### How to Test

1. `pnpm -F blog test` — all pass
2. Browse blog pages in a dev/preview build — hero images, media embeds, affiliate images (all Cloudinary) and Instagram timeline images render as before
3. `/_next/image?url=https://some-bucket.s3.amazonaws.com/...` now returns 400 instead of proxying

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

If any legacy content ever rendered a raw S3 URL it would now be blocked — investigation found no such rendering path (all callers pass `publicId` to `CloudinaryImage`, which overrides any raw `src`).

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #332

## Additional Context

Found in the 2026-07 repository audit (issue #332). The issue proposed pinning to specific hostnames; investigation showed no hostname is needed at all, so the entry was removed entirely (subtraction over configuration).

## Reviewer Notes

- Evidence trail: `getFirstFileUrl` (`infrastructure/notion/propertyExtractors.ts`) → `notionPageToImageSource` → `sync-hero-images` → `CloudinaryImageRepository.uploadImage` — S3 URLs are consumed server-side by Cloudinary's fetch, not by the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
