### PR TITLE
✅ Test: #345 Bootstrap portfolio test infrastructure

### DIFF
--- a/apps/portfolio/i18n/dictionaries.test.ts
+++ b/apps/portfolio/i18n/dictionaries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import en from './locales/en/translation.json';
+import ja from './locales/ja/translation.json';
+import { getDictionary } from './dictionaries';
+
+// The `server-only` package throws when imported outside a Next.js server
+// build; dictionaries.ts imports it as a guard. Stub it so the module can be
+// loaded directly under Vitest.
+vi.mock('server-only', () => ({}));
+
+function collectKeyPaths(value: unknown, prefix = ''): string[] {
+  if (typeof value !== 'object' || value === null) {
+    return [prefix];
+  }
+
+  return Object.entries(value).flatMap(([key, nested]) =>
+    collectKeyPaths(nested, prefix ? `${prefix}.${key}` : key)
+  );
+}
+
+describe('getDictionary', () => {
+  it('loads the Japanese dictionary', async () => {
+    const dictionary = await getDictionary('ja');
+
+    expect(dictionary.hero.corporateName).toBe(ja.hero.corporateName);
+  });
+
+  it('loads the English dictionary', async () => {
+    const dictionary = await getDictionary('en');
+
+    expect(dictionary.hero.corporateName).toBe(en.hero.corporateName);
+  });
+});
+
+describe('locale translation files', () => {
+  it('have identical key structure between ja and en', () => {
+    const jaKeyPaths = collectKeyPaths(ja).sort();
+    const enKeyPaths = collectKeyPaths(en).sort();
+
+    expect(jaKeyPaths).toEqual(enKeyPaths);
+  });
+});

--- a/apps/portfolio/i18n/settings.test.ts
+++ b/apps/portfolio/i18n/settings.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { fallbackLanguage, resolveLanguage } from './settings';
+
+describe('resolveLanguage', () => {
+  it.each(['ja', 'en'] as const)(
+    'returns the language unchanged when given the supported language "%s"',
+    (language) => {
+      const result = resolveLanguage(language);
+
+      expect(result).toBe(language);
+    }
+  );
+
+  it.each(['fr', 'zh', ''])(
+    'falls back to the fallback language when given the unsupported language "%s"',
+    (language) => {
+      const result = resolveLanguage(language);
+
+      expect(result).toBe(fallbackLanguage);
+    }
+  );
+});

