### PR TITLE
✨ Feat: #338 Add RSS feed, web manifest, and OG metadata for concept/contact

### DIFF
--- a/apps/blog/app/concept/page.tsx
+++ b/apps/blog/app/concept/page.tsx
@@ -5,16 +5,38 @@ import { PageHeading } from '../../components/page-heading/PageHeading';
 import { PageLayout } from '../../components/page-layout';
 import { ScrollToTopButton } from '../../components/scroll-to-top-button/ScrollToTopButton';
 import { Sidebar } from '../../components/sidebar/Sidebar';
-import { createFetchPostUseCase } from '../../infrastructure/di';
+import {
+  createFetchPostUseCase,
+  getDefaultOgImageUrl,
+} from '../../infrastructure/di';
+import { blogSiteName } from '../siteMetadata';
 
 const CONCEPT_PAGE_ID = process.env.NOTION_CONCEPT_PAGE_ID ?? '';
+const conceptDescription = 'K2.B.G Technology Blog のコンセプトを紹介します。';
+const defaultOgImageUrl = getDefaultOgImageUrl();
 
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'コンセプトページ',
+  description: conceptDescription,
   alternates: {
     canonical: '/concept',
+  },
+  openGraph: {
+    title: 'コンセプトページ',
+    description: conceptDescription,
+    type: 'website',
+    locale: 'ja_JP',
+    url: '/concept',
+    siteName: blogSiteName,
+    images: [{ url: defaultOgImageUrl, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'コンセプトページ',
+    description: conceptDescription,
+    images: [defaultOgImageUrl],
   },
 };
 

--- a/apps/blog/app/contact/page.tsx
+++ b/apps/blog/app/contact/page.tsx
@@ -3,13 +3,35 @@ import type { Metadata } from 'next';
 import { PageLayout } from '../../components/page-layout';
 import { ScrollToTopButton } from '../../components/scroll-to-top-button/ScrollToTopButton';
 import { Sidebar } from '../../components/sidebar/Sidebar';
+import { getDefaultOgImageUrl } from '../../infrastructure/di';
+import { blogSiteName } from '../siteMetadata';
 
 import { ContactForm } from './ContactForm';
 
+const contactDescription =
+  'K2.B.G Technology Blog へのお問い合わせはこちらからお送りください。';
+const defaultOgImageUrl = getDefaultOgImageUrl();
+
 export const metadata: Metadata = {
   title: 'お問い合わせページ',
+  description: contactDescription,
   alternates: {
     canonical: '/contact',
+  },
+  openGraph: {
+    title: 'お問い合わせページ',
+    description: contactDescription,
+    type: 'website',
+    locale: 'ja_JP',
+    url: '/contact',
+    siteName: blogSiteName,
+    images: [{ url: defaultOgImageUrl, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'お問い合わせページ',
+    description: contactDescription,
+    images: [defaultOgImageUrl],
   },
 };
 

--- a/apps/blog/app/feed.xml/route.test.ts
+++ b/apps/blog/app/feed.xml/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PostStatus } from '../../modules/post/domain';
+
+const { execute } = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/di', () => ({
+  createFetchPostSummariesUseCase: () => ({ execute }),
+}));
+
+vi.mock('../siteMetadata', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../siteMetadata')>();
+  return {
+    ...actual,
+    getBlogSiteBaseUrl: () => 'https://example.com',
+  };
+});
+
+describe('GET', () => {
+  it('returns an RSS response for published posts', async () => {
+    const { GET } = await import('./route');
+    execute.mockResolvedValue({
+      items: [
+        {
+          id: 'post-id',
+          title: 'Published post',
+          excerpt: 'Post excerpt',
+          imageUrl: 'https://example.com/image.png',
+          slug: 'post-id/published-post',
+          category: 'ENGINEERING',
+          author: null,
+          releaseDate: '2024-01-10',
+        },
+      ],
+      totalCount: 1,
+      totalPages: 1,
+      currentPage: 1,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+
+    const sut = await GET();
+
+    await expect(sut.text()).resolves.toContain(
+      '<link>https://example.com/blog/post-id/published-post</link>'
+    );
+    expect(sut.headers.get('Content-Type')).toBe(
+      'application/rss+xml; charset=utf-8'
+    );
+    expect(execute).toHaveBeenCalledWith({
+      page: 1,
+      pageSize: 100,
+      status: PostStatus.PUBLISHED,
+    });
+  });
+});

--- a/apps/blog/app/feed.xml/route.ts
+++ b/apps/blog/app/feed.xml/route.ts
@@ -1,0 +1,44 @@
+import { createFetchPostSummariesUseCase } from '../../infrastructure/di';
+import { PostStatus } from '../../modules/post/domain';
+import type { PostSummaryOutput } from '../../modules/post/use-cases';
+import { getBlogSiteBaseUrl } from '../siteMetadata';
+import { buildRssFeed } from './rss';
+
+export const revalidate = 3600;
+
+const PAGE_SIZE = 100;
+
+export async function GET(): Promise<Response> {
+  const posts = await fetchAllPublishedPostSummaries();
+  const rssFeed = buildRssFeed({
+    baseUrl: getBlogSiteBaseUrl(),
+    posts,
+  });
+
+  return new Response(rssFeed, {
+    headers: {
+      'Cache-Control': 's-maxage=3600, stale-while-revalidate=86400',
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  });
+}
+
+async function fetchAllPublishedPostSummaries(): Promise<PostSummaryOutput[]> {
+  const fetchPostSummaries = createFetchPostSummariesUseCase();
+  const posts: PostSummaryOutput[] = [];
+  let page = 1;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const result = await fetchPostSummaries.execute({
+      page,
+      pageSize: PAGE_SIZE,
+      status: PostStatus.PUBLISHED,
+    });
+    posts.push(...result.items);
+    hasNextPage = result.hasNextPage;
+    page += 1;
+  }
+
+  return posts;
+}

--- a/apps/blog/app/feed.xml/rss.test.ts
+++ b/apps/blog/app/feed.xml/rss.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PostSummaryOutput } from '../../modules/post/use-cases';
+import { buildRssFeed, escapeXml } from './rss';
+
+describe('escapeXml', () => {
+  it('escapes XML special characters', () => {
+    expect(escapeXml(`Tom & "Jerry" <tag> 'value'`)).toBe(
+      'Tom &amp; &quot;Jerry&quot; &lt;tag&gt; &apos;value&apos;'
+    );
+  });
+});
+
+describe('buildRssFeed', () => {
+  it('renders RSS item fields with escaped text', () => {
+    vi.setSystemTime(new Date('2024-02-01T00:00:00.000Z'));
+    const post: PostSummaryOutput = {
+      id: 'post-id',
+      title: 'A & B <C>',
+      excerpt: 'Learn "RSS" safely',
+      imageUrl: 'https://example.com/image.png',
+      slug: 'post-id/a-b-c',
+      category: 'ENGINEERING',
+      author: null,
+      releaseDate: '2024-01-10',
+    };
+
+    const sut = buildRssFeed({
+      baseUrl: 'https://example.com/',
+      posts: [post],
+    });
+
+    expect(sut).toContain('<rss version="2.0">');
+    expect(sut).toContain('<title>A &amp; B &lt;C&gt;</title>');
+    expect(sut).toContain(
+      '<link>https://example.com/blog/post-id/a-b-c</link>'
+    );
+    expect(sut).toContain(
+      '<description>Learn &quot;RSS&quot; safely</description>'
+    );
+    expect(sut).toContain('<pubDate>Wed, 10 Jan 2024 00:00:00 GMT</pubDate>');
+    expect(sut).toContain(
+      '<guid isPermaLink="true">https://example.com/blog/post-id/a-b-c</guid>'
+    );
+  });
+});

--- a/apps/blog/app/feed.xml/rss.ts
+++ b/apps/blog/app/feed.xml/rss.ts
@@ -1,0 +1,60 @@
+import type { PostSummaryOutput } from '../../modules/post/use-cases';
+import { blogSiteDescription, blogSiteName } from '../siteMetadata';
+
+interface RssFeedOptions {
+  baseUrl: string;
+  posts: PostSummaryOutput[];
+}
+
+export function buildRssFeed({ baseUrl, posts }: RssFeedOptions): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '');
+  const items = posts.map((post) => buildRssItem(post, normalizedBaseUrl));
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0">',
+    '<channel>',
+    `<title>${escapeXml(blogSiteName)}</title>`,
+    `<link>${escapeXml(`${normalizedBaseUrl}/blog`)}</link>`,
+    `<description>${escapeXml(blogSiteDescription)}</description>`,
+    '<language>ja</language>',
+    `<lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,
+    ...items,
+    '</channel>',
+    '</rss>',
+  ].join('\n');
+}
+
+export function escapeXml(value: string): string {
+  return value.replace(/[<>&'"]/g, (character) => {
+    switch (character) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case "'":
+        return '&apos;';
+      case '"':
+        return '&quot;';
+      default:
+        return character;
+    }
+  });
+}
+
+function buildRssItem(post: PostSummaryOutput, baseUrl: string): string {
+  const postUrl = `${baseUrl}/blog/${post.slug}`;
+  const description = post.excerpt ?? '';
+
+  return [
+    '<item>',
+    `<title>${escapeXml(post.title)}</title>`,
+    `<link>${escapeXml(postUrl)}</link>`,
+    `<description>${escapeXml(description)}</description>`,
+    `<pubDate>${new Date(post.releaseDate).toUTCString()}</pubDate>`,
+    `<guid isPermaLink="true">${escapeXml(postUrl)}</guid>`,
+    '</item>',
+  ].join('\n');
+}

--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -3,18 +3,24 @@ import { GoogleScripts } from '../components/google-scripts/GoogleScripts';
 import { PageScrollArea } from '../components/page-scroll-area/PageScrollArea';
 import { ReactQueryClientProvider } from '../components/react-query-client-provider/ReactQueryClientProvider';
 import { Toaster } from '../components/toaster/Toaster';
+import { getBlogSiteBaseUrl } from './siteMetadata';
 import './globals.css';
 
-const siteBaseUrl = process.env.BLOG_SITE_BASE_URL;
+const siteBaseUrl = getBlogSiteBaseUrl();
 
-if (!siteBaseUrl && process.env.NODE_ENV === 'production') {
+if (!process.env.BLOG_SITE_BASE_URL && process.env.NODE_ENV === 'production') {
   throw new Error(
     'BLOG_SITE_BASE_URL environment variable is required in production'
   );
 }
 
 export const metadata: Metadata = {
-  metadataBase: new URL(siteBaseUrl || 'http://localhost:3000'),
+  metadataBase: new URL(siteBaseUrl),
+  alternates: {
+    types: {
+      'application/rss+xml': '/feed.xml',
+    },
+  },
 };
 
 export default function RootLayout({

--- a/apps/blog/app/manifest.ts
+++ b/apps/blog/app/manifest.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+
+import {
+  blogSiteDescription,
+  blogSiteName,
+  blogThemeColor,
+} from './siteMetadata';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: blogSiteName,
+    short_name: 'K2.B.G Blog',
+    description: blogSiteDescription,
+    lang: 'ja',
+    start_url: '/blog',
+    scope: '/',
+    display: 'standalone',
+    background_color: '#ffffff',
+    theme_color: blogThemeColor,
+    icons: [
+      {
+        src: '/favicon.ico',
+        sizes: '16x16 32x32',
+        type: 'image/x-icon',
+      },
+    ],
+  };
+}

--- a/apps/blog/app/siteMetadata.ts
+++ b/apps/blog/app/siteMetadata.ts
@@ -1,0 +1,10 @@
+export const blogSiteName = 'K2.B.G Technology Blog';
+
+export const blogSiteDescription =
+  'エンジニアでなくてもテクノロジーを活用できる —— そんな情報を発信するブログです。非IT出身からエンジニアへ転身した筆者が、プログラミング・AI・自動化・UI/UXなど幅広いテーマを、わかりやすく解説します。';
+
+export const blogThemeColor = '#111827';
+
+export function getBlogSiteBaseUrl(): string {
+  return process.env.BLOG_SITE_BASE_URL || 'http://localhost:3000';
+}

--- a/apps/blog/biome.jsonc
+++ b/apps/blog/biome.jsonc
@@ -56,6 +56,7 @@
         "app/**/error.tsx",
         "app/**/global-error.tsx",
         "app/**/route.ts",
+        "app/manifest.ts",
         "app/robots.ts",
         "app/sitemap.ts"
       ],

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.db.test.ts
@@ -3,7 +3,7 @@ import {
   authors,
   posts,
 } from '../../../../../../infrastructure/drizzle/schema';
-import { PostType, ReleaseDate, Slug } from '../../../../domain';
+import { PostStatus, PostType, ReleaseDate, Slug } from '../../../../domain';
 import {
   createPost,
   createPosts,
@@ -96,6 +96,37 @@ describe('DrizzleFetchPostSummariesQueryService', () => {
 
     expect(result.totalCount).toBe(1);
     expect(result.posts.map((p) => p.id)).toEqual([article.id.getValue()]);
+  });
+
+  it('excludes posts whose status is not the requested status', async () => {
+    await seedAuthor();
+    const db = getTestDb();
+    const publishedArticle = createPost();
+    const draftArticle = createPost({
+      id: publishedArticle.id,
+      slug: Slug.create('draft-slug'),
+      status: PostStatus.DRAFT,
+    });
+    // Use a fresh id to avoid clobbering the published article on insert.
+    await db.insert(posts).values(toPersistence(publishedArticle));
+    await db.insert(posts).values({
+      ...toPersistence(draftArticle),
+      uuid: '550e8400-e29b-41d4-a716-446655440001',
+      slug: 'draft-only',
+    });
+    const sut = new DrizzleFetchPostSummariesQueryService(db);
+
+    const result = await sut.fetchPostSummaries({
+      page: 1,
+      pageSize: 10,
+      orderBy: 'desc',
+      status: PostStatus.PUBLISHED,
+    });
+
+    expect(result.totalCount).toBe(1);
+    expect(result.posts.map((p) => p.id)).toEqual([
+      publishedArticle.id.getValue(),
+    ]);
   });
 
   it('paginates with limit and offset and orders by releaseDate', async () => {

--- a/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts
+++ b/apps/blog/modules/post/adapters/output/query-services/drizzle/fetchPostSummariesQueryService.ts
@@ -1,4 +1,4 @@
-import { asc, count, desc, eq } from 'drizzle-orm';
+import { and, asc, count, desc, eq } from 'drizzle-orm';
 import type { DrizzleClient } from '../../../../../../infrastructure/drizzle/client';
 import {
   authors,
@@ -23,6 +23,9 @@ export class DrizzleFetchPostSummariesQueryService
     const { page, pageSize, orderBy } = params;
     const offset = (page - 1) * pageSize;
     const direction = orderBy === 'asc' ? asc : desc;
+    const whereClause = params.status
+      ? and(eq(posts.type, 'ARTICLE'), eq(posts.status, params.status))
+      : eq(posts.type, 'ARTICLE');
 
     try {
       const [rows, totalRow] = await Promise.all([
@@ -41,14 +44,11 @@ export class DrizzleFetchPostSummariesQueryService
           })
           .from(posts)
           .leftJoin(authors, eq(posts.authorId, authors.uuid))
-          .where(eq(posts.type, 'ARTICLE'))
+          .where(whereClause)
           .orderBy(direction(posts.releaseDate), direction(posts.uuid))
           .limit(pageSize)
           .offset(offset),
-        this.db
-          .select({ value: count() })
-          .from(posts)
-          .where(eq(posts.type, 'ARTICLE')),
+        this.db.select({ value: count() }).from(posts).where(whereClause),
       ]);
 
       return {

--- a/apps/blog/modules/post/use-cases/query/fetch-post-summaries/queryService.ts
+++ b/apps/blog/modules/post/use-cases/query/fetch-post-summaries/queryService.ts
@@ -1,9 +1,11 @@
+import type { PostStatus } from '../../../domain';
 import type { PostSummaryOutput, SortOrder } from '../../shared';
 
 export interface FetchPostSummariesParams {
   page: number;
   pageSize: number;
   orderBy: SortOrder;
+  status?: PostStatus;
 }
 
 export interface FetchPostSummariesResult {

--- a/apps/blog/modules/post/use-cases/query/fetch-post-summaries/useCase.test.ts
+++ b/apps/blog/modules/post/use-cases/query/fetch-post-summaries/useCase.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PostStatus } from '../../../domain';
 import { InvalidPaginationError } from '../../shared';
 import {
   createPostSummaryOutput,
@@ -43,6 +44,24 @@ describe('FetchPostSummaries', () => {
         page: 1,
         pageSize: 10,
         orderBy: 'desc',
+        status: undefined,
+      });
+    });
+
+    it('passes status filter to the query service', async () => {
+      const fetchPostSummaries = vi
+        .fn()
+        .mockResolvedValue({ posts: [], totalCount: 0 });
+      const queryService = createMockQueryService({ fetchPostSummaries });
+      const sut = new FetchPostSummaries(queryService);
+
+      await sut.execute({ status: PostStatus.PUBLISHED });
+
+      expect(fetchPostSummaries).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        orderBy: 'desc',
+        status: PostStatus.PUBLISHED,
       });
     });
 

--- a/apps/blog/modules/post/use-cases/query/fetch-post-summaries/useCase.ts
+++ b/apps/blog/modules/post/use-cases/query/fetch-post-summaries/useCase.ts
@@ -1,3 +1,4 @@
+import type { PostStatus } from '../../../domain';
 import {
   InvalidPaginationError,
   type PaginatedResult,
@@ -10,6 +11,7 @@ export interface FetchPostSummariesInput {
   page?: number;
   pageSize?: number;
   orderBy?: SortOrder;
+  status?: PostStatus;
 }
 
 export type FetchPostSummariesOutput = PaginatedResult<PostSummaryOutput>;
@@ -32,6 +34,7 @@ export class FetchPostSummaries {
     const page = input.page ?? DEFAULT_PAGE;
     const pageSize = input.pageSize ?? DEFAULT_PAGE_SIZE;
     const orderBy = input.orderBy ?? DEFAULT_ORDER;
+    const { status } = input;
 
     this.validatePagination(page, pageSize);
 
@@ -39,6 +42,7 @@ export class FetchPostSummaries {
       page,
       pageSize,
       orderBy,
+      status,
     });
 
     const totalPages = Math.ceil(totalCount / pageSize);


### PR DESCRIPTION
## Summary

Fills the blog's standard discoverability gaps: RSS feed, web manifest, and OG metadata for the concept/contact pages.

### What changed?

- `apps/blog/app/feed.xml/route.ts` — RSS 2.0 feed generated from published posts via `createFetchPostSummariesUseCase()` (route → use-case only), `application/rss+xml` content type, 1h revalidate + SWR caching. `rss.ts` is a pure XML builder with full entity escaping; both covered by unit tests.
- `apps/blog/app/manifest.ts` — Next.js `MetadataRoute.Manifest` with name/description/lang/display/colors, referencing the existing `favicon.ico` (the repo has no 192/512 icon source assets — flagged below).
- OG + Twitter metadata added to `concept` and `contact` pages, following the post-page pattern and using `getDefaultOgImageUrl()`.
- `apps/blog/app/siteMetadata.ts` — shared site constants (`blogSiteName`, `getBlogSiteBaseUrl()`, …) now used by layout, manifest, feed, and both OG pages.
- Layout advertises the feed via `alternates.types['application/rss+xml']`.
- `fetch-post-summaries` use-case/port/Drizzle adapter accept an optional `status?: PostStatus` (needed to filter the feed to published posts). Backward compatible — omitting it reproduces the prior query exactly.

### Why was this changed?

The 2026-07 audit found no feed (readers can't subscribe), no manifest/icons, and share cards without title/description/image on concept/contact.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

`rss.test.ts` (escaping, feed rendering) and `route.test.ts` (headers/body) added.

### How to Test

1. `pnpm -F blog test`
2. `pnpm -F blog dev` → `curl http://localhost:3000/feed.xml` (valid RSS 2.0), `curl http://localhost:3000/manifest.webmanifest`
3. View source on /concept and /contact → complete OG/Twitter tags

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

`pnpm -F blog test`: 106 files / 951 tests pass (including the new feed tests). Full `next build` not run locally (needs Notion/DB env); feed shape validated at the route level by unit tests.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Related Issues

Closes #338

## Additional Context

Found in the 2026-07 repository audit. Icon gap: `apps/blog/public` has no logo/192/512 source assets, so the manifest references `favicon.ico` only; PWA-grade icons need a source logo first (worth a small follow-up issue).
