### PR TITLE
🔒 Fix: #331 Harden contact form against spam relay

### DIFF
--- a/apps/blog/app/_mail-templates/contact-notification.hbs
+++ b/apps/blog/app/_mail-templates/contact-notification.hbs
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>お問合せいただきありがとうございます、{{ name }} 様！</title>
+  <title>{{ name }} 様からお問合せが届きました。</title>
   <style type="text/css">
     /* Reset styles */
     body,
@@ -89,7 +89,7 @@
 <body style="margin: 0; padding: 0; background-color: #f4f4f4;">
   <!-- Preheader text (hidden) -->
   <div style="display: none; max-height: 0px; overflow: hidden;">
-    お問合せいただきありがとうございます、{{ name }} 様！
+    {{ name }} 様からお問合せが届きました。
   </div>
 
   <!-- Email container -->
@@ -110,22 +110,19 @@
           <!-- Main content -->
           <tr>
             <td align="left" valign="top" class="mobile-padding" style="padding: 30px 40px;">
-              <h1 style="color: #333333; font-size: 24px; margin: 0 0 20px 0;">お問合せいただきありがとうございます、{{ name }} 様！</h1>
+              <h1 style="color: #333333; font-size: 24px; margin: 0 0 20px 0;">{{ name }} 様からお問合せが届きました。</h1>
               <p style="color: #666666; font-size: 16px; margin: 0 0 20px 0;">
-                お問合せを受け付けました。内容を確認のうえ、必要に応じて返信いたします。
+                送信者メールアドレス
               </p>
-
-              <ul style="color: #666666; font-size: 12px; margin: 20px 0 20px 0;">
-                <li>
-                  返信には数日かかる場合がございますが、極力早急に返信するように致します。
-                </li>
-                <li>
-                  誠に恐れ入りますが、平日は9:00〜20:00以外でのご対応となります。
-                </li>
-                <li>
-                  案件によってはお受けするのが難しい場合もございます。
-                </li>
-              </ul>
+              <p style="color: #666666; font-size: 16px; margin: 0 0 20px 0;">
+                {{ email }}
+              </p>
+              <p style="color: #666666; font-size: 16px; margin: 0 0 20px 0;">
+                お問合せ内容
+              </p>
+              <p style="color: #666666; font-size: 16px; margin: 0 0 20px 0;">
+                {{ message }}
+              </p>
             </td>
           </tr>
 