--- a/apps/portfolio/middleware.test.ts
+++ b/apps/portfolio/middleware.test.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+
+import { cookieName } from './i18n/settings';
+import { middleware } from './middleware';
+
+const prefetchHeaderVariants: Record<string, string>[] = [
+  { 'Next-Router-Prefetch': '1' },
+  { Purpose: 'prefetch' },
+];
+
+describe('middleware', () => {
+  describe('when the request path has no locale prefix', () => {
+    it('redirects using the locale from the NEXT_LOCALE cookie', () => {
+      const request = new NextRequest(new URL('http://localhost/about'), {
+        headers: { cookie: `${cookieName}=en` },
+      });
+
+      const response = middleware(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(
+        'http://localhost/en/about'
+      );
+    });
+
+    it('redirects using the highest-quality supported language from Accept-Language when no cookie is present', () => {
+      const request = new NextRequest(new URL('http://localhost/about'), {
+        headers: { 'Accept-Language': 'fr;q=0.9,en;q=0.5' },
+      });
+
+      const response = middleware(request);
+
+      expect(response.headers.get('location')).toBe(
+        'http://localhost/en/about'
+      );
+    });
+
+    it('redirects using the fallback language when neither a cookie nor a matching Accept-Language is present', () => {
+      const request = new NextRequest(new URL('http://localhost/about'));
+
+      const response = middleware(request);
+
+      expect(response.headers.get('location')).toBe(
+        'http://localhost/ja/about'
+      );
+    });
+
+    it('prefers the cookie locale over the Accept-Language header', () => {
+      const request = new NextRequest(new URL('http://localhost/about'), {
+        headers: {
+          cookie: `${cookieName}=ja`,
+          'Accept-Language': 'en;q=0.9',
+        },
+      });
+
+      const response = middleware(request);
+
+      expect(response.headers.get('location')).toBe(
+        'http://localhost/ja/about'
+      );
+    });
+  });
+
+  describe('when the request path already has a locale prefix', () => {
+    it('returns NextResponse.next() without redirecting', () => {
+      const request = new NextRequest(new URL('http://localhost/en/about'));
+
+      const response = middleware(request);
+
+      expect(response.headers.get('location')).toBeNull();
+    });
+
+    it('writes the locale cookie for a normal navigation request', () => {
+      const request = new NextRequest(new URL('http://localhost/en/about'));
+
+      const response = middleware(request);
+
+      expect(response.cookies.get(cookieName)?.value).toBe('en');
+    });
+
+    it.each(
+      prefetchHeaderVariants
+    )('does not write the locale cookie for a prefetch request with headers %o', (headers) => {
+      const request = new NextRequest(new URL('http://localhost/en/about'), {
+        headers,
+      });
+
+      const response = middleware(request);
+
+      expect(response.cookies.get(cookieName)).toBeUndefined();
+    });
+  });
+
+  describe('when the path contains "icon" or "chrome"', () => {
+    it.each([
+      '/icon.png',
+      '/apple-touch-icon.png',
+      '/chrome-devtools.json',
+    ])('returns NextResponse.next() without redirecting for %s', (pathname) => {
+      const request = new NextRequest(new URL(`http://localhost${pathname}`));
+
+      const response = middleware(request);
+
+      expect(response.headers.get('location')).toBeNull();
+    });
+  });
+});

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -12,13 +12,16 @@
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "storybook": "storybook dev -p 6008",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@next/third-parties": "^16.2.1",
     "next": "^16.2.1",
     "react": "^19.0.1",
     "react-dom": "^19.0.1",
+    "server-only": "^0.0.1",
     "ui": "workspace:*"
   },
   "devDependencies": {
@@ -29,18 +32,25 @@
     "@storybook/nextjs": "^10.1.11",
     "@svgr/webpack": "^8.1.0",
     "@tailwindcss/postcss": "^4.0.9",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^17.0.12",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react-swc": "^3.9.0",
     "autoprefixer": "^10.4.14",
     "babel-plugin-react-compiler": "^1.0.0",
     "biome-config": "workspace:*",
+    "jsdom": "^26.0.0",
     "postcss": "^8.5.3",
     "postcss-preset-env": "^9.1.1",
     "storybook": "^10.1.11",
     "tailwind-config": "workspace:*",
     "tailwindcss": "^4.0.9",
+    "test-utils": "workspace:*",
     "tsconfig": "workspace:*",
+    "vitest": "^3.1.1",
     "wrangler": "^4.76.0"
   }
 }

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -50,6 +50,7 @@
     "tailwindcss": "^4.0.9",
     "test-utils": "workspace:*",
     "tsconfig": "workspace:*",
+    "vite": "^6.2.6",
     "vitest": "^3.1.1",
     "wrangler": "^4.76.0"
   }

