### PR TITLE
🐛 Fix: #344 Align portfolio content with the current architecture

### DIFF
--- a/apps/portfolio/README.md
+++ b/apps/portfolio/README.md
@@ -1,195 +1,74 @@
 # K2BG Portfolio
 
-A **Next.js 16** multilingual portfolio website supporting **English** and **Japanese**, with automatic language detection and i18n routing. Part of the [K2BG Branding monorepo](../../README.md).
+A Next.js 16 portfolio site for K2.B.G. Technology. It supports Japanese and English with server-only dictionary-based internationalization and language-prefixed routes.
 
-## Technology Stack
+## Stack
 
 | Category | Technologies |
-|---|---|
-| **Framework** | Next.js 16, React 19, TypeScript |
-| **Styling** | Tailwind CSS v4 |
-| **i18n** | i18next, react-i18next, i18next-browser-languagedetector |
-| **Contact** | Formspree |
-| **Analytics** | Google Tag Manager |
-| **Linting** | Biome |
-| **Docs** | Storybook 10 |
+| --- | --- |
+| Framework | Next.js 16, React, TypeScript |
+| Styling | Tailwind CSS v4, shared `ui` package |
+| i18n | Server-only JSON dictionaries |
+| Contact | Formspree |
+| Analytics | Google Tag Manager |
+| Tooling | Biome, Storybook |
 
-## Getting Started
+## Development
 
-### Prerequisites
-
-- Node.js 20.9+
-- pnpm 10.33.2+
-
-### Installation
-
-From the monorepo root:
+Run commands from the monorepo root:
 
 ```bash
-pnpm install
+pnpm -F portfolio dev
+pnpm -F portfolio build
+pnpm -F portfolio typecheck
+pnpm -F portfolio lint
+pnpm -F portfolio storybook
 ```
 
