### PR TITLE
📝 Docs: #351 Fix AGENTS.md naming rule and test-utils drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,8 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
 - Component stories: **PascalCase** `.stories.tsx` (`Button.stories.tsx`).
 - Tests: **camelCase** `.test.ts(x)` / `.spec.ts(x)` (`useSnsShareInfo.test.ts`).
 - Utility files: **camelCase** (`generateHtmlTemplate.ts`).
-- Entity/domain files: **PascalCase** (`Entity.ts`, `Repository.ts`).
+- Entity/domain files: **camelCase** (`apps/blog/modules/post/domain/entities/entity.ts`,
+  `apps/blog/modules/contact/domain/repositories/emailSender.ts`).
 - Config files: **lowercase** (`globals.css`, `middleware.ts`).
 - Component directories: **kebab-case** in apps (`apps/blog/components/article-heading/`);
   **PascalCase** in `packages/ui` (`packages/ui/src/components/Avatar/`); domain/module
@@ -221,9 +222,10 @@ export const postSchema = z.object({ id: z.string(), title: z.string() })
 
 - Framework: Vitest with jsdom. Co-locate tests as `*.test.ts(x)` / `*.spec.ts(x)` near source.
 - Libraries: React Testing Library (`@testing-library/react`, `user-event`), `vi` mocks.
-- Shared config: apps re-export `defineConfig` from `test-utils` (see `apps/blog/vitest.config.mts`);
-  setup `packages/test-utils/setupTests.ts` loads `@testing-library/jest-dom/vitest`.
-- Coverage reporters: `text,json,html` (see `packages/test-utils/vitest.config.ts`).
+- App Vitest configs define projects inline and resolve the shared setup file directly
+  (see `apps/blog/vitest.config.mts`); `packages/test-utils/setupTests.ts` loads
+  `@testing-library/jest-dom/vitest`.
+- Coverage reporters: `text,json,html` (see `apps/blog/vitest.config.mts`).
 - Test behavior over implementation; AAA structure; name the subject `sut`; prefer `it.each`
   over loops. Full standards: `.claude/rules/unit-test-guidelines.md`.
 - Run before pushing: `pnpm typecheck && pnpm lint && pnpm test` (or scope via `pnpm -F blog test`).


### PR DESCRIPTION
## Summary

Fixes two concrete rule/reality mismatches in `AGENTS.md` (the single source of truth for all agents) found in the 2026-07 audit.

### What changed?

- Naming rule: Entity/domain files documented as **PascalCase** (`Entity.ts`, `Repository.ts`) → corrected to **camelCase** with real repository paths as examples (`apps/blog/modules/post/domain/entities/entity.ts`, `apps/blog/modules/contact/domain/repositories/emailSender.ts`). Every existing domain file is camelCase; agents following the old rule produced wrongly-named files.
- Testing section: removed the false claim that apps "re-export `defineConfig` from `test-utils`" — no such import exists. Now describes the actual pattern: app Vitest configs define projects inline and resolve the shared setup file (`packages/test-utils/setupTests.ts`) directly. The wording stays accurate after #352 removes the dead `defineConfig` export.

### Why was this changed?

AI agents and contributors rely on `AGENTS.md` as the source of truth; drifted rules actively produce wrong output.

## Type of Change

- [x] 📝 Documentation update

## Affected Applications

- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [x] No tests needed (explain why below)

Docs-only change; `pnpm docs:check` guards path references.

### How to Test

1. `pnpm docs:check`
2. Compare the naming rule against `find apps/blog/modules -path '*/domain/*' -name '*.ts'`

### Test Results

- [x] Linting passes (`pnpm lint`)

`pnpm docs:check` → passed (18 files scanned). The dead `minThreads` option and `packages/test-utils` code cleanup are tracked in #352 (code side), not here.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

## Related Issues

Closes #351

## Additional Context

Found in the 2026-07 repository audit. `CLAUDE.md` and `.claude/rules/*.md` were checked for the same stale claims — none present. Related: #352 (removes the dead `defineConfig` export and `minThreads` option).