--- a/apps/portfolio/tsconfig.json
+++ b/apps/portfolio/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/nextjs.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "types": ["@testing-library/jest-dom"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/portfolio/vitest.config.mts
+++ b/apps/portfolio/vitest.config.mts
@@ -1,0 +1,30 @@
+import react from '@vitejs/plugin-react-swc';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const uiAlias = resolve(__dirname, '../../packages/ui/index.ts');
+const jsdomSetupPath = resolve(
+  __dirname,
+  '../../packages/test-utils/setupTests.ts'
+);
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias: { ui: uiAlias } },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: [jsdomSetupPath],
+    css: false,
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: ['node_modules/**', 'dist/**'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+    ...(process.env.CI && { minThreads: 4, maxThreads: 4 }),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       react-dom:
         specifier: ^19.0.1
         version: 19.2.1(react@19.2.1)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       ui:
         specifier: workspace:*
         version: link:../../packages/ui
@@ -254,6 +257,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.9
         version: 4.0.9
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: ^17.0.12
         version: 17.0.45
@@ -263,6 +275,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.4
         version: 19.0.4(@types/react@19.0.10)
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.9.0
+        version: 3.9.0(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.19(postcss@8.5.3)
@@ -272,6 +287,9 @@ importers:
       biome-config:
         specifier: workspace:*
         version: link:../../packages/biome-config
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.0.0
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -287,9 +305,15 @@ importers:
       tailwindcss:
         specifier: ^4.0.9
         version: 4.0.9
+      test-utils:
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      vitest:
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@17.0.45)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.76.0
         version: 4.76.0
@@ -7636,6 +7660,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
@@ -12795,6 +12822,13 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitejs/plugin-react-swc@3.9.0(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
+    dependencies:
+      '@swc/core': 1.13.5
+      vite: 7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
   '@vitest/expect@3.1.1':
     dependencies:
       '@vitest/spy': 3.1.1
@@ -12818,7 +12852,6 @@ snapshots:
     optionalDependencies:
       msw: 2.12.7(@types/node@17.0.45)(typescript@5.5.4)
       vite: 6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
-    optional: true
 
   '@vitest/mocker@3.1.1(msw@2.12.7(@types/node@18.19.130)(typescript@5.5.4))(vite@6.2.6(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
@@ -17157,6 +17190,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  server-only@0.0.1: {}
+
   set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
@@ -18045,7 +18080,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-    optional: true
 
   vite-node@3.1.1(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2):
     dependencies:
@@ -18081,7 +18115,6 @@ snapshots:
       terser: 5.31.3
       tsx: 4.22.0
       yaml: 2.8.2
-    optional: true
 
   vite@6.2.6(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2):
     dependencies:
@@ -18113,7 +18146,6 @@ snapshots:
       terser: 5.31.3
       tsx: 4.22.0
       yaml: 2.8.2
-    optional: true
 
   vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2):
     dependencies:
@@ -18171,7 +18203,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-    optional: true
 
   vitest@3.1.1(@types/debug@4.1.12)(@types/node@18.19.130)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(msw@2.12.7(@types/node@18.19.130)(typescript@5.5.4))(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,13 +244,13 @@ importers:
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/addon-docs':
         specifier: ^10.1.11
-        version: 10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+        version: 10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       '@storybook/addon-onboarding':
         specifier: ^10.1.11
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/nextjs':
         specifier: ^10.1.11
-        version: 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+        version: 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.5.4)
@@ -277,7 +277,7 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
-        version: 3.9.0(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
+        version: 3.9.0(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.19(postcss@8.5.3)
@@ -311,6 +311,9 @@ importers:
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      vite:
+        specifier: ^6.2.6
+        version: 6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.1.1
         version: 3.1.1(@types/debug@4.1.12)(@types/node@17.0.45)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
@@ -11939,10 +11942,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.0.10)(react@19.2.1)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       '@storybook/icons': 2.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       react: 19.2.1
@@ -12008,6 +12011,36 @@ snapshots:
       - rollup
       - webpack
 
+  '@storybook/builder-webpack5@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
+    dependencies:
+      '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      cjs-module-lexer: 1.3.1
+      css-loader: 7.1.2(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      es-module-lexer: 1.6.0
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      html-webpack-plugin: 5.6.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      magic-string: 0.30.17
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      style-loader: 4.0.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.13.5)(esbuild@0.25.2)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      ts-dedent: 2.2.0
+      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack-dev-middleware: 6.1.3(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      webpack-hot-middleware: 2.26.1
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@swc/core'
+      - esbuild
+      - msw
+      - uglify-js
+      - vite
+      - webpack-cli
+
   '@storybook/builder-webpack5@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
       '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
@@ -12043,14 +12076,14 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.25.2
       rollup: 4.62.2
-      vite: 7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
+      vite: 6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
       webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
 
   '@storybook/csf-plugin@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
@@ -12079,6 +12112,68 @@ snapshots:
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
+
+  '@storybook/nextjs@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.28.5)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.28.5)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.28.5)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.28.5)
+      '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-env': 7.24.8(@babel/core@7.28.5)
+      '@babel/preset-react': 7.24.7(@babel/core@7.28.5)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.28.5)
+      '@babel/runtime': 7.29.2
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      '@storybook/builder-webpack5': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
+      '@storybook/preset-react-webpack': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+      '@storybook/react': 10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+      '@types/semver': 7.7.1
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      css-loader: 6.11.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      image-size: 2.0.2
+      loader-utils: 3.3.1
+      next: 16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      postcss: 8.5.3
+      postcss-loader: 8.2.0(postcss@8.5.3)(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-refresh: 0.14.2
+      resolve-url-loader: 5.0.0
+      sass-loader: 16.0.6(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      semver: 7.7.3
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      style-loader: 3.3.4(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+    optionalDependencies:
+      typescript: 5.5.4
+      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - babel-plugin-macros
+      - esbuild
+      - msw
+      - node-sass
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - uglify-js
+      - vite
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
 
   '@storybook/nextjs@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
     dependencies:
@@ -12815,17 +12910,17 @@ snapshots:
     dependencies:
       valibot: 1.2.0(typescript@5.5.4)
 
+  '@vitejs/plugin-react-swc@3.9.0(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
+    dependencies:
+      '@swc/core': 1.13.5
+      vite: 6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
   '@vitejs/plugin-react-swc@3.9.0(vite@6.2.6(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
       '@swc/core': 1.13.5
       vite: 6.2.6(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  '@vitejs/plugin-react-swc@3.9.0(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
-    dependencies:
-      '@swc/core': 1.13.5
-      vite: 7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -12861,6 +12956,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.7(@types/node@18.19.130)(typescript@5.5.4)
       vite: 6.2.6(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
+
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@17.0.45)(typescript@5.5.4)
+      vite: 6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
 
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
@@ -18146,6 +18250,7 @@ snapshots:
       terser: 5.31.3
       tsx: 4.22.0
       yaml: 2.8.2
+    optional: true
 
   vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

`apps/portfolio` had zero tests, no test script, and no Vitest wiring — unlike the blog. Locale detection in `middleware.ts` (where two real bugs were found: #341) and the dictionary loading path had no regression coverage.

### What changed?

- Vitest devDependencies added (versions mirror `apps/blog`), plus `test-utils: workspace:*` and an explicit `server-only` dependency
- `apps/portfolio/vitest.config.mts`: single jsdom project reusing `packages/test-utils/setupTests.ts`
- Scripts: `test` / `test:watch` — root `pnpm test` (turbo) now includes the portfolio automatically
- First tests (19):
  - `middleware.test.ts` (11): cookie → Accept-Language (quality parsing) → `ja` fallback priority, 307 redirect for locale-less paths, pass-through for locale-prefixed paths, cookie written on non-prefetch and skipped on prefetch, icon/chrome early return
  - `i18n/settings.test.ts` / `i18n/dictionaries.test.ts` (8): `resolveLanguage` fallback, dictionary loading for both locales, recursive key-parity between `ja`/`en` translation files (guards the "add keys to BOTH files" rule)

### Why was this changed?

- Foundations default to quality (k2bg principles); the portfolio had no safety net at all (issue #345)

## Type of Change

- [x] 🧪 Test additions or updates
- [x] 🏗️ Build/CI changes

## Affected Applications

- [x] 💼 Portfolio app (`apps/portfolio/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

### How to Test

1. `pnpm -F portfolio test` — 3 files / 19 tests green
2. Root `pnpm test` — turbo now runs blog + portfolio + test-utils suites

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #345
Relates to #341

## Additional Context

Found in the 2026-07 repository audit (issue #345). The middleware tests deliberately cover CURRENT behavior only — the two known middleware bugs (query-string loss, language-switch cookie persistence) are scoped to #341 and will adjust these tests when fixed.

## Reviewer Notes

- Commits are split: dependency changes (`📦 Deps`) separately from config + tests (`✅ Test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
