### PR TITLE
🐛 Fix: #341 Preserve query string and persist locale on language switch

### DIFF
--- a/apps/portfolio/components/LanguageSelector.test.tsx
+++ b/apps/portfolio/components/LanguageSelector.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LanguageSelector } from './LanguageSelector';
+
+describe('LanguageSelector', () => {
+  it('renders a link to the Japanese locale', () => {
+    render(<LanguageSelector />);
+
+    expect(screen.getByRole('link', { name: 'ja' })).toHaveAttribute(
+      'href',
+      '/ja'
+    );
+  });
+
+  it('renders a link to the English locale', () => {
+    render(<LanguageSelector />);
+
+    expect(screen.getByRole('link', { name: 'en' })).toHaveAttribute(
+      'href',
+      '/en'
+    );
+  });
+});

--- a/apps/portfolio/components/LanguageSelector.test.tsx
+++ b/apps/portfolio/components/LanguageSelector.test.tsx
@@ -1,7 +1,22 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 
 import { LanguageSelector } from './LanguageSelector';
+
+// Expose Link's prefetch prop in the DOM so tests can guard the
+// prefetch={false} fix for issue #341 (next/link never renders it).
+vi.mock('next/link', () => ({
+  default: ({
+    prefetch,
+    children,
+    ...anchorProps
+  }: ComponentProps<'a'> & { prefetch?: boolean }) => (
+    <a {...anchorProps} data-prefetch={String(prefetch)}>
+      {children}
+    </a>
+  ),
+}));
 
 describe('LanguageSelector', () => {
   it('renders a link to the Japanese locale', () => {
@@ -19,6 +34,20 @@ describe('LanguageSelector', () => {
     expect(screen.getByRole('link', { name: 'en' })).toHaveAttribute(
       'href',
       '/en'
+    );
+  });
+
+  it.each([
+    { locale: 'ja' },
+    { locale: 'en' },
+  ])('disables prefetching on the $locale locale link so the switch hits the middleware', ({
+    locale,
+  }) => {
+    render(<LanguageSelector />);
+
+    expect(screen.getByRole('link', { name: locale })).toHaveAttribute(
+      'data-prefetch',
+      'false'
     );
   });
 });

--- a/apps/portfolio/components/LanguageSelector.tsx
+++ b/apps/portfolio/components/LanguageSelector.tsx
@@ -4,8 +4,10 @@ import { buttonVariants } from 'ui';
 export function LanguageSelector() {
   return (
     <div className="fixed left-4 bottom-4 overflow-hidden rounded-md border w-max bg-white/80 shadow-xs">
+      {/* prefetch=false: cookie persistence needs a real (non-prefetch) request to hit the middleware */}
       <Link
         href="/ja"
+        prefetch={false}
         className={buttonVariants({
           color: 'dark',
           variant: 'ghost',
@@ -17,6 +19,7 @@ export function LanguageSelector() {
       </Link>
       <Link
         href="/en"
+        prefetch={false}
         className={buttonVariants({
           color: 'dark',
           variant: 'ghost',

--- a/apps/portfolio/middleware.test.ts
+++ b/apps/portfolio/middleware.test.ts
@@ -60,6 +60,32 @@ describe('middleware', () => {
         'http://localhost/ja/about'
       );
     });
+
+    it('preserves the query string when redirecting to the locale path', () => {
+      const request = new NextRequest(
+        new URL('http://localhost/?utm_source=x&b=2'),
+        { headers: { cookie: `${cookieName}=ja` } }
+      );
+
+      const response = middleware(request);
+
+      expect(response.headers.get('location')).toBe(
+        'http://localhost/ja?utm_source=x&b=2'
+      );
+    });
+
+    it('preserves the query string when redirecting a nested path to the locale path', () => {
+      const request = new NextRequest(
+        new URL('http://localhost/about?utm_source=x&b=2'),
+        { headers: { cookie: `${cookieName}=ja` } }
+      );
+
+      const response = middleware(request);
+
+      expect(response.headers.get('location')).toBe(
+        'http://localhost/ja/about?utm_source=x&b=2'
+      );
+    });
   });
 
   describe('when the request path already has a locale prefix', () => {

--- a/apps/portfolio/middleware.ts
+++ b/apps/portfolio/middleware.ts
@@ -56,7 +56,9 @@ export function middleware(request: NextRequest) {
 
   if (!pathnameHasLocale) {
     const locale = getLocale(request);
-    return NextResponse.redirect(new URL(`/${locale}${pathname}`, request.url));
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = `/${locale}${pathname}`;
+    return NextResponse.redirect(redirectUrl);
   }
 
   const response = NextResponse.next();


### PR DESCRIPTION
## Summary

Two locale-handling bugs in the portfolio (issue #341):

1. **Query strings were dropped**: the locale redirect was built from `pathname` only (`new URL(\`/${locale}${pathname}\`, request.url)`), so `?utm_source=...` and any other search params were lost on the first visit — campaign attribution broke.
2. **Language choice did not persist**: the language switcher navigated via prefetched `next/link`, so the navigation was served from the prefetch/router cache, the middleware's cookie-write path never ran, and the visitor's explicit choice was forgotten on the next visit.

### What changed?

- `apps/portfolio/middleware.ts`: the redirect clones `request.nextUrl` and only rewrites `pathname`, preserving search params
- `apps/portfolio/components/LanguageSelector.tsx`: switch links use `prefetch={false}` so the actual navigation is a real request that runs the middleware and writes the `NEXT_LOCALE` cookie (constraint documented in a comment)
- Tests: middleware suite extended (+2: query-string preservation on root and nested paths, 13 total) and a new `LanguageSelector.test.tsx` (renders both locale links with correct hrefs)

### Why was this changed?

- UTM attribution loss and non-persistent language choice are real visitor-facing defects found in the 2026-07 audit

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test additions or updates

## Affected Applications

- [x] 💼 Portfolio app (`apps/portfolio/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

### How to Test

1. `pnpm -F portfolio test` — 4 files / 23 tests green
2. Visit `/?utm_source=x` with no locale cookie → redirected to `/ja?utm_source=x`
3. Switch language, close the browser, revisit `/` → served the chosen locale

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #341

**Depends on #360** — this branch is stacked on `feature/345-portfolio-test-infra` (the test infrastructure). Merge #360 first; this PR then retargets to `main` automatically when the base branch is deleted.

## Additional Context

Found in the 2026-07 repository audit (issue #341).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