--- a/apps/blog/app/contact/contactFormAction.test.ts
+++ b/apps/blog/app/contact/contactFormAction.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ContactRateLimitExceededError } from '../../modules/contact/use-cases';
+import { contactFormAction } from './contactFormAction';
+
+const {
+  mockCreateEnforceContactRateLimitUseCase,
+  mockCreateSendEmailUseCase,
+  mockEnforceContactRateLimitExecute,
+  mockHeaders,
+  mockSendEmailExecute,
+  mockVerify,
+} = vi.hoisted(() => ({
+  mockCreateEnforceContactRateLimitUseCase: vi.fn(),
+  mockCreateSendEmailUseCase: vi.fn(),
+  mockEnforceContactRateLimitExecute: vi.fn(),
+  mockHeaders: vi.fn(),
+  mockSendEmailExecute: vi.fn(),
+  mockVerify: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  headers: mockHeaders,
+}));
+
+vi.mock('hcaptcha', () => ({
+  verify: mockVerify,
+}));
+
+vi.mock('../../infrastructure/di', () => ({
+  createEnforceContactRateLimitUseCase:
+    mockCreateEnforceContactRateLimitUseCase,
+  createSendEmailUseCase: mockCreateSendEmailUseCase,
+}));
+
+vi.mock('../../modules/contact/adapters/shared', () => ({
+  contactLogger: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+describe('contactFormAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue('203.0.113.1, 198.51.100.1'),
+    });
+    mockVerify.mockResolvedValue({ success: true });
+    mockCreateEnforceContactRateLimitUseCase.mockReturnValue({
+      execute: mockEnforceContactRateLimitExecute,
+    });
+    mockCreateSendEmailUseCase.mockReturnValue({
+      execute: mockSendEmailExecute,
+    });
+    mockEnforceContactRateLimitExecute.mockResolvedValue(undefined);
+    mockSendEmailExecute.mockResolvedValue(undefined);
+  });
+
+  it('checks the rate limit with a hashed client IP before verifying hCaptcha', async () => {
+    const data = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      message: 'Test message',
+      token: 'valid-token',
+    };
+
+    await contactFormAction(data);
+
+    const expectedIpHash =
+      'a1ceb3dc7b127ea22d04f67b50908245930cfa9a3f91e1d38c0b266c44669ee7';
+    expect(mockEnforceContactRateLimitExecute).toHaveBeenCalledWith({
+      ipHash: expectedIpHash,
+    });
+    const [rateLimitCallOrder] =
+      mockEnforceContactRateLimitExecute.mock.invocationCallOrder;
+    const [hCaptchaCallOrder] = mockVerify.mock.invocationCallOrder;
+    expect(rateLimitCallOrder).toBeLessThan(hCaptchaCallOrder);
+  });
+
+  it('returns the user-facing message when the rate limit is exceeded', async () => {
+    mockEnforceContactRateLimitExecute.mockRejectedValue(
+      new ContactRateLimitExceededError()
+    );
+    const data = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      message: 'Test message',
+      token: 'valid-token',
+    };
+
+    await expect(contactFormAction(data)).rejects.toThrow(
+      '送信回数の上限に達しました。しばらくしてからお試しください。'
+    );
+
+    expect(mockVerify).not.toHaveBeenCalled();
+    expect(mockSendEmailExecute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/blog/app/contact/contactFormAction.ts
+++ b/apps/blog/app/contact/contactFormAction.ts
@@ -1,10 +1,32 @@
 'use server';
 
-import { verify } from 'hcaptcha';
+import { createHash } from 'node:crypto';
 
-import { createSendEmailUseCase } from '../../infrastructure/di';
+import { verify } from 'hcaptcha';
+import { headers } from 'next/headers';
+
+import {
+  createEnforceContactRateLimitUseCase,
+  createSendEmailUseCase,
+} from '../../infrastructure/di';
 import { contactLogger } from '../../modules/contact/adapters/shared';
+import { ContactRateLimitExceededError } from '../../modules/contact/use-cases';
 import { type Contact, contactSchema } from './contactSchema';
+
+const UNKNOWN_CLIENT_IP = 'unknown';
+const RATE_LIMIT_EXCEEDED_MESSAGE =
+  '送信回数の上限に達しました。しばらくしてからお試しください。';
+
+function hashClientIp(clientIp: string): string {
+  return createHash('sha256').update(clientIp).digest('hex');
+}
+
+async function getClientIpHash(): Promise<string> {
+  const forwardedFor = (await headers()).get('x-forwarded-for');
+  const clientIp = forwardedFor?.split(',')[0]?.trim() || UNKNOWN_CLIENT_IP;
+
+  return hashClientIp(clientIp);
+}
 
 export async function contactFormAction(
   data: Contact & {
@@ -19,6 +41,18 @@ export async function contactFormAction(
     throw new Error(
       JSON.stringify(validatedFields.error.flatten().fieldErrors)
     );
+  }
+
+  try {
+    const enforceContactRateLimit = createEnforceContactRateLimitUseCase();
+    await enforceContactRateLimit.execute({
+      ipHash: await getClientIpHash(),
+    });
+  } catch (error) {
+    if (error instanceof ContactRateLimitExceededError) {
+      throw new Error(RATE_LIMIT_EXCEEDED_MESSAGE);
+    }
+    throw error;
   }
 
   const verifyResponse = await verify(

--- a/apps/blog/drizzle.config.ts
+++ b/apps/blog/drizzle.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     'Session',
     'Account',
     'Verification',
+    'contact_submissions',
   ],
   strict: true,
   verbose: true,

--- a/apps/blog/infrastructure/di/contact.ts
+++ b/apps/blog/infrastructure/di/contact.ts
@@ -1,6 +1,16 @@
+import { getDrizzleClient } from '../drizzle';
 import { SendEmail } from '../../modules/contact/use-cases';
+import { EnforceContactRateLimit } from '../../modules/contact/use-cases/command/enforce-rate-limit';
+import { DrizzleContactSubmissionRepository } from '../../modules/contact/adapters/output';
 import { getAwsSesEmailSender } from '../aws-ses';
 
 export function createSendEmailUseCase(): SendEmail {
   return new SendEmail(getAwsSesEmailSender());
+}
+
+export function createEnforceContactRateLimitUseCase(): EnforceContactRateLimit {
+  const db = getDrizzleClient();
+  return new EnforceContactRateLimit(
+    new DrizzleContactSubmissionRepository(db)
+  );
 }

--- a/apps/blog/infrastructure/di/index.ts
+++ b/apps/blog/infrastructure/di/index.ts
@@ -2,7 +2,10 @@ export {
   createFetchAffiliateUseCase,
   createFetchAffiliatesByIdsUseCase,
 } from './affiliate';
-export { createSendEmailUseCase } from './contact';
+export {
+  createEnforceContactRateLimitUseCase,
+  createSendEmailUseCase,
+} from './contact';
 export { createFetchMediaUseCase } from './media';
 export {
   createFetchPostSummariesUseCase,

--- a/apps/blog/infrastructure/drizzle/migrations/0002_skinny_hitman.sql
+++ b/apps/blog/infrastructure/drizzle/migrations/0002_skinny_hitman.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "contact_submissions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"ip_hash" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "contact_submissions_ip_hash_created_at_idx" ON "contact_submissions" USING btree ("ip_hash","created_at");

--- a/apps/blog/infrastructure/drizzle/migrations/meta/0002_snapshot.json
+++ b/apps/blog/infrastructure/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,686 @@
+{
+  "id": "b007e146-f103-422b-987d-e9c1fd721371",
+  "prevId": "93ce0ea4-2d98-4dd9-8c6d-ffafecb23275",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Account": {
+      "name": "Account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Account_userId_idx": {
+          "name": "Account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Account_user_id_User_id_fk": {
+          "name": "Account_user_id_User_id_fk",
+          "tableFrom": "Account",
+          "tableTo": "User",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Author": {
+      "name": "Author",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Author_uuid_key": {
+          "name": "Author_uuid_key",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Author_pkey": {
+          "name": "Author_pkey",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_submissions_ip_hash_created_at_idx": {
+          "name": "contact_submissions_ip_hash_created_at_idx",
+          "columns": [
+            {
+              "expression": "ip_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Post": {
+      "name": "Post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "Type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ARTICLE'"
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "Status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "category": {
+          "name": "category",
+          "type": "Category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OTHER'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "releaseDate": {
+          "name": "releaseDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisionDate": {
+          "name": "revisionDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Post_uuid_key": {
+          "name": "Post_uuid_key",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Post_authorId_fkey": {
+          "name": "Post_authorId_fkey",
+          "tableFrom": "Post",
+          "tableTo": "Author",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Post_pkey": {
+          "name": "Post_pkey",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Session": {
+      "name": "Session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Session_userId_idx": {
+          "name": "Session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Session_user_id_User_id_fk": {
+          "name": "Session_user_id_User_id_fk",
+          "tableFrom": "Session",
+          "tableTo": "User",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Session_token_unique": {
+          "name": "Session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Verification": {
+      "name": "Verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Verification_identifier_idx": {
+          "name": "Verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.Category": {
+      "name": "Category",
+      "schema": "public",
+      "values": [
+        "ENGINEERING",
+        "DESIGN",
+        "DATA_SCIENCE",
+        "LIFE_STYLE",
+        "OTHER"
+      ]
+    },
+    "public.Status": {
+      "name": "Status",
+      "schema": "public",
+      "values": [
+        "IDEA",
+        "DRAFT",
+        "PREVIEW",
+        "PUBLISHED",
+        "ARCHIVED"
+      ]
+    },
+    "public.Type": {
+      "name": "Type",
+      "schema": "public",
+      "values": [
+        "ARTICLE",
+        "PAGE"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/blog/infrastructure/drizzle/migrations/meta/_journal.json
+++ b/apps/blog/infrastructure/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781907321674,
       "tag": "0001_colorful_agent_zero",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783175314812,
+      "tag": "0002_skinny_hitman",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/blog/infrastructure/drizzle/schema.ts
+++ b/apps/blog/infrastructure/drizzle/schema.ts
@@ -14,6 +14,7 @@ import {
   text,
   timestamp,
   uniqueIndex,
+  uuid,
 } from 'drizzle-orm/pg-core';
 
 export const typeEnum = pgEnum('Type', ['ARTICLE', 'PAGE']);
@@ -203,3 +204,23 @@ export const accountsRelations = relations(accounts, ({ one }) => ({
     references: [users.id],
   }),
 }));
+
+export const contactSubmissions = pgTable(
+  'contact_submissions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    ipHash: text('ip_hash').notNull(),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'date',
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('contact_submissions_ip_hash_created_at_idx').on(
+      table.ipHash,
+      table.createdAt
+    ),
+  ]
+);

--- a/apps/blog/modules/contact/adapters/output/email-services/aws-ses/awsSesEmailSender.test.ts
+++ b/apps/blog/modules/contact/adapters/output/email-services/aws-ses/awsSesEmailSender.test.ts
@@ -61,8 +61,8 @@ describe('AwsSesEmailSender', () => {
     mockSesClient = new MockSESClient();
   });
 
-  describe('send', () => {
-    it('sends email with correct parameters', async () => {
+  describe('sendToVisitor', () => {
+    it('sends email to the visitor without BCC addresses', async () => {
       mockSend.mockResolvedValue({});
       const sut = new AwsSesEmailSender(
         mockSesClient as unknown as ConstructorParameters<
@@ -72,25 +72,28 @@ describe('AwsSesEmailSender', () => {
       );
       const contact = createContact();
 
-      await sut.send(contact, 'Test Subject', '<p>Test body</p>');
+      await sut.sendToVisitor(contact, 'Test Subject', '<p>Test body</p>');
 
       expect(mockSend).toHaveBeenCalledTimes(1);
       const command = mockSend.mock.calls[0][0];
+      const expectedDestination = {
+        ToAddresses: ['john@example.com'],
+      };
       expect(command).toBeInstanceOf(MockSendEmailCommand);
+      expect(command.input.Destination).toEqual(expectedDestination);
       expect(command.input).toEqual({
         Source: senderEmail,
-        Destination: {
-          ToAddresses: ['john@example.com'],
-          BccAddresses: [senderEmail],
-        },
+        Destination: expectedDestination,
         Message: {
           Subject: { Data: 'Test Subject', Charset: 'UTF-8' },
           Body: { Html: { Data: '<p>Test body</p>', Charset: 'UTF-8' } },
         },
       });
     });
+  });
 
-    it('includes sender email in BCC', async () => {
+  describe('sendToOwner', () => {
+    it('sends email to the configured sender email without BCC addresses', async () => {
       mockSend.mockResolvedValue({});
       const sut = new AwsSesEmailSender(
         mockSesClient as unknown as ConstructorParameters<
@@ -98,12 +101,22 @@ describe('AwsSesEmailSender', () => {
         >[0],
         senderEmail
       );
-      const contact = createContact();
 
-      await sut.send(contact, 'Subject', '<p>Body</p>');
+      await sut.sendToOwner('Owner Subject', '<p>Owner body</p>');
 
+      expect(mockSend).toHaveBeenCalledTimes(1);
       const command = mockSend.mock.calls[0][0];
-      expect(command.input.Destination.BccAddresses).toContain(senderEmail);
+      const expectedDestination = {
+        ToAddresses: [senderEmail],
+      };
+      expect(command.input).toEqual({
+        Source: senderEmail,
+        Destination: expectedDestination,
+        Message: {
+          Subject: { Data: 'Owner Subject', Charset: 'UTF-8' },
+          Body: { Html: { Data: '<p>Owner body</p>', Charset: 'UTF-8' } },
+        },
+      });
     });
 
     it('throws EmailSendFailedError when SES returns an error', async () => {
@@ -118,12 +131,11 @@ describe('AwsSesEmailSender', () => {
         >[0],
         senderEmail
       );
-      const contact = createContact();
 
-      await expect(sut.send(contact, 'Subject', '<p>Body</p>')).rejects.toThrow(
+      await expect(sut.sendToOwner('Subject', '<p>Body</p>')).rejects.toThrow(
         EmailSendFailedError
       );
-      await expect(sut.send(contact, 'Subject', '<p>Body</p>')).rejects.toThrow(
+      await expect(sut.sendToOwner('Subject', '<p>Body</p>')).rejects.toThrow(
         'Failed to send email: [MessageRejected] Email address is not verified'
       );
     });
@@ -136,12 +148,11 @@ describe('AwsSesEmailSender', () => {
         >[0],
         senderEmail
       );
-      const contact = createContact();
 
-      await expect(sut.send(contact, 'Subject', '<p>Body</p>')).rejects.toThrow(
+      await expect(sut.sendToOwner('Subject', '<p>Body</p>')).rejects.toThrow(
         EmailSendFailedError
       );
-      await expect(sut.send(contact, 'Subject', '<p>Body</p>')).rejects.toThrow(
+      await expect(sut.sendToOwner('Subject', '<p>Body</p>')).rejects.toThrow(
         'Failed to send email: Unknown error occurred'
       );
     });
@@ -155,12 +166,11 @@ describe('AwsSesEmailSender', () => {
         >[0],
         senderEmail
       );
-      const contact = createContact();
 
-      await expect(sut.send(contact, 'Subject', '<p>Body</p>')).rejects.toThrow(
+      await expect(sut.sendToOwner('Subject', '<p>Body</p>')).rejects.toThrow(
         EmailSendFailedError
       );
-      await expect(sut.send(contact, 'Subject', '<p>Body</p>')).rejects.toThrow(
+      await expect(sut.sendToOwner('Subject', '<p>Body</p>')).rejects.toThrow(
         'Failed to send email: Network timeout'
       );
     });

--- a/apps/blog/modules/contact/adapters/output/email-services/aws-ses/awsSesEmailSender.ts
+++ b/apps/blog/modules/contact/adapters/output/email-services/aws-ses/awsSesEmailSender.ts
@@ -20,16 +20,27 @@ export class AwsSesEmailSender implements EmailSender {
     private readonly senderEmail: string
   ) {}
 
-  async send(
+  async sendToVisitor(
     contact: Contact,
+    subject: string,
+    htmlBody: string
+  ): Promise<void> {
+    await this.sendEmail([contact.email.getValue()], subject, htmlBody);
+  }
+
+  async sendToOwner(subject: string, htmlBody: string): Promise<void> {
+    await this.sendEmail([this.senderEmail], subject, htmlBody);
+  }
+
+  private async sendEmail(
+    toAddresses: string[],
     subject: string,
     htmlBody: string
   ): Promise<void> {
     const params: SendEmailCommandInput = {
       Source: this.senderEmail,
       Destination: {
-        ToAddresses: [contact.email.getValue()],
-        BccAddresses: [this.senderEmail],
+        ToAddresses: toAddresses,
       },
       Message: {
         Subject: { Data: subject, Charset: 'UTF-8' },

--- a/apps/blog/modules/contact/adapters/output/index.ts
+++ b/apps/blog/modules/contact/adapters/output/index.ts
@@ -1,1 +1,2 @@
 export { AwsSesEmailSender } from './email-services';
+export { DrizzleContactSubmissionRepository } from './repositories';

--- a/apps/blog/modules/contact/adapters/output/repositories/drizzle/contactSubmissionRepository.ts
+++ b/apps/blog/modules/contact/adapters/output/repositories/drizzle/contactSubmissionRepository.ts
@@ -1,0 +1,51 @@
+import { and, count, eq, gte, lt } from 'drizzle-orm';
+
+import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
+import { contactSubmissions } from '../../../../../../infrastructure/drizzle/schema';
+import type { ContactSubmissionRepository } from '../../../../domain';
+import { RepositoryError } from '../../../shared';
+
+const SUBMISSION_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+export class DrizzleContactSubmissionRepository
+  implements ContactSubmissionRepository
+{
+  constructor(private readonly db: DrizzleClient) {}
+
+  async countSince(ipHash: string, since: Date): Promise<number> {
+    try {
+      const [result] = await this.db
+        .select({ value: count() })
+        .from(contactSubmissions)
+        .where(
+          and(
+            eq(contactSubmissions.ipHash, ipHash),
+            gte(contactSubmissions.createdAt, since)
+          )
+        );
+
+      return result.value;
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to count contact submissions for IP hash: ${ipHash}`,
+        error
+      );
+    }
+  }
+
+  async record(ipHash: string): Promise<void> {
+    const retentionCutoff = new Date(Date.now() - SUBMISSION_RETENTION_MS);
+
+    try {
+      await this.db
+        .delete(contactSubmissions)
+        .where(lt(contactSubmissions.createdAt, retentionCutoff));
+      await this.db.insert(contactSubmissions).values({ ipHash });
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to record contact submission for IP hash: ${ipHash}`,
+        error
+      );
+    }
+  }
+}

--- a/apps/blog/modules/contact/adapters/output/repositories/drizzle/contactSubmissionRepository.ts
+++ b/apps/blog/modules/contact/adapters/output/repositories/drizzle/contactSubmissionRepository.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, gte, lt } from 'drizzle-orm';
+import { and, count, eq, gte, lt, sql } from 'drizzle-orm';
 
 import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
 import { contactSubmissions } from '../../../../../../infrastructure/drizzle/schema';
@@ -6,41 +6,53 @@ import type { ContactSubmissionRepository } from '../../../../domain';
 import { RepositoryError } from '../../../shared';
 
 const SUBMISSION_RETENTION_MS = 24 * 60 * 60 * 1000;
+// Namespaces the per-IP advisory lock so it cannot collide with other
+// advisory-lock users in the same database.
+const ADVISORY_LOCK_NAMESPACE = 'contact_submissions';
 
 export class DrizzleContactSubmissionRepository
   implements ContactSubmissionRepository
 {
   constructor(private readonly db: DrizzleClient) {}
 
-  async countSince(ipHash: string, since: Date): Promise<number> {
-    try {
-      const [result] = await this.db
-        .select({ value: count() })
-        .from(contactSubmissions)
-        .where(
-          and(
-            eq(contactSubmissions.ipHash, ipHash),
-            gte(contactSubmissions.createdAt, since)
-          )
-        );
-
-      return result.value;
-    } catch (error) {
-      throw new RepositoryError(
-        `Failed to count contact submissions for IP hash: ${ipHash}`,
-        error
-      );
-    }
-  }
-
-  async record(ipHash: string): Promise<void> {
+  async recordIfUnderLimit(
+    ipHash: string,
+    since: Date,
+    maxSubmissions: number
+  ): Promise<boolean> {
     const retentionCutoff = new Date(Date.now() - SUBMISSION_RETENTION_MS);
 
     try {
-      await this.db
-        .delete(contactSubmissions)
-        .where(lt(contactSubmissions.createdAt, retentionCutoff));
-      await this.db.insert(contactSubmissions).values({ ipHash });
+      return await this.db.transaction(async (tx) => {
+        // Serialize concurrent submissions per IP hash: under READ COMMITTED
+        // a plain count cannot see other in-flight inserts, so a burst of
+        // simultaneous requests would all pass the limit check together. The
+        // xact-scoped lock is released automatically on commit/rollback.
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${ADVISORY_LOCK_NAMESPACE}), hashtext(${ipHash}))`
+        );
+
+        const [result] = await tx
+          .select({ value: count() })
+          .from(contactSubmissions)
+          .where(
+            and(
+              eq(contactSubmissions.ipHash, ipHash),
+              gte(contactSubmissions.createdAt, since)
+            )
+          );
+
+        if (result.value >= maxSubmissions) {
+          return false;
+        }
+
+        await tx
+          .delete(contactSubmissions)
+          .where(lt(contactSubmissions.createdAt, retentionCutoff));
+        await tx.insert(contactSubmissions).values({ ipHash });
+
+        return true;
+      });
     } catch (error) {
       throw new RepositoryError(
         `Failed to record contact submission for IP hash: ${ipHash}`,

--- a/apps/blog/modules/contact/adapters/output/repositories/drizzle/drizzleContactSubmissionRepository.db.test.ts
+++ b/apps/blog/modules/contact/adapters/output/repositories/drizzle/drizzleContactSubmissionRepository.db.test.ts
@@ -1,0 +1,93 @@
+import { count, eq } from 'drizzle-orm';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { contactSubmissions } from '../../../../../../infrastructure/drizzle/schema';
+import {
+  getTestDb,
+  truncateAllTables,
+} from '../../../../../post/adapters/shared/testing/testDatabase';
+import { DrizzleContactSubmissionRepository } from './contactSubmissionRepository';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+const TWENTY_FIVE_HOURS_IN_MS = 25 * ONE_HOUR_IN_MS;
+const TWENTY_THREE_HOURS_IN_MS = 23 * ONE_HOUR_IN_MS;
+
+describe('DrizzleContactSubmissionRepository', () => {
+  beforeAll(async () => {
+    await truncateAllTables();
+  });
+
+  afterEach(async () => {
+    await truncateAllTables();
+  });
+
+  describe('countSince', () => {
+    it('counts only submissions for the IP hash inside the time window', async () => {
+      const db = getTestDb();
+      const sut = new DrizzleContactSubmissionRepository(db);
+      const ipHash = 'target-ip-hash';
+      const otherIpHash = 'other-ip-hash';
+      const windowStart = new Date('2026-07-04T11:00:00.000Z');
+      await db.insert(contactSubmissions).values([
+        {
+          ipHash,
+          createdAt: new Date('2026-07-04T11:30:00.000Z'),
+        },
+        {
+          ipHash,
+          createdAt: new Date('2026-07-04T10:59:59.000Z'),
+        },
+        {
+          ipHash: otherIpHash,
+          createdAt: new Date('2026-07-04T11:45:00.000Z'),
+        },
+      ]);
+
+      const result = await sut.countSince(ipHash, windowStart);
+
+      const expectedCount = 1;
+      expect(result).toBe(expectedCount);
+    });
+  });
+
+  describe('record', () => {
+    it('inserts a submission and prunes submissions older than twenty four hours', async () => {
+      const db = getTestDb();
+      const sut = new DrizzleContactSubmissionRepository(db);
+      const ipHash = 'target-ip-hash';
+      const oldIpHash = 'old-ip-hash';
+      const recentIpHash = 'recent-ip-hash';
+      await db.insert(contactSubmissions).values([
+        {
+          ipHash: oldIpHash,
+          createdAt: new Date(Date.now() - TWENTY_FIVE_HOURS_IN_MS),
+        },
+        {
+          ipHash: recentIpHash,
+          createdAt: new Date(Date.now() - TWENTY_THREE_HOURS_IN_MS),
+        },
+      ]);
+
+      await sut.record(ipHash);
+
+      const [oldSubmissionCount] = await db
+        .select({ value: count() })
+        .from(contactSubmissions)
+        .where(eq(contactSubmissions.ipHash, oldIpHash));
+      const [recentSubmissionCount] = await db
+        .select({ value: count() })
+        .from(contactSubmissions)
+        .where(eq(contactSubmissions.ipHash, recentIpHash));
+      const [newSubmissionCount] = await db
+        .select({ value: count() })
+        .from(contactSubmissions)
+        .where(eq(contactSubmissions.ipHash, ipHash));
+      const expectedOldSubmissionCount = 0;
+      const expectedRecentSubmissionCount = 1;
+      const expectedNewSubmissionCount = 1;
+      expect(oldSubmissionCount.value).toBe(expectedOldSubmissionCount);
+      expect(recentSubmissionCount.value).toBe(expectedRecentSubmissionCount);
+      expect(newSubmissionCount.value).toBe(expectedNewSubmissionCount);
+    });
+  });
+});

--- a/apps/blog/modules/contact/adapters/output/repositories/drizzle/drizzleContactSubmissionRepository.db.test.ts
+++ b/apps/blog/modules/contact/adapters/output/repositories/drizzle/drizzleContactSubmissionRepository.db.test.ts
@@ -9,8 +9,27 @@ import {
 import { DrizzleContactSubmissionRepository } from './contactSubmissionRepository';
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+const TWO_HOURS_IN_MS = 2 * ONE_HOUR_IN_MS;
 const TWENTY_FIVE_HOURS_IN_MS = 25 * ONE_HOUR_IN_MS;
 const TWENTY_THREE_HOURS_IN_MS = 23 * ONE_HOUR_IN_MS;
+const MAX_SUBMISSIONS = 5;
+
+async function countSubmissionsFor(ipHash: string): Promise<number> {
+  const [result] = await getTestDb()
+    .select({ value: count() })
+    .from(contactSubmissions)
+    .where(eq(contactSubmissions.ipHash, ipHash));
+
+  return result.value;
+}
+
+function createSubmissionRows(
+  ipHash: string,
+  amount: number,
+  createdAt: Date
+): { ipHash: string; createdAt: Date }[] {
+  return Array.from({ length: amount }, () => ({ ipHash, createdAt }));
+}
 
 describe('DrizzleContactSubmissionRepository', () => {
   beforeAll(async () => {
@@ -21,42 +40,75 @@ describe('DrizzleContactSubmissionRepository', () => {
     await truncateAllTables();
   });
 
-  describe('countSince', () => {
-    it('counts only submissions for the IP hash inside the time window', async () => {
+  describe('recordIfUnderLimit', () => {
+    it('records the submission and returns true when the IP hash is under the limit', async () => {
+      const db = getTestDb();
+      const sut = new DrizzleContactSubmissionRepository(db);
+      const ipHash = 'target-ip-hash';
+      const since = new Date(Date.now() - ONE_HOUR_IN_MS);
+      await db
+        .insert(contactSubmissions)
+        .values(createSubmissionRows(ipHash, MAX_SUBMISSIONS - 1, new Date()));
+
+      const result = await sut.recordIfUnderLimit(
+        ipHash,
+        since,
+        MAX_SUBMISSIONS
+      );
+
+      expect(result).toBe(true);
+      await expect(countSubmissionsFor(ipHash)).resolves.toBe(MAX_SUBMISSIONS);
+    });
+
+    it('returns false without recording when the IP hash reached the limit', async () => {
+      const db = getTestDb();
+      const sut = new DrizzleContactSubmissionRepository(db);
+      const ipHash = 'target-ip-hash';
+      const since = new Date(Date.now() - ONE_HOUR_IN_MS);
+      await db
+        .insert(contactSubmissions)
+        .values(createSubmissionRows(ipHash, MAX_SUBMISSIONS, new Date()));
+
+      const result = await sut.recordIfUnderLimit(
+        ipHash,
+        since,
+        MAX_SUBMISSIONS
+      );
+
+      expect(result).toBe(false);
+      await expect(countSubmissionsFor(ipHash)).resolves.toBe(MAX_SUBMISSIONS);
+    });
+
+    it('ignores submissions outside the window and from other IP hashes', async () => {
       const db = getTestDb();
       const sut = new DrizzleContactSubmissionRepository(db);
       const ipHash = 'target-ip-hash';
       const otherIpHash = 'other-ip-hash';
-      const windowStart = new Date('2026-07-04T11:00:00.000Z');
-      await db.insert(contactSubmissions).values([
-        {
-          ipHash,
-          createdAt: new Date('2026-07-04T11:30:00.000Z'),
-        },
-        {
-          ipHash,
-          createdAt: new Date('2026-07-04T10:59:59.000Z'),
-        },
-        {
-          ipHash: otherIpHash,
-          createdAt: new Date('2026-07-04T11:45:00.000Z'),
-        },
-      ]);
+      const since = new Date(Date.now() - ONE_HOUR_IN_MS);
+      const beforeWindow = new Date(Date.now() - TWO_HOURS_IN_MS);
+      await db
+        .insert(contactSubmissions)
+        .values([
+          ...createSubmissionRows(ipHash, MAX_SUBMISSIONS, beforeWindow),
+          ...createSubmissionRows(otherIpHash, MAX_SUBMISSIONS, new Date()),
+        ]);
 
-      const result = await sut.countSince(ipHash, windowStart);
+      const result = await sut.recordIfUnderLimit(
+        ipHash,
+        since,
+        MAX_SUBMISSIONS
+      );
 
-      const expectedCount = 1;
-      expect(result).toBe(expectedCount);
+      expect(result).toBe(true);
     });
-  });
 
-  describe('record', () => {
-    it('inserts a submission and prunes submissions older than twenty four hours', async () => {
+    it('prunes submissions older than twenty four hours when recording', async () => {
       const db = getTestDb();
       const sut = new DrizzleContactSubmissionRepository(db);
       const ipHash = 'target-ip-hash';
       const oldIpHash = 'old-ip-hash';
       const recentIpHash = 'recent-ip-hash';
+      const since = new Date(Date.now() - ONE_HOUR_IN_MS);
       await db.insert(contactSubmissions).values([
         {
           ipHash: oldIpHash,
@@ -68,26 +120,42 @@ describe('DrizzleContactSubmissionRepository', () => {
         },
       ]);
 
-      await sut.record(ipHash);
+      await sut.recordIfUnderLimit(ipHash, since, MAX_SUBMISSIONS);
 
-      const [oldSubmissionCount] = await db
-        .select({ value: count() })
-        .from(contactSubmissions)
-        .where(eq(contactSubmissions.ipHash, oldIpHash));
-      const [recentSubmissionCount] = await db
-        .select({ value: count() })
-        .from(contactSubmissions)
-        .where(eq(contactSubmissions.ipHash, recentIpHash));
-      const [newSubmissionCount] = await db
-        .select({ value: count() })
-        .from(contactSubmissions)
-        .where(eq(contactSubmissions.ipHash, ipHash));
       const expectedOldSubmissionCount = 0;
       const expectedRecentSubmissionCount = 1;
       const expectedNewSubmissionCount = 1;
-      expect(oldSubmissionCount.value).toBe(expectedOldSubmissionCount);
-      expect(recentSubmissionCount.value).toBe(expectedRecentSubmissionCount);
-      expect(newSubmissionCount.value).toBe(expectedNewSubmissionCount);
+      await expect(countSubmissionsFor(oldIpHash)).resolves.toBe(
+        expectedOldSubmissionCount
+      );
+      await expect(countSubmissionsFor(recentIpHash)).resolves.toBe(
+        expectedRecentSubmissionCount
+      );
+      await expect(countSubmissionsFor(ipHash)).resolves.toBe(
+        expectedNewSubmissionCount
+      );
+    });
+
+    it('allows only the remaining quota when submissions arrive concurrently', async () => {
+      const db = getTestDb();
+      const sut = new DrizzleContactSubmissionRepository(db);
+      const ipHash = 'target-ip-hash';
+      const since = new Date(Date.now() - ONE_HOUR_IN_MS);
+      const concurrentAttempts = MAX_SUBMISSIONS;
+      await db
+        .insert(contactSubmissions)
+        .values(createSubmissionRows(ipHash, MAX_SUBMISSIONS - 1, new Date()));
+
+      const results = await Promise.all(
+        Array.from({ length: concurrentAttempts }, () =>
+          sut.recordIfUnderLimit(ipHash, since, MAX_SUBMISSIONS)
+        )
+      );
+
+      const recordedCount = results.filter((recorded) => recorded).length;
+      const expectedRecordedCount = 1;
+      expect(recordedCount).toBe(expectedRecordedCount);
+      await expect(countSubmissionsFor(ipHash)).resolves.toBe(MAX_SUBMISSIONS);
     });
   });
 });

--- a/apps/blog/modules/contact/adapters/output/repositories/drizzle/index.ts
+++ b/apps/blog/modules/contact/adapters/output/repositories/drizzle/index.ts
@@ -1,0 +1,1 @@
+export { DrizzleContactSubmissionRepository } from './contactSubmissionRepository';

--- a/apps/blog/modules/contact/adapters/output/repositories/index.ts
+++ b/apps/blog/modules/contact/adapters/output/repositories/index.ts
@@ -1,0 +1,1 @@
+export { DrizzleContactSubmissionRepository } from './drizzle';

--- a/apps/blog/modules/contact/adapters/shared/errors.ts
+++ b/apps/blog/modules/contact/adapters/shared/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Base error class for repository operations.
+ * Wraps underlying errors while preserving the original cause.
+ */
+export class RepositoryError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/apps/blog/modules/contact/adapters/shared/index.ts
+++ b/apps/blog/modules/contact/adapters/shared/index.ts
@@ -1,2 +1,3 @@
+export { RepositoryError } from './errors';
 export { contactLogger } from './logger';
 export { generateHtmlTemplate } from './templateGenerator';

--- a/apps/blog/modules/contact/domain/index.ts
+++ b/apps/blog/modules/contact/domain/index.ts
@@ -1,5 +1,6 @@
 export { Contact } from './entities/contact';
 export * from './errors/errors';
+export type { ContactSubmissionRepository } from './repositories/contactSubmissionRepository';
 export type { EmailSender } from './repositories/emailSender';
 export type * from './types';
 export { Email, Message, Name } from './value-objects';

--- a/apps/blog/modules/contact/domain/repositories/contactSubmissionRepository.ts
+++ b/apps/blog/modules/contact/domain/repositories/contactSubmissionRepository.ts
@@ -1,0 +1,18 @@
+/**
+ * ContactSubmissionRepository Interface
+ *
+ * Defines the contract for contact form submission tracking.
+ * This interface is part of the domain layer and should be
+ * implemented by adapters in the infrastructure layer.
+ */
+export interface ContactSubmissionRepository {
+  /**
+   * Count submissions for an IP hash since the given timestamp.
+   */
+  countSince(ipHash: string, since: Date): Promise<number>;
+
+  /**
+   * Record a contact form submission for an IP hash.
+   */
+  record(ipHash: string): Promise<void>;
+}

--- a/apps/blog/modules/contact/domain/repositories/contactSubmissionRepository.ts
+++ b/apps/blog/modules/contact/domain/repositories/contactSubmissionRepository.ts
@@ -7,12 +7,15 @@
  */
 export interface ContactSubmissionRepository {
   /**
-   * Count submissions for an IP hash since the given timestamp.
+   * Atomically record a submission for an IP hash unless it already has
+   * `maxSubmissions` submissions since the given timestamp. Returns `true`
+   * when the submission was recorded, `false` when the limit was reached
+   * (in which case nothing is recorded). Implementations must guard the
+   * check-and-insert against concurrent submissions from the same IP hash.
    */
-  countSince(ipHash: string, since: Date): Promise<number>;
-
-  /**
-   * Record a contact form submission for an IP hash.
-   */
-  record(ipHash: string): Promise<void>;
+  recordIfUnderLimit(
+    ipHash: string,
+    since: Date,
+    maxSubmissions: number
+  ): Promise<boolean>;
 }

--- a/apps/blog/modules/contact/domain/repositories/emailSender.ts
+++ b/apps/blog/modules/contact/domain/repositories/emailSender.ts
@@ -7,5 +7,10 @@ import type { Contact } from '../entities/contact';
  * This is a port that will be implemented by adapters (e.g., AWS SES).
  */
 export interface EmailSender {
-  send(contact: Contact, subject: string, htmlBody: string): Promise<void>;
+  sendToVisitor(
+    contact: Contact,
+    subject: string,
+    htmlBody: string
+  ): Promise<void>;
+  sendToOwner(subject: string, htmlBody: string): Promise<void>;
 }

--- a/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/index.ts
+++ b/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/index.ts
@@ -1,0 +1,4 @@
+export {
+  EnforceContactRateLimit,
+  type EnforceContactRateLimitInput,
+} from './useCase';

--- a/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.test.ts
+++ b/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.test.ts
@@ -10,8 +10,7 @@ const RATE_LIMIT_MAX_SUBMISSIONS = 5;
 
 function createMockContactSubmissionRepository(): ContactSubmissionRepository {
   return {
-    countSince: vi.fn().mockResolvedValue(0),
-    record: vi.fn().mockResolvedValue(undefined),
+    recordIfUnderLimit: vi.fn().mockResolvedValue(true),
   };
 }
 
@@ -26,40 +25,39 @@ describe('EnforceContactRateLimit', () => {
   });
 
   describe('execute', () => {
-    it('records the submission when the IP hash is under the limit', async () => {
+    it('records the submission atomically with the hourly window and limit', async () => {
       const repository = createMockContactSubmissionRepository();
-      const underLimitSubmissionCount = RATE_LIMIT_MAX_SUBMISSIONS - 1;
-      vi.mocked(repository.countSince).mockResolvedValue(
-        underLimitSubmissionCount
-      );
       const sut = new EnforceContactRateLimit(repository);
       const ipHash = 'hashed-client-ip';
 
       await sut.execute({ ipHash });
 
       const expectedSince = new Date(FIXED_NOW.getTime() - ONE_HOUR_IN_MS);
-      expect(repository.countSince).toHaveBeenCalledWith(ipHash, expectedSince);
-      expect(repository.record).toHaveBeenCalledWith(ipHash);
+      expect(repository.recordIfUnderLimit).toHaveBeenCalledWith(
+        ipHash,
+        expectedSince,
+        RATE_LIMIT_MAX_SUBMISSIONS
+      );
     });
 
-    it.each`
-      submissionCount
-      ${RATE_LIMIT_MAX_SUBMISSIONS}
-      ${RATE_LIMIT_MAX_SUBMISSIONS + 1}
-    `(
-      'throws without recording when submission count is $submissionCount',
-      async ({ submissionCount }: { submissionCount: number }) => {
-        const repository = createMockContactSubmissionRepository();
-        vi.mocked(repository.countSince).mockResolvedValue(submissionCount);
-        const sut = new EnforceContactRateLimit(repository);
-        const ipHash = 'hashed-client-ip';
+    it('resolves when the repository records the submission', async () => {
+      const repository = createMockContactSubmissionRepository();
+      vi.mocked(repository.recordIfUnderLimit).mockResolvedValue(true);
+      const sut = new EnforceContactRateLimit(repository);
 
-        await expect(sut.execute({ ipHash })).rejects.toThrow(
-          ContactRateLimitExceededError
-        );
+      await expect(
+        sut.execute({ ipHash: 'hashed-client-ip' })
+      ).resolves.toBeUndefined();
+    });
 
-        expect(repository.record).not.toHaveBeenCalled();
-      }
-    );
+    it('throws when the repository reports the limit is reached', async () => {
+      const repository = createMockContactSubmissionRepository();
+      vi.mocked(repository.recordIfUnderLimit).mockResolvedValue(false);
+      const sut = new EnforceContactRateLimit(repository);
+
+      await expect(sut.execute({ ipHash: 'hashed-client-ip' })).rejects.toThrow(
+        ContactRateLimitExceededError
+      );
+    });
   });
 });

--- a/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.test.ts
+++ b/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ContactSubmissionRepository } from '../../../domain';
+import { ContactRateLimitExceededError } from '../../shared';
+import { EnforceContactRateLimit } from './useCase';
+
+const FIXED_NOW = new Date('2026-07-04T12:00:00.000Z');
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+const RATE_LIMIT_MAX_SUBMISSIONS = 5;
+
+function createMockContactSubmissionRepository(): ContactSubmissionRepository {
+  return {
+    countSince: vi.fn().mockResolvedValue(0),
+    record: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('EnforceContactRateLimit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('execute', () => {
+    it('records the submission when the IP hash is under the limit', async () => {
+      const repository = createMockContactSubmissionRepository();
+      const underLimitSubmissionCount = RATE_LIMIT_MAX_SUBMISSIONS - 1;
+      vi.mocked(repository.countSince).mockResolvedValue(
+        underLimitSubmissionCount
+      );
+      const sut = new EnforceContactRateLimit(repository);
+      const ipHash = 'hashed-client-ip';
+
+      await sut.execute({ ipHash });
+
+      const expectedSince = new Date(FIXED_NOW.getTime() - ONE_HOUR_IN_MS);
+      expect(repository.countSince).toHaveBeenCalledWith(ipHash, expectedSince);
+      expect(repository.record).toHaveBeenCalledWith(ipHash);
+    });
+
+    it.each`
+      submissionCount
+      ${RATE_LIMIT_MAX_SUBMISSIONS}
+      ${RATE_LIMIT_MAX_SUBMISSIONS + 1}
+    `(
+      'throws without recording when submission count is $submissionCount',
+      async ({ submissionCount }: { submissionCount: number }) => {
+        const repository = createMockContactSubmissionRepository();
+        vi.mocked(repository.countSince).mockResolvedValue(submissionCount);
+        const sut = new EnforceContactRateLimit(repository);
+        const ipHash = 'hashed-client-ip';
+
+        await expect(sut.execute({ ipHash })).rejects.toThrow(
+          ContactRateLimitExceededError
+        );
+
+        expect(repository.record).not.toHaveBeenCalled();
+      }
+    );
+  });
+});

--- a/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.ts
+++ b/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.ts
@@ -1,0 +1,29 @@
+import type { ContactSubmissionRepository } from '../../../domain';
+import { ContactRateLimitExceededError } from '../../shared';
+
+export interface EnforceContactRateLimitInput {
+  ipHash: string;
+}
+
+const RATE_LIMIT_MAX_SUBMISSIONS = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+export class EnforceContactRateLimit {
+  constructor(
+    private readonly contactSubmissionRepository: ContactSubmissionRepository
+  ) {}
+
+  async execute(input: EnforceContactRateLimitInput): Promise<void> {
+    const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
+    const submissionCount = await this.contactSubmissionRepository.countSince(
+      input.ipHash,
+      since
+    );
+
+    if (submissionCount >= RATE_LIMIT_MAX_SUBMISSIONS) {
+      throw new ContactRateLimitExceededError();
+    }
+
+    await this.contactSubmissionRepository.record(input.ipHash);
+  }
+}

--- a/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.ts
+++ b/apps/blog/modules/contact/use-cases/command/enforce-rate-limit/useCase.ts
@@ -15,15 +15,16 @@ export class EnforceContactRateLimit {
 
   async execute(input: EnforceContactRateLimitInput): Promise<void> {
     const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
-    const submissionCount = await this.contactSubmissionRepository.countSince(
+    // Check-and-record must be one atomic repository operation; a separate
+    // count + insert lets concurrent submissions all pass the check together.
+    const recorded = await this.contactSubmissionRepository.recordIfUnderLimit(
       input.ipHash,
-      since
+      since,
+      RATE_LIMIT_MAX_SUBMISSIONS
     );
 
-    if (submissionCount >= RATE_LIMIT_MAX_SUBMISSIONS) {
+    if (!recorded) {
       throw new ContactRateLimitExceededError();
     }
-
-    await this.contactSubmissionRepository.record(input.ipHash);
   }
 }

--- a/apps/blog/modules/contact/use-cases/command/index.ts
+++ b/apps/blog/modules/contact/use-cases/command/index.ts
@@ -1,1 +1,5 @@
+export {
+  EnforceContactRateLimit,
+  type EnforceContactRateLimitInput,
+} from './enforce-rate-limit';
 export { type EmailSender, SendEmail, type SendEmailInput } from './send-email';

--- a/apps/blog/modules/contact/use-cases/command/send-email/useCase.test.ts
+++ b/apps/blog/modules/contact/use-cases/command/send-email/useCase.test.ts
@@ -1,12 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Contact } from '../../../domain';
 import type { EmailSender } from './emailSender';
 import { SendEmail, type SendEmailInput } from './useCase';
-
-vi.mock('../../../adapters/shared', () => ({
-  generateHtmlTemplate: vi.fn().mockReturnValue('<html>Test Email</html>'),
-}));
 
 vi.mock('date-fns', () => ({
   format: vi.fn().mockReturnValue('2024'),
@@ -14,7 +9,8 @@ vi.mock('date-fns', () => ({
 
 function createMockEmailSender(): EmailSender {
   return {
-    send: vi.fn().mockResolvedValue(undefined),
+    sendToOwner: vi.fn().mockResolvedValue(undefined),
+    sendToVisitor: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -39,19 +35,44 @@ describe('SendEmail Use Case', () => {
 
       await sut.execute(input);
 
-      expect(mockEmailSender.send).toHaveBeenCalledTimes(1);
+      expect(mockEmailSender.sendToOwner).toHaveBeenCalledTimes(1);
+      expect(mockEmailSender.sendToVisitor).toHaveBeenCalledTimes(1);
 
-      const [contact, subject, htmlBody] = vi.mocked(mockEmailSender.send).mock
-        .calls[0] as [Contact, string, string];
-      const expectedSubject =
+      const expectedOwnerSubject = 'John Doe 様からお問合せが届きました。';
+      const expectedVisitorSubject =
         'John Doe 様。お問合せいただきありがとうございます。';
-      const expectedHtmlBody = '<html>Test Email</html>';
 
-      expect(contact.name.getValue()).toBe('John Doe');
-      expect(contact.email.getValue()).toBe('john@example.com');
-      expect(contact.message.getValue()).toBe('Test message');
-      expect(subject).toBe(expectedSubject);
-      expect(htmlBody).toBe(expectedHtmlBody);
+      expect(mockEmailSender.sendToOwner).toHaveBeenCalledWith(
+        expectedOwnerSubject,
+        expect.stringContaining('Test message')
+      );
+      expect(mockEmailSender.sendToOwner).toHaveBeenCalledWith(
+        expectedOwnerSubject,
+        expect.stringContaining('john@example.com')
+      );
+      expect(mockEmailSender.sendToVisitor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.objectContaining({ value: 'John Doe' }),
+          email: expect.objectContaining({ value: 'john@example.com' }),
+          message: expect.objectContaining({ value: 'Test message' }),
+        }),
+        expectedVisitorSubject,
+        expect.not.stringContaining('Test message')
+      );
+    });
+
+    it('sends owner notification before visitor confirmation', async () => {
+      const mockEmailSender = createMockEmailSender();
+      const sut = new SendEmail(mockEmailSender);
+      const input = createValidInput();
+
+      await sut.execute(input);
+
+      const [ownerCallOrder] = vi.mocked(mockEmailSender.sendToOwner).mock
+        .invocationCallOrder;
+      const [visitorCallOrder] = vi.mocked(mockEmailSender.sendToVisitor).mock
+        .invocationCallOrder;
+      expect(ownerCallOrder).toBeLessThan(visitorCallOrder);
     });
 
     it('throws error when name is empty', async () => {
@@ -66,7 +87,8 @@ describe('SendEmail Use Case', () => {
       await expect(sut.execute(invalidInput)).rejects.toThrow(
         'Name cannot be empty'
       );
-      expect(mockEmailSender.send).not.toHaveBeenCalled();
+      expect(mockEmailSender.sendToOwner).not.toHaveBeenCalled();
+      expect(mockEmailSender.sendToVisitor).not.toHaveBeenCalled();
     });
 
     it('throws error when email format is invalid', async () => {
@@ -81,12 +103,13 @@ describe('SendEmail Use Case', () => {
       await expect(sut.execute(invalidInput)).rejects.toThrow(
         'Invalid email format'
       );
-      expect(mockEmailSender.send).not.toHaveBeenCalled();
+      expect(mockEmailSender.sendToOwner).not.toHaveBeenCalled();
+      expect(mockEmailSender.sendToVisitor).not.toHaveBeenCalled();
     });
 
     it('propagates error when email sending fails', async () => {
       const mockEmailSender = createMockEmailSender();
-      vi.mocked(mockEmailSender.send).mockRejectedValue(
+      vi.mocked(mockEmailSender.sendToOwner).mockRejectedValue(
         new Error('Email send failed')
       );
       const sut = new SendEmail(mockEmailSender);

--- a/apps/blog/modules/contact/use-cases/command/send-email/useCase.ts
+++ b/apps/blog/modules/contact/use-cases/command/send-email/useCase.ts
@@ -22,18 +22,39 @@ export class SendEmail {
   async execute(input: SendEmailInput): Promise<void> {
     const contact = Contact.create(input);
 
-    const emailBody = generateHtmlTemplate(
-      path.join(process.cwd(), 'app', '_mail-templates', 'contact.hbs'),
+    const sharedTemplateValues = {
+      name: contact.name.getValue(),
+      year: format(new Date(), 'yyyy'),
+      companyLogoUrl: process.env.COMPANY_LOGO_URL ?? '',
+    };
+
+    const ownerEmailBody = generateHtmlTemplate(
+      path.join(
+        process.cwd(),
+        'app',
+        '_mail-templates',
+        'contact-notification.hbs'
+      ),
       {
-        name: contact.name.getValue(),
+        ...sharedTemplateValues,
+        email: contact.email.getValue(),
         message: contact.message.getValue(),
-        year: format(new Date(), 'yyyy'),
-        companyLogoUrl: process.env.COMPANY_LOGO_URL ?? '',
       }
     );
 
-    const subject = `${contact.name.getValue()} 様。お問合せいただきありがとうございます。`;
+    const visitorEmailBody = generateHtmlTemplate(
+      path.join(process.cwd(), 'app', '_mail-templates', 'contact.hbs'),
+      sharedTemplateValues
+    );
 
-    await this.emailSender.send(contact, subject, emailBody);
+    const visitorSubject = `${contact.name.getValue()} 様。お問合せいただきありがとうございます。`;
+    const ownerSubject = `${contact.name.getValue()} 様からお問合せが届きました。`;
+
+    await this.emailSender.sendToOwner(ownerSubject, ownerEmailBody);
+    await this.emailSender.sendToVisitor(
+      contact,
+      visitorSubject,
+      visitorEmailBody
+    );
   }
 }

--- a/apps/blog/modules/contact/use-cases/index.ts
+++ b/apps/blog/modules/contact/use-cases/index.ts
@@ -1,1 +1,8 @@
-export { type EmailSender, SendEmail, type SendEmailInput } from './command';
+export {
+  type EmailSender,
+  EnforceContactRateLimit,
+  type EnforceContactRateLimitInput,
+  SendEmail,
+  type SendEmailInput,
+} from './command';
+export { ContactRateLimitExceededError, UseCaseError } from './shared';

--- a/apps/blog/modules/contact/use-cases/shared/errors.ts
+++ b/apps/blog/modules/contact/use-cases/shared/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Base error for use-case layer.
+ */
+export class UseCaseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Thrown when contact form submission rate limit is exceeded.
+ */
+export class ContactRateLimitExceededError extends UseCaseError {
+  constructor() {
+    super('Contact form submission rate limit exceeded');
+  }
+}

--- a/apps/blog/modules/contact/use-cases/shared/index.ts
+++ b/apps/blog/modules/contact/use-cases/shared/index.ts
@@ -1,0 +1,1 @@
+export { ContactRateLimitExceededError, UseCaseError } from './errors';

--- a/apps/blog/modules/post/adapters/shared/testing/testDatabase.ts
+++ b/apps/blog/modules/post/adapters/shared/testing/testDatabase.ts
@@ -34,6 +34,6 @@ export async function closeTestDb(): Promise<void> {
 
 export async function truncateAllTables(): Promise<void> {
   await getTestDb().execute(
-    sql`TRUNCATE TABLE "Post", "Author", "Session", "Account", "Verification", "User" RESTART IDENTITY CASCADE`
+    sql`TRUNCATE TABLE "Post", "Author", "Session", "Account", "Verification", "User", "contact_submissions" RESTART IDENTITY CASCADE`
   );
 }


### PR DESCRIPTION
## Summary

The contact form sent a confirmation email from our SES-verified sender to whatever address the visitor typed, with the visitor's message embedded — an attacker with solved captchas could deliver arbitrary content from our domain to arbitrary recipients (SES reputation/cost risk). There was no rate limiting.

### What changed?

**1. Email split — visitor-controlled content no longer relayed**
- Owner notification (new `contact-notification.hbs`, To: sender address): name, visitor email, full message — sent FIRST so inquiries are never lost
- Visitor confirmation (`contact.hbs`, To: visitor, Bcc removed): fixed thank-you copy + name only; the message body no longer appears
- `EmailSender` port split into `sendToOwner` / `sendToVisitor`; `AwsSesEmailSender` updated accordingly

**2. Per-IP rate limiting (DB-backed, Clean Architecture)**
- New `contact_submissions` table (uuid PK, `ip_hash`, `created_at`, composite index) — migration `0002_skinny_hitman.sql`
- `ContactSubmissionRepository` port (domain) + `DrizzleContactSubmissionRepository` adapter (constructor-injected client; `record()` prunes rows older than 24h)
- `EnforceContactRateLimit` use case: ≥5 submissions per rolling hour per hashed IP → `ContactRateLimitExceededError`
- `contactFormAction` enforces the limit before the hCaptcha verify; client IP is sha256-hashed from `x-forwarded-for` — the raw IP is never stored or logged (PII rule)

### Why was this changed?

- Closes the spam-relay vector (issue #331): the visitor-addressed email now contains no attacker-controlled body, and volume abuse is bounded by the rate limit

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security improvements
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated

New/updated: `send-email/useCase.test.ts` (owner-first order, visitor html lacks message, owner html contains it), `enforce-rate-limit/useCase.test.ts`, `awsSesEmailSender.test.ts` (both methods; visitor send has no Bcc), `contactFormAction.test.ts` (rate-limit rejection), `drizzleContactSubmissionRepository.db.test.ts` (windowed count, record+prune).

### How to Test

1. `pnpm -F blog test` (953 pass) and `pnpm -F blog test:db` (11 files / 43 pass, Testcontainers)
2. `pnpm -F blog db:verify` — migration round-trip clean
3. Submit the contact form: owner receives the inquiry; visitor receives a confirmation without the message body; 6th submission within an hour from one IP is rejected with a Japanese error message

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] Database migration included
- [x] Drizzle schema updated

**Migration details:**

`0002_skinny_hitman.sql` — creates `contact_submissions` (uuid PK default `gen_random_uuid()`, `ip_hash` text, `created_at` timestamptz default now) with a btree index on `(ip_hash, created_at)`. Additive only. Run against production only after merge, with a backup first (per AGENTS.md).

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

Product behavior change (intentional): the visitor confirmation no longer echoes the submitted message, and the owner now receives a dedicated notification email instead of a Bcc copy.

## Deployment Notes

- [x] Requires database migration

Apply the migration after merge (backup first). No env changes.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #331
Relates to #141

## Additional Context

Found in the 2026-07 repository audit (issue #331). Name (≤100) and message (≤1000) length caps were already enforced at both zod and domain layers — no changes needed there.

## Reviewer Notes

- Rate limit constants: 5 submissions / rolling 1h window (`enforce-rate-limit/useCase.ts`) — adjust there if product needs differ
- `testDatabase.ts` (truncateAllTables) was extended with the new table to keep db-test isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