-### Development
+The development server runs on [http://localhost:3001](http://localhost:3001). Storybook runs on [http://localhost:6008](http://localhost:6008).
 
-```bash
-# From monorepo root
-pnpm dev --filter=portfolio
+## Internationalization
 
-# Or from this directory
-pnpm dev
-```
+The portfolio does not use client-side translation hooks. Server components resolve the route language, load a dictionary, and pass typed dictionary slices to leaf components.
 
-Open [http://localhost:3001](http://localhost:3001).
+- Routes live under `app/[lang]/`.
+- Supported languages are `ja` and `en`; `ja` is the fallback.
+- Dictionaries live in `i18n/locales/{ja,en}/translation.json`.
+- `i18n/dictionaries.ts` is server-only; the English dictionary defines the TypeScript shape.
+- `middleware.ts` performs locale detection in this order: `NEXT_LOCALE` cookie, `Accept-Language` header, then `ja`.
+- The portfolio intentionally keeps `middleware.ts` because locale detection uses the edge runtime; do not rename it to `proxy.ts`.
 
-### Build
+## Structure
 
-```bash
-pnpm build
-```
-
-### Storybook
-
-```bash
-pnpm storybook
-```
-
-Opens on [http://localhost:6008](http://localhost:6008).
-
-## Architecture
-
-### i18n System
-
-| Setting | Value |
-|---|---|
-| **Languages** | Japanese (`ja`), English (`en`) |
-| **Default / Fallback** | `ja` |
-| **Cookie name** | `i18next` |
-| **Detection priority** | path > htmlTag > cookie > navigator |
-
-**Proxy behavior** (Next.js 16 `proxy.ts`)**:**
-
-1. Check `i18next` cookie for saved language preference
-2. Fall back to `Accept-Language` header
-3. Default to `ja` if no preference is detected
-4. Redirect paths without a language prefix to `/{detected-language}{pathname}`
-5. Update cookie from referer URL when present
-
-All routes are prefixed with the language code (e.g., `/ja`, `/en`).
-
-### Sections
-
-The portfolio is a single-page application composed of these sections:
-
-| Section | Description |
-|---|---|
-| **Hero** | Company name and slogan |
-| **Background** | Personal background and certifications |
-| **Skill** | Technical skills organized by category |
-| **Portfolio** | Project showcase with videos and images |
-| **Contact** | Contact form via Formspree |
-
-### Components
-
-- **LanguageSelector** - Language switcher (ja/en)
-- **ScrollHelper** - Scroll navigation assistance
-- **Slider** - Content slider for portfolio items
-- **ExternalLinkButton** - External link component
-- **Footer** - Site footer with attribution
-
-### Custom Hooks
-
-- **useMatchMedia** - Media query matching hook using `useSyncExternalStore` for SSR-safe responsive behavior
-
-### Portfolio App Architecture
-
-```mermaid
-flowchart TB
-    Request["Client Request"] --> Middleware
-
-    subgraph i18n["Internationalization"]
-        direction TB
-        Middleware["i18n Proxy<br/>Language Detection & Routing"]
-        Translations["Translation Files<br/>en / ja"]
-        Middleware -.-> Translations
-    end
-
-    subgraph app["Next.js Application"]
-        direction TB
-        Layout["Layout"] --> Page["Page /[lng]"]
-        Page --> Sections["Sections<br/>Hero / Background / Skill<br/>Portfolio / Contact"]
-    end
-
-    subgraph shared["Shared Packages"]
-        direction TB
-        UIPackage["UI Package<br/>Component Library"]
-        TailwindConfig["Tailwind Config<br/>Design System"]
-    end
-
-    Formspree["Formspree<br/>Contact Forms"]
-
-    Middleware -->|locale| Layout
-    Sections --> UIPackage
-    Sections --> TailwindConfig
-    Sections -.->|Contact Form| Formspree
-
-    classDef requestStyle fill:#6B7280,stroke:#4B5563,stroke-width:2px,color:#fff
-    classDef i18nStyle fill:#8B5CF6,stroke:#7C3AED,stroke-width:2px,color:#fff
-    classDef appStyle fill:#3B82F6,stroke:#1E40AF,stroke-width:2px,color:#fff
-    classDef sharedStyle fill:#F59E0B,stroke:#D97706,stroke-width:2px,color:#fff
-    classDef externalStyle fill:#EF4444,stroke:#DC2626,stroke-width:2px,color:#fff
-
-    class Request requestStyle
-    class Middleware,Translations i18nStyle
-    class Layout,Page,Sections appStyle
-    class UIPackage,TailwindConfig sharedStyle
-    class Formspree externalStyle
+```text
+apps/portfolio/
+|-- app/
+|   `-- [lang]/
+|       |-- layout.tsx
+|       |-- page.tsx
+|       `-- loading.tsx
+|-- components/
+|   |-- contents/
+|   |-- footer/
+|   |-- ExternalLinkButton.tsx
+|   |-- LanguageSelector.tsx
+|   |-- ScrollHelper.tsx
+|   `-- Slider.tsx
+|-- hooks/
+|-- i18n/
+|   |-- dictionaries.ts
+|   |-- settings.ts
+|   `-- locales/
+|-- middleware.ts
+`-- public/
 ```
 
 ## Environment Variables
 
-Create `apps/portfolio/.env.local`:
+Create `apps/portfolio/.env.local` when local integrations are needed:
 
 ```bash
-# Contact Form
-FORMSPREE_FORM_ACTION_URL=
-
-# Analytics
+NEXT_PUBLIC_FORMSPREE_FORM_ACTION_URL=
 GOOGLE_TAG_MANAGER_ID=
-```
-
-## Project Structure
-
-```
-apps/portfolio/
-├── app/
-│   └── [lng]/                 # Language-specific routes
-│       ├── layout.tsx         # Root layout with GTM
-│       ├── page.tsx           # Main page (all sections)
-│       └── loading.tsx        # Loading fallback
-├── components/
-│   ├── contents/              # Page sections
-│   │   ├── Hero.tsx
-│   │   ├── Background.tsx
-│   │   ├── Skill.tsx
-│   │   ├── Portfolio.tsx
-│   │   └── Contact.tsx
-│   ├── footer/                # Footer component
-│   ├── LanguageSelector.tsx
-│   ├── ScrollHelper.tsx
-│   ├── Slider.tsx
-│   └── ExternalLinkButton.tsx
-├── hooks/
-│   └── useMatchMedia.ts       # Responsive media query hook
-├── i18n/
-│   ├── settings.ts            # Language configuration
-│   ├── client.ts              # Client-side i18n
-│   ├── index.ts               # Server-side translation helper
-│   └── locales/
-│       ├── en/translation.json
-│       └── ja/translation.json
-├── proxy.ts                    # Language detection & routing (Next.js 16)
-├── public/
-│   ├── images/                # Background and project images
-│   └── videos/                # Portfolio demo videos
-└── .storybook/                # Storybook config
+PORTFOLIO_SITE_BASE_URL=
 ```

--- a/apps/portfolio/app/[lang]/page.tsx
+++ b/apps/portfolio/app/[lang]/page.tsx
@@ -39,7 +39,7 @@ export default async function Page({ params }: PageProps) {
         <Footer copyright={dictionary.footer.copyright} />
       </div>
       <LanguageSelector />
-      <ScrollHelper />
+      <ScrollHelper dictionary={dictionary.scrollHelper} />
     </Suspense>
   );
 }

--- a/apps/portfolio/components/ScrollHelper.stories.tsx
+++ b/apps/portfolio/components/ScrollHelper.stories.tsx
@@ -1,9 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
+import jaTranslation from '../i18n/locales/ja/translation.json';
+
 import { ScrollHelper } from './ScrollHelper';
 
 const meta: Meta<typeof ScrollHelper> = {
   component: ScrollHelper,
+  args: {
+    dictionary: jaTranslation.scrollHelper,
+  },
 };
 
 export default meta;

--- a/apps/portfolio/components/ScrollHelper.tsx
+++ b/apps/portfolio/components/ScrollHelper.tsx
@@ -5,10 +5,17 @@ import { Icon } from 'ui';
 import { twMerge } from 'ui/src/utils/extendTailwindMerge';
 
 import { useMatchMedia } from '../hooks/useMatchMedia';
+import type { Dictionary } from '../i18n/dictionaries';
 
 import styles from './ScrollHelper.module.css';
 
-export function ScrollHelper() {
+type ScrollHelperDictionary = Dictionary['scrollHelper'];
+
+export function ScrollHelper({
+  dictionary,
+}: {
+  dictionary: ScrollHelperDictionary;
+}) {
   const [isShow, setIsShow] = useState(false);
   const isDesktopLayout = useMatchMedia('(min-width: 768px)');
 
@@ -50,7 +57,7 @@ export function ScrollHelper() {
             styles.ScrollHelp
           )}
         >
-          <span className="text-button-r-sm">Scroll</span>
+          <span className="text-button-r-sm">{dictionary.label}</span>
           <Icon
             name="chevron-double-right"
             color="var(--color-base-white)"

--- a/apps/portfolio/components/contents/Background.tsx
+++ b/apps/portfolio/components/contents/Background.tsx
@@ -15,7 +15,7 @@ export function Background({
           <Image
             src="/images/background-pattern.jpg"
             fill
-            alt="Background Pattern Image"
+            alt={dictionary.imageAlt}
           />
         </div>
         <div className="flex flex-col gap-normal">

--- a/apps/portfolio/components/contents/Contact.tsx
+++ b/apps/portfolio/components/contents/Contact.tsx
@@ -12,7 +12,7 @@ export function Contact({ dictionary }: { dictionary: ContactDictionary }) {
           <Image
             src="/images/contact-pattern.jpg"
             fill
-            alt="Contact Pattern Image"
+            alt={dictionary.imageAlt}
           />
         </div>
         <div className="flex flex-col justify-center gap-spacious p-6 w-full text-white h-full md:p-12 md:w-[37.5rem]">

--- a/apps/portfolio/components/contents/Hero.tsx
+++ b/apps/portfolio/components/contents/Hero.tsx
@@ -11,7 +11,7 @@ export function Hero({ dictionary }: { dictionary: HeroDictionary }) {
           <Image
             src="/images/hero.jpg"
             fill
-            alt="Hero Image"
+            alt={dictionary.imageAlt}
             className="object-cover"
           />
         </div>

--- a/apps/portfolio/components/contents/Portfolio.tsx
+++ b/apps/portfolio/components/contents/Portfolio.tsx
@@ -14,8 +14,10 @@ interface DocumentProps {
   techStack: string;
   overview: string;
   backgroundImage: string;
+  backgroundImageAlt: string;
   preview: ReactNode;
   previewVideo: string;
+  videoFallback: string;
   siteLink?: ReactNode;
 }
 
@@ -27,9 +29,11 @@ function Document(props: DocumentProps) {
     techStack,
     overview,
     backgroundImage,
+    backgroundImageAlt,
     siteLink,
     preview,
     previewVideo,
+    videoFallback,
   } = props;
 
   return (
@@ -38,7 +42,7 @@ function Document(props: DocumentProps) {
         <Image
           src={backgroundImage}
           fill
-          alt="Stock Image"
+          alt={backgroundImageAlt}
           className="object-cover brightness-50 transition-all duration-300 ease-in group-hover:scale-110"
         />
         <div className="absolute top-0 left-0 w-full h-full backdrop-blur-xs" />
@@ -67,7 +71,7 @@ function Document(props: DocumentProps) {
               className="w-full max-w-screen-lg max-h-[calc(100vh-10rem)] aspect-video"
             >
               <source src={previewVideo} type="video/mp4" />
-              <p>Your browser support HTML5 video.</p>
+              <p>{videoFallback}</p>
             </video>
           </div>
         }
@@ -105,6 +109,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
               techStack={dictionary.webApp.techStack}
               overview={dictionary.webApp.overview}
               backgroundImage="/images/stock.jpg"
+              backgroundImageAlt={dictionary.webApp.imageAlt}
               preview={
                 <Button
                   color="light"
@@ -115,6 +120,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
                 </Button>
               }
               previewVideo="/videos/stock-app.mp4"
+              videoFallback={dictionary.videoFallback}
               siteLink={
                 <>
                   <ExternalLinkButton
@@ -141,6 +147,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
               techStack={dictionary.mobileApp.techStack}
               overview={dictionary.mobileApp.overview}
               backgroundImage="/images/mobile.jpg"
+              backgroundImageAlt={dictionary.mobileApp.imageAlt}
               preview={
                 <Button
                   color="light"
@@ -151,6 +158,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
                 </Button>
               }
               previewVideo="/videos/mobile.mp4"
+              videoFallback={dictionary.videoFallback}
               siteLink={
                 <>
                   <ExternalLinkButton
@@ -177,6 +185,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
               techStack={dictionary.scrapingApp.techStack}
               overview={dictionary.scrapingApp.overview}
               backgroundImage="/images/web.jpg"
+              backgroundImageAlt={dictionary.scrapingApp.imageAlt}
               preview={
                 <Button
                   color="light"
@@ -187,6 +196,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
                 </Button>
               }
               previewVideo="/videos/scrapy.mp4"
+              videoFallback={dictionary.videoFallback}
               siteLink={
                 <ExternalLinkButton
                   href="https://github.com/krd-knt/scrapy_snippets"
@@ -205,6 +215,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
               techStack={dictionary.blogApp.techStack}
               overview={dictionary.blogApp.overview}
               backgroundImage="/images/blog.jpg"
+              backgroundImageAlt={dictionary.blogApp.imageAlt}
               preview={
                 <Button
                   color="light"
@@ -215,6 +226,7 @@ export function Portfolio({ dictionary }: { dictionary: PortfolioDictionary }) {
                 </Button>
               }
               previewVideo="/videos/blog.mp4"
+              videoFallback={dictionary.videoFallback}
               siteLink={
                 <ExternalLinkButton
                   href="https://blog.k2bg.technology"

--- a/apps/portfolio/components/contents/Skill.tsx
+++ b/apps/portfolio/components/contents/Skill.tsx
@@ -12,7 +12,7 @@ export function Skill({ dictionary }: { dictionary: SkillDictionary }) {
           <Image
             src="/images/skill-pattern.jpg"
             fill
-            alt="Skill Pattern Image"
+            alt={dictionary.imageAlt}
           />
         </div>
         <div className="flex flex-col gap-spacious h-full md:flex-row md:gap-0">

--- a/apps/portfolio/i18n/locales/en/translation.json
+++ b/apps/portfolio/i18n/locales/en/translation.json
@@ -5,6 +5,7 @@
   "hero": {
     "corporateName": "K2.B.G. Technology",
     "officialName": "KK Bit Growth Technology",
+    "imageAlt": "K2.B.G. Technology hero image",
     "slogan": "Scale up your business with the power of IT",
     "description1": "IT is crucial for modern business, but it's also fast-changing and hard to use effectively.",
     "description2": "From my work across various industries, I've seen the challenges and benefits of shifting to IT-based processes. The transition can be tough but the gains in productivity, flexibility, and risk avoidance are significant.",
@@ -12,6 +13,7 @@
   },
   "background": {
     "background": "Background",
+    "imageAlt": "Background section pattern image",
     "description1": "I have a bachelor's in Information Science and Engineering. Early in my career, I worked in design and layout for a printing company. Then, I switched to a trading company to handle purchasing and sales analysis for kitchenware.",
     "description2": "I realized the huge impact IT can have on business efficiency while working in non-IT industries. This led me to become a web application engineer. I've since worked in various sectors like healthcare, e-commerce, and online communication.",
     "description3": "Now, I'm a freelance engineer specializing in UI/UX design and data analysis. I support IT companies in app development and share my expertise through my own platforms.",
@@ -23,6 +25,7 @@
   },
   "skill": {
     "skill": "Skill",
+    "imageAlt": "Skill section pattern image",
     "programming": "Programming and Frameworks",
     "programmingStack": "Nodejs（Javascript、Typescript）、React(ReactNative）、Python、FastAPI、Scrapy、Golang、Wordpress",
     "uiux": "UI・UX",
@@ -40,32 +43,38 @@
     "overview": "overview",
     "webApp": {
       "title": "Web Application Development",
+      "imageAlt": "Stock analysis web application preview image",
       "techStack": "Node.js、Typescript、React、Next.js、Python、FastAPI、Jupyter Notebook",
       "overview": "This is an app for analyzing and predicting stock prices using historical data. Right now, it only lets you view past stock prices and create portfolios. In the future, we'll add a feature to forecast stock prices using backend APIs and display the predictions."
     },
     "mobileApp": {
       "title": "Mobile Application Development",
+      "imageAlt": "Mobile application preview image",
       "techStack": "Node.js、Typescript、React Native、Golang、Mysql、Docker",
       "overview": "This is a product management app that lets you quickly enter and check costs and inventory from your phone. We developed it to eliminate the hassle of using a PC and Excel for tracking product info during fieldwork like buying and inspections."
     },
     "scrapingApp": {
       "title": "Web scraping",
+      "imageAlt": "Web scraping application preview image",
       "techStack": "Python、Scrapy、Selenium、Docker、Bigquery",
       "overview": "In a time where having lots of data is valuable, we think it's crucial to gather information from the web. We've built a tool using the Scrapy framework that can collect data from both static and dynamic web pages. It can also send this data to places like CSV files or BigQuery through a pipeline."
     },
     "blogApp": {
       "title": "Blog",
-      "techStack": "TypeScript、React、Next.js(App Router)、Tailwind CSS、Notion API、Prisma、PostgreSQL、Cloudinary、AWS SES、TanStack Query、Zustand、Zod、Vitest、Storybook",
-      "overview": "A tech blog built with Clean Architecture, covering programming, marketing, design, and finance. Uses Notion as a headless CMS, Prisma + PostgreSQL for persistence, Cloudinary for image optimization, and AWS SES for emails. Features Markdown rendering with syntax highlighting, search, and category filtering."
+      "imageAlt": "Blog application preview image",
+      "techStack": "TypeScript、React、Next.js(App Router)、Tailwind CSS、Notion API、Drizzle ORM、PostgreSQL、Cloudinary、AWS SES、TanStack Query、Zustand、Zod、Vitest、Storybook",
+      "overview": "A tech blog built with Clean Architecture, covering programming, marketing, design, and finance. Uses Notion as a headless CMS, Drizzle ORM + PostgreSQL for persistence, Cloudinary for image optimization, and AWS SES for emails. Features Markdown rendering with syntax highlighting, search, and category filtering."
     },
     "github": "Github",
     "githubApp": "Github App",
     "githubApi": "Github Api",
     "siteURL": "site URL",
-    "preview": "preview"
+    "preview": "preview",
+    "videoFallback": "Your browser does not support HTML5 video."
   },
   "contact": {
     "contact": "Contact",
+    "imageAlt": "Contact section pattern image",
     "description1": "Please fill in the required information and press the send button. It may take a few days to reply, but we will try to reply as soon as possible.",
     "description2": "We are available to work from home for 1-2 hours on weekdays and 3 hours on weekends.",
     "description3": "We are sorry, but we are available outside of the hours of 9:00 to 20:00 on weekdays. We would appreciate it if you could consult with us accordingly.",
@@ -85,5 +94,8 @@
   },
   "footer": {
     "copyright": "\u00A9 K2.B.G. Technology Design: "
+  },
+  "scrollHelper": {
+    "label": "Scroll"
   }
 }

--- a/apps/portfolio/i18n/locales/ja/translation.json
+++ b/apps/portfolio/i18n/locales/ja/translation.json
@@ -5,6 +5,7 @@
   "hero": {
     "corporateName": "K2.B.G. Technology",
     "officialName": "KK Bit Growth Technology",
+    "imageAlt": "K2.B.G. Technologyのヒーロー画像",
     "slogan": "ITの力でビジネスのスケールアップを実現します。",
     "description1": "現代のビジネスは、ITとデジタル技術の活用が不可欠になっています。しかし、ITの進歩は急速で、その効果的な利用は専門知識を必要とし、難易度が高いものとなっています。",
     "description2": "私自身、非IT業界からスタートアップまで、幅広い業界での経験を通じて、伝統的なビジネスプロセスからITを活用した効率的なプロセスへの移行の難しさを感じてきました。しかし、一方で、ITを導入することでビジネスの生産性を向上させ、自由度を高め、リスクを回避できるというメリットを体感してきました。",
@@ -12,6 +13,7 @@
   },
   "background": {
     "background": "経歴",
+    "imageAlt": "経歴セクションのパターン画像",
     "description1": "情報理工学専攻 学部卒。初期のキャリアでは印刷メーカーにおいて、商業印刷物のデザイン・レイアウト・フォトレタッチを担当。その後、貿易商社に転職し、キッチンウェアの商品仕入れ及び販売データ分析に従事。",
     "description2": "非IT業界での実務経験を通じて、業務効率の向上及び問題解決に対するITの可能性を痛感。この認識をもとに、Webアプリケーションエンジニアへの転身を決意。以降、「ヘルスケア」「ECマーケティング」「オンラインコミュニケーション」等、多様な事業領域でのアプリケーション開発に携わる。",
     "description3": "現在はフリーランスエンジニアとして、「UI・UXデザイン」と「データ分析」の専門性を強みに、IT企業向けのアプリケーション開発支援や、自身のメディアを通じた知見の発信を主軸に活動を展開している。",
@@ -23,6 +25,7 @@
   },
   "skill": {
     "skill": "スキル",
+    "imageAlt": "スキルセクションのパターン画像",
     "programming": "プログラミング・フレームワーク",
     "programmingStack": "Nodejs（Javascript、Typescript）、React(ReactNative）、Python、FastAPI、Scrapy、Golang、Wordpress",
     "uiux": "UI・UX",
@@ -40,32 +43,38 @@
     "overview": "概要",
     "webApp": {
       "title": "Webアプリ開発",
+      "imageAlt": "株価分析Webアプリケーションのプレビュー画像",
       "techStack": "Node.js、Typescript、React、Next.js、Python、FastAPI、Jupyter Notebook",
       "overview": "株価分析・予測アプリケーションです。株価の過去データを元に、株価の予測を行うことができます。現状は「過去の株価データの確認」と「ポートフォリオの作成」のみの機能提供ですが、今後は株価予測API機能をバックエンド側で実装し、アプリケーションで可視化できるようにしていきます。"
     },
     "mobileApp": {
       "title": "モバイルアプリ開発",
+      "imageAlt": "モバイルアプリケーションのプレビュー画像",
       "techStack": "Node.js、Typescript、React Native、Golang、Mysql、Docker",
       "overview": "商品仕入れ管理用のアプリケーションです。商品原価・商品在庫などをモバイルから手軽に入力・確認できるようになっています。\n仕入れや検品などのフィールドワーク時に、いちいちPCを開いて商品情報をExcelで確認・入力・管理することの不便さを解決するために開発致しました。"
     },
     "scrapingApp": {
       "title": "Webスクレイピング",
+      "imageAlt": "Webスクレイピングアプリケーションのプレビュー画像",
       "techStack": "Python、Scrapy、Selenium、Docker、Bigquery",
       "overview": "多くのデータを保有することが資産と呼べる時代に、豊富なデータが存在するWebから情報を得ることは必須だと考えます。\nクローリングフレームワークScrapyを活用して、静的・動的ページ問わず情報収集できる、かつPipelineを通して、CSVやBigqueryなどにデータを流し込めるスニペットを開発致しました。"
     },
     "blogApp": {
       "title": "ブログ運営",
-      "techStack": "TypeScript、React、Next.js(App Router)、Tailwind CSS、Notion API、Prisma、PostgreSQL、Cloudinary、AWS SES、TanStack Query、Zustand、Zod、Vitest、Storybook",
-      "overview": "Clean Architectureで設計した技術ブログです。プログラミング・マーケティング・デザイン・ファイナンスなどのテーマで記事を発信しています。NotionをヘッドレスCMSとして活用し、Prisma + PostgreSQLでデータ永続化、Cloudinaryで画像最適化、AWS SESでメール送信を実現。シンタックスハイライト付きMarkdown表示や検索機能も備えています。"
+      "imageAlt": "ブログアプリケーションのプレビュー画像",
+      "techStack": "TypeScript、React、Next.js(App Router)、Tailwind CSS、Notion API、Drizzle ORM、PostgreSQL、Cloudinary、AWS SES、TanStack Query、Zustand、Zod、Vitest、Storybook",
+      "overview": "Clean Architectureで設計した技術ブログです。プログラミング・マーケティング・デザイン・ファイナンスなどのテーマで記事を発信しています。NotionをヘッドレスCMSとして活用し、Drizzle ORM + PostgreSQLでデータ永続化、Cloudinaryで画像最適化、AWS SESでメール送信を実現。シンタックスハイライト付きMarkdown表示や検索機能も備えています。"
     },
     "github": "Github",
     "githubApp": "Github（アプリ）",
     "githubApi": "Github（API）",
     "siteURL": "サイトURL",
-    "preview": "プレビュー"
+    "preview": "プレビュー",
+    "videoFallback": "お使いのブラウザはHTML5動画に対応していません。"
   },
   "contact": {
     "contact": "お問い合わせ",
+    "imageAlt": "お問い合わせセクションのパターン画像",
     "description1": "必要事項をご入力いただき、送信ボタンを押してください。返信には数日かかる場合がございますが、極力早急に返信するように致しますので、お気軽にお問い合わせいただけると幸いです。",
     "description2": "平日は1〜2時間、休日は3時間程度で在宅ワークをお受けすることが可能です。",
     "description3": "※ 誠に恐れ入りますが、平日は9:00〜20:00以外でのご対応となります。 \n※ 案件によってはお受けするのが難しい場合もございますので、適宜ご相談いただけると幸いです。",
@@ -85,5 +94,8 @@
   },
   "footer": {
     "copyright": "\u00A9 K2.B.G. Technology Design: "
+  },
+  "scrollHelper": {
+    "label": "スクロール"
   }
 }

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -38,6 +38,25 @@ const REMOVED_TECH_GUARDS = [
   },
 ];
 
+const PORTFOLIO_CONTENT_DRIFT_FILES = [
+  'apps/portfolio/README.md',
+  'apps/portfolio/i18n/locales/en/translation.json',
+  'apps/portfolio/i18n/locales/ja/translation.json',
+];
+
+export const PORTFOLIO_CONTENT_DRIFT_GUARDS = [
+  {
+    pattern: /\bprisma\b/i,
+    reason:
+      'Portfolio content drift: Prisma was replaced by Drizzle (#255) — use Drizzle ORM',
+  },
+  {
+    pattern: /react-i18next/i,
+    reason:
+      'Portfolio content drift: portfolio i18n is server-only dictionaries, not react-i18next',
+  },
+];
+
 const VERSION_PIN_GUARD = {
   pattern:
     /\b(?:Storybook|Next\.js|React|TypeScript|Node|pnpm|Vite|Tailwind)\s+v?\d+\.\d+\.\d+\b/,
@@ -50,7 +69,10 @@ const DENYLIST = [...REMOVED_TECH_GUARDS, VERSION_PIN_GUARD];
  * Scan one document's content and return failure messages.
  * `pathExists` is injected so the scan logic stays testable without disk fixtures.
  */
-export function findDocumentationProblems(content, { fileLabel, pathExists }) {
+export function findDocumentationProblems(
+  content,
+  { fileLabel, pathExists, denylist = DENYLIST, checkPaths = true }
+) {
   const failures = [];
 
   content.split('\n').forEach((line, index) => {
@@ -59,17 +81,21 @@ export function findDocumentationProblems(content, { fileLabel, pathExists }) {
     }
     const location = `${fileLabel}:${index + 1}`;
 
-    for (const match of line.matchAll(PATH_PATTERN)) {
-      const referencedPath = match[1].replace(/[.,;:]+$/, '');
-      if (GLOB_OR_PLACEHOLDER.test(referencedPath)) {
-        continue;
-      }
-      if (!pathExists(referencedPath)) {
-        failures.push(`${location}: referenced path does not exist: ${referencedPath}`);
+    if (checkPaths) {
+      for (const match of line.matchAll(PATH_PATTERN)) {
+        const referencedPath = match[1].replace(/[.,;:]+$/, '');
+        if (GLOB_OR_PLACEHOLDER.test(referencedPath)) {
+          continue;
+        }
+        if (!pathExists(referencedPath)) {
+          failures.push(
+            `${location}: referenced path does not exist: ${referencedPath}`
+          );
+        }
       }
     }
 
-    for (const { pattern, reason } of DENYLIST) {
+    for (const { pattern, reason } of denylist) {
       if (pattern.test(line)) {
         failures.push(`${location}: ${reason} (matched ${pattern})`);
       }
@@ -98,15 +124,31 @@ function runCheck() {
   const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
   const documentationFiles = collectDocumentationFiles(repositoryRoot);
 
-  const failures = documentationFiles.flatMap((documentationFile) =>
+  const documentationFailures = documentationFiles.flatMap((documentationFile) =>
     findDocumentationProblems(
       readFileSync(join(repositoryRoot, documentationFile), 'utf8'),
       {
         fileLabel: documentationFile,
-        pathExists: (referencedPath) => existsSync(join(repositoryRoot, referencedPath)),
+        pathExists: (referencedPath) =>
+          existsSync(join(repositoryRoot, referencedPath)),
       }
     )
   );
+
+  const portfolioContentFailures = PORTFOLIO_CONTENT_DRIFT_FILES.flatMap(
+    (documentationFile) =>
+      findDocumentationProblems(
+        readFileSync(join(repositoryRoot, documentationFile), 'utf8'),
+        {
+          fileLabel: documentationFile,
+          pathExists: () => true,
+          denylist: PORTFOLIO_CONTENT_DRIFT_GUARDS,
+          checkPaths: false,
+        }
+      )
+  );
+
+  const failures = [...documentationFailures, ...portfolioContentFailures];
 
   if (failures.length > 0) {
     console.error(`docs:check failed with ${failures.length} problem(s):\n`);
@@ -116,7 +158,9 @@ function runCheck() {
     process.exit(1);
   }
 
-  console.log(`docs:check passed (${documentationFiles.length} files scanned)`);
+  console.log(
+    `docs:check passed (${documentationFiles.length + PORTFOLIO_CONTENT_DRIFT_FILES.length} files scanned)`
+  );
 }
 
 const isDirectRun =

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -1,11 +1,23 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { findDocumentationProblems } from './check-docs.mjs';
+import {
+  findDocumentationProblems,
+  PORTFOLIO_CONTENT_DRIFT_GUARDS,
+} from './check-docs.mjs';
 
 function runChecker(content, { existingPaths = [] } = {}) {
   return findDocumentationProblems(content, {
     fileLabel: 'DOC.md',
     pathExists: (referencedPath) => existingPaths.includes(referencedPath),
+  });
+}
+
+function runPortfolioContentDriftChecker(content) {
+  return findDocumentationProblems(content, {
+    fileLabel: 'apps/portfolio/README.md',
+    pathExists: () => true,
+    denylist: PORTFOLIO_CONTENT_DRIFT_GUARDS,
+    checkPaths: false,
   });
 }
 
@@ -106,6 +118,31 @@ describe('findDocumentationProblems', () => {
       const content = 'Use Drizzle ORM and @base-ui/react with the Vite builder.';
 
       const failures = runChecker(content);
+
+      assert.deepEqual(failures, []);
+    });
+  });
+
+  describe('portfolio content drift guard', () => {
+    const driftCases = [
+      { name: 'Prisma', line: 'Uses Prisma for persistence.' },
+      { name: 'react-i18next', line: 'Uses react-i18next for translations.' },
+    ];
+
+    for (const { name, line } of driftCases) {
+      it(`flags portfolio content drift: ${name}`, () => {
+        const failures = runPortfolioContentDriftChecker(line);
+
+        assert.equal(failures.length, 1);
+        assert.match(failures[0], /Portfolio content drift/);
+      });
+    }
+
+    it('allows current portfolio i18n and persistence wording', () => {
+      const content =
+        'Uses server-only dictionaries and Drizzle ORM + PostgreSQL.';
+
+      const failures = runPortfolioContentDriftChecker(content);
 
       assert.deepEqual(failures, []);
     });


### PR DESCRIPTION
## Summary

Fixes public-facing portfolio content that drifted from reality, and adds a docs-check guard so it cannot recur.

### What changed?

- Tech stack in both locale files: "Prisma, PostgreSQL" → "Drizzle ORM, PostgreSQL" (`blogApp` techStack/overview strings).
- Inverted video fallback fixed in both locales ("Your browser support HTML5 video." → "does not support"; natural Japanese equivalent), wired through a new `videoFallback` dictionary key.
- Hardcoded UI strings moved into dictionaries: `imageAlt` keys for every section image and a `scrollHelper.label` key ("Scroll"/"スクロール"); `ScrollHelper` now receives its dictionary slice as a prop. Deliberately left as-is: locale codes ("ja"/"en"), brand/credit names ("K2.B.G. Technology", "HTML5 UP"), and dev-only strings (data-gtm, URLs).
- `apps/portfolio/README.md` rewritten to match the current architecture: dictionary-based server-only i18n (no react-i18next), middleware locale detection (cookie → Accept-Language → ja), `app/[lang]/` routing, actual scripts/ports and env vars.
- `scripts/check-docs.mjs`: new `PORTFOLIO_CONTENT_DRIFT_GUARDS` denylist (Prisma, react-i18next) scanned against the portfolio README and both translation files, with tests in `check-docs.test.mjs`.

### Why was this changed?

The 2026-07 audit found the portfolio advertising removed tech (Prisma) and a README describing an architecture that no longer exists; the existing docs guard did not scan translations/README.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Affected Applications

- [x] 💼 Portfolio app (`apps/portfolio/`)
- [x] 🏗️ Build configuration (Turborepo, configs)

## Testing

### Test Coverage

- [x] Unit tests added/updated

New guard covered by `scripts/check-docs.test.mjs` (node:test, matching that file's existing conventions).

### How to Test

1. `pnpm docs:check`
2. `node --test scripts/check-docs.test.mjs`
3. Open the portfolio skills section → Drizzle ORM displayed instead of Prisma

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

`node --test scripts/check-docs.test.mjs` 17/17 passed; `pnpm docs:check` passed (21 files scanned); `pnpm typecheck` / `pnpm lint` clean (5 pre-existing unrelated blog test warnings).

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

## Related Issues

Closes #344

## Additional Context

Found in the 2026-07 repository audit. Note: #343 (error/404 + form feedback) also touches the translation files and `Contact.tsx` on a parallel branch — whichever merges second needs a small rebase.
