### PR TITLE
♻️ Refactor: #336 Fix layer and type-safety boundary violations

### DIFF
--- a/apps/blog/infrastructure/di/contact.ts
+++ b/apps/blog/infrastructure/di/contact.ts
@@ -1,6 +1,10 @@
+import { HandlebarsEmailTemplateRenderer } from '../../modules/contact/adapters';
 import { SendEmail } from '../../modules/contact/use-cases';
 import { getAwsSesEmailSender } from '../aws-ses';
 
 export function createSendEmailUseCase(): SendEmail {
-  return new SendEmail(getAwsSesEmailSender());
+  return new SendEmail(
+    getAwsSesEmailSender(),
+    new HandlebarsEmailTemplateRenderer()
+  );
 }

--- a/apps/blog/infrastructure/notion/index.ts
+++ b/apps/blog/infrastructure/notion/index.ts
@@ -14,6 +14,11 @@ export {
 } from './client';
 
 export {
+  filterFullPageObjectResponses,
+  isFullPageObjectResponse,
+} from './pageGuards';
+
+export {
   getAllFileUrls,
   getDate,
   getFirstFileUrl,

--- a/apps/blog/infrastructure/notion/pageGuards.test.ts
+++ b/apps/blog/infrastructure/notion/pageGuards.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  filterFullPageObjectResponses,
+  isFullPageObjectResponse,
+} from './pageGuards';
+
+const fullPage = {
+  object: 'page',
+  id: 'full-page-id',
+  url: 'https://www.notion.so/full-page-id',
+  properties: {},
+} as const;
+
+const partialPage = {
+  object: 'page',
+  id: 'partial-page-id',
+} as const;
+
+describe('Notion page guards', () => {
+  describe('isFullPageObjectResponse', () => {
+    it.each([
+      { result: fullPage, expected: true },
+      { result: partialPage, expected: false },
+    ])(
+      'returns $expected when checking $result.id',
+      ({ result, expected }) => {
+        const sut = isFullPageObjectResponse;
+
+        const isFullPageResult = sut(result);
+
+        expect(isFullPageResult).toBe(expected);
+      }
+    );
+  });
+
+  describe('filterFullPageObjectResponses', () => {
+    it('returns only full pages when query results include partial pages', () => {
+      const sut = filterFullPageObjectResponses;
+      const queryResults = [fullPage, partialPage];
+
+      const filteredPages = sut(queryResults);
+
+      expect(filteredPages).toEqual([fullPage]);
+    });
+  });
+});

--- a/apps/blog/infrastructure/notion/pageGuards.ts
+++ b/apps/blog/infrastructure/notion/pageGuards.ts
@@ -1,0 +1,19 @@
+import { isFullPage } from '@notionhq/client';
+import type {
+  PageObjectResponse,
+  QueryDatabaseResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+type QueryDatabaseResult = QueryDatabaseResponse['results'][number];
+
+export function isFullPageObjectResponse(
+  result: QueryDatabaseResult
+): result is PageObjectResponse {
+  return isFullPage(result);
+}
+
+export function filterFullPageObjectResponses(
+  results: QueryDatabaseResponse['results']
+): PageObjectResponse[] {
+  return results.filter(isFullPageObjectResponse);
+}

--- a/apps/blog/modules/affiliate/adapters/output/external-sources/notion/externalImageSource.ts
+++ b/apps/blog/modules/affiliate/adapters/output/external-sources/notion/externalImageSource.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@notionhq/client';
-import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type {
   ExternalImageSource,
   ImageSourceRecord,
@@ -32,8 +32,8 @@ export class NotionAffiliateExternalImageSource implements ExternalImageSource {
         },
       });
 
-      const sources = database.results
-        .map((page) => notionPageToImageSource(page as PageObjectResponse))
+      const sources = filterFullPageObjectResponses(database.results)
+        .map((page) => notionPageToImageSource(page))
         .filter((item): item is ImageSource => item !== null)
         .map((item) => ({
           id: item.id.getValue(),

--- a/apps/blog/modules/affiliate/adapters/output/query-services/notion/fetchAllImageSourcesQueryService.ts
+++ b/apps/blog/modules/affiliate/adapters/output/query-services/notion/fetchAllImageSourcesQueryService.ts
@@ -1,6 +1,6 @@
 import type { Client } from '@notionhq/client';
-import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type { ImageSource } from '../../../../domain';
 import type { FetchAllImageSourcesQueryService } from '../../../../use-cases/query/fetch-all-image-sources/queryService';
 import { affiliateLogger, ExternalSourceError } from '../../../shared';
@@ -28,8 +28,8 @@ export class NotionFetchAllImageSourcesQueryService
         },
       });
 
-      const sources = database.results
-        .map((page) => notionPageToImageSource(page as PageObjectResponse))
+      const sources = filterFullPageObjectResponses(database.results)
+        .map((page) => notionPageToImageSource(page))
         .filter((source): source is ImageSource => source !== null);
       affiliateLogger.info(
         { count: sources.length },

--- a/apps/blog/modules/affiliate/adapters/output/repositories/notion/affiliateRepository.ts
+++ b/apps/blog/modules/affiliate/adapters/output/repositories/notion/affiliateRepository.ts
@@ -1,6 +1,7 @@
 import { APIResponseError, type Client } from '@notionhq/client';
 import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type {
   Affiliate,
   AffiliateId,
@@ -101,8 +102,8 @@ export class NotionAffiliateRepository implements AffiliateRepository {
         },
       });
 
-      const sources = database.results
-        .map((page) => notionPageToImageSource(page as PageObjectResponse))
+      const sources = filterFullPageObjectResponses(database.results)
+        .map((page) => notionPageToImageSource(page))
         .filter((source): source is ImageSource => source !== null);
       affiliateLogger.info(
         { count: sources.length },

--- a/apps/blog/modules/contact/adapters/index.ts
+++ b/apps/blog/modules/contact/adapters/index.ts
@@ -1,2 +1,2 @@
-export { AwsSesEmailSender } from './output';
+export { AwsSesEmailSender, HandlebarsEmailTemplateRenderer } from './output';
 export { generateHtmlTemplate } from './shared';

--- a/apps/blog/modules/contact/adapters/output/index.ts
+++ b/apps/blog/modules/contact/adapters/output/index.ts
@@ -1,1 +1,2 @@
 export { AwsSesEmailSender } from './email-services';
+export { HandlebarsEmailTemplateRenderer } from './template-renderers';

--- a/apps/blog/modules/contact/adapters/output/template-renderers/handlebars/handlebarsEmailTemplateRenderer.test.ts
+++ b/apps/blog/modules/contact/adapters/output/template-renderers/handlebars/handlebarsEmailTemplateRenderer.test.ts
@@ -1,0 +1,84 @@
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Contact } from '../../../../domain';
+import { RepositoryError } from '../../../shared';
+import { HandlebarsEmailTemplateRenderer } from './handlebarsEmailTemplateRenderer';
+
+const { mockGenerateHtmlTemplate } = vi.hoisted(() => ({
+  mockGenerateHtmlTemplate: vi.fn(),
+}));
+
+vi.mock('../../../shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../shared')>();
+  return {
+    ...actual,
+    generateHtmlTemplate: mockGenerateHtmlTemplate,
+  };
+});
+
+function createContact(): Contact {
+  return Contact.create({
+    name: 'John Doe',
+    email: 'john@example.com',
+    message: 'Test message',
+  });
+}
+
+describe('HandlebarsEmailTemplateRenderer', () => {
+  const originalCompanyLogoUrl = process.env.COMPANY_LOGO_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15'));
+    process.env.COMPANY_LOGO_URL = 'https://example.com/logo.png';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.COMPANY_LOGO_URL = originalCompanyLogoUrl;
+  });
+
+  describe('render', () => {
+    it('returns the rendered template mapped from the contact', () => {
+      mockGenerateHtmlTemplate.mockReturnValue('<html>Rendered</html>');
+      const sut = new HandlebarsEmailTemplateRenderer();
+      const contact = createContact();
+
+      const result = sut.render(contact);
+
+      expect(result).toBe('<html>Rendered</html>');
+      expect(mockGenerateHtmlTemplate).toHaveBeenCalledTimes(1);
+      const [filePath, templateContext] = mockGenerateHtmlTemplate.mock
+        .calls[0] as [string, Record<string, unknown>];
+      expect(filePath).toBe(
+        path.join(process.cwd(), 'app', '_mail-templates', 'contact.hbs')
+      );
+      expect(templateContext).toEqual({
+        name: 'John Doe',
+        message: 'Test message',
+        year: '2024',
+        companyLogoUrl: 'https://example.com/logo.png',
+      });
+    });
+
+    it('throws RepositoryError when generateHtmlTemplate fails', () => {
+      const originalError = new Error('Template file not found');
+      mockGenerateHtmlTemplate.mockImplementation(() => {
+        throw originalError;
+      });
+      const sut = new HandlebarsEmailTemplateRenderer();
+      const contact = createContact();
+
+      expect(() => sut.render(contact)).toThrow(RepositoryError);
+      expect(() => sut.render(contact)).toThrow(
+        'Failed to render email template'
+      );
+      expect(() => sut.render(contact)).toThrow(
+        expect.objectContaining({ cause: originalError })
+      );
+    });
+  });
+});

--- a/apps/blog/modules/contact/adapters/output/template-renderers/handlebars/handlebarsEmailTemplateRenderer.ts
+++ b/apps/blog/modules/contact/adapters/output/template-renderers/handlebars/handlebarsEmailTemplateRenderer.ts
@@ -1,0 +1,23 @@
+import { format } from 'date-fns';
+import path from 'path';
+
+import type { Contact, EmailTemplateRenderer } from '../../../../domain';
+import { generateHtmlTemplate, RepositoryError } from '../../../shared';
+
+export class HandlebarsEmailTemplateRenderer implements EmailTemplateRenderer {
+  render(contact: Contact): string {
+    try {
+      return generateHtmlTemplate(
+        path.join(process.cwd(), 'app', '_mail-templates', 'contact.hbs'),
+        {
+          name: contact.name.getValue(),
+          message: contact.message.getValue(),
+          year: format(new Date(), 'yyyy'),
+          companyLogoUrl: process.env.COMPANY_LOGO_URL ?? '',
+        }
+      );
+    } catch (error) {
+      throw new RepositoryError('Failed to render email template', error);
+    }
+  }
+}

--- a/apps/blog/modules/contact/adapters/output/template-renderers/handlebars/index.ts
+++ b/apps/blog/modules/contact/adapters/output/template-renderers/handlebars/index.ts
@@ -1,0 +1,1 @@
+export { HandlebarsEmailTemplateRenderer } from './handlebarsEmailTemplateRenderer';

--- a/apps/blog/modules/contact/adapters/output/template-renderers/index.ts
+++ b/apps/blog/modules/contact/adapters/output/template-renderers/index.ts
@@ -1,0 +1,1 @@
+export { HandlebarsEmailTemplateRenderer } from './handlebars';

--- a/apps/blog/modules/contact/adapters/shared/errors.ts
+++ b/apps/blog/modules/contact/adapters/shared/errors.ts
@@ -1,0 +1,9 @@
+export class RepositoryError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'RepositoryError';
+  }
+}

--- a/apps/blog/modules/contact/adapters/shared/index.ts
+++ b/apps/blog/modules/contact/adapters/shared/index.ts
@@ -1,2 +1,3 @@
+export { RepositoryError } from './errors';
 export { contactLogger } from './logger';
 export { generateHtmlTemplate } from './templateGenerator';

--- a/apps/blog/modules/contact/domain/index.ts
+++ b/apps/blog/modules/contact/domain/index.ts
@@ -1,5 +1,6 @@
 export { Contact } from './entities/contact';
 export * from './errors/errors';
 export type { EmailSender } from './repositories/emailSender';
+export type { EmailTemplateRenderer } from './repositories/emailTemplateRenderer';
 export type * from './types';
 export { Email, Message, Name } from './value-objects';

--- a/apps/blog/modules/contact/domain/repositories/emailTemplateRenderer.ts
+++ b/apps/blog/modules/contact/domain/repositories/emailTemplateRenderer.ts
@@ -1,0 +1,5 @@
+import type { Contact } from '../entities/contact';
+
+export interface EmailTemplateRenderer {
+  render(contact: Contact): string;
+}

--- a/apps/blog/modules/contact/index.ts
+++ b/apps/blog/modules/contact/index.ts
@@ -1,4 +1,12 @@
-export { AwsSesEmailSender, generateHtmlTemplate } from './adapters';
-export type { ContactPrimitives, EmailSender } from './domain';
+export {
+  AwsSesEmailSender,
+  generateHtmlTemplate,
+  HandlebarsEmailTemplateRenderer,
+} from './adapters';
+export type {
+  ContactPrimitives,
+  EmailSender,
+  EmailTemplateRenderer,
+} from './domain';
 export { Contact } from './domain';
 export { SendEmail, type SendEmailInput } from './use-cases';

--- a/apps/blog/modules/contact/use-cases/command/index.ts
+++ b/apps/blog/modules/contact/use-cases/command/index.ts
@@ -1,1 +1,6 @@
-export { type EmailSender, SendEmail, type SendEmailInput } from './send-email';
+export {
+  type EmailSender,
+  type EmailTemplateRenderer,
+  SendEmail,
+  type SendEmailInput,
+} from './send-email';

--- a/apps/blog/modules/contact/use-cases/command/send-email/emailTemplateRenderer.ts
+++ b/apps/blog/modules/contact/use-cases/command/send-email/emailTemplateRenderer.ts
@@ -1,0 +1,3 @@
+import type { EmailTemplateRenderer } from '../../../domain';
+
+export type { EmailTemplateRenderer };

--- a/apps/blog/modules/contact/use-cases/command/send-email/index.ts
+++ b/apps/blog/modules/contact/use-cases/command/send-email/index.ts
@@ -1,2 +1,3 @@
 export type { EmailSender } from './emailSender';
+export type { EmailTemplateRenderer } from './emailTemplateRenderer';
 export { SendEmail, type SendEmailInput } from './useCase';

--- a/apps/blog/modules/contact/use-cases/command/send-email/useCase.test.ts
+++ b/apps/blog/modules/contact/use-cases/command/send-email/useCase.test.ts
@@ -2,19 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Contact } from '../../../domain';
 import type { EmailSender } from './emailSender';
+import type { EmailTemplateRenderer } from './emailTemplateRenderer';
 import { SendEmail, type SendEmailInput } from './useCase';
-
-vi.mock('../../../adapters/shared', () => ({
-  generateHtmlTemplate: vi.fn().mockReturnValue('<html>Test Email</html>'),
-}));
-
-vi.mock('date-fns', () => ({
-  format: vi.fn().mockReturnValue('2024'),
-}));
 
 function createMockEmailSender(): EmailSender {
   return {
     send: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createFakeEmailTemplateRenderer(): EmailTemplateRenderer {
+  return {
+    render: vi.fn().mockReturnValue('<html>Test Email</html>'),
   };
 }
 
@@ -34,10 +33,19 @@ describe('SendEmail Use Case', () => {
   describe('execute', () => {
     it('creates contact and sends email with correct parameters', async () => {
       const mockEmailSender = createMockEmailSender();
-      const sut = new SendEmail(mockEmailSender);
+      const fakeEmailTemplateRenderer = createFakeEmailTemplateRenderer();
+      const sut = new SendEmail(mockEmailSender, fakeEmailTemplateRenderer);
       const input = createValidInput();
 
       await sut.execute(input);
+
+      expect(fakeEmailTemplateRenderer.render).toHaveBeenCalledTimes(1);
+
+      const [renderedContact] = vi.mocked(fakeEmailTemplateRenderer.render).mock
+        .calls[0] as [Contact];
+      expect(renderedContact.name.getValue()).toBe('John Doe');
+      expect(renderedContact.email.getValue()).toBe('john@example.com');
+      expect(renderedContact.message.getValue()).toBe('Test message');
 
       expect(mockEmailSender.send).toHaveBeenCalledTimes(1);
 
@@ -56,7 +64,8 @@ describe('SendEmail Use Case', () => {
 
     it('throws error when name is empty', async () => {
       const mockEmailSender = createMockEmailSender();
-      const sut = new SendEmail(mockEmailSender);
+      const fakeEmailTemplateRenderer = createFakeEmailTemplateRenderer();
+      const sut = new SendEmail(mockEmailSender, fakeEmailTemplateRenderer);
       const invalidInput: SendEmailInput = {
         name: '',
         email: 'john@example.com',
@@ -66,12 +75,14 @@ describe('SendEmail Use Case', () => {
       await expect(sut.execute(invalidInput)).rejects.toThrow(
         'Name cannot be empty'
       );
+      expect(fakeEmailTemplateRenderer.render).not.toHaveBeenCalled();
       expect(mockEmailSender.send).not.toHaveBeenCalled();
     });
 
     it('throws error when email format is invalid', async () => {
       const mockEmailSender = createMockEmailSender();
-      const sut = new SendEmail(mockEmailSender);
+      const fakeEmailTemplateRenderer = createFakeEmailTemplateRenderer();
+      const sut = new SendEmail(mockEmailSender, fakeEmailTemplateRenderer);
       const invalidInput: SendEmailInput = {
         name: 'John Doe',
         email: 'invalid-email',
@@ -81,6 +92,7 @@ describe('SendEmail Use Case', () => {
       await expect(sut.execute(invalidInput)).rejects.toThrow(
         'Invalid email format'
       );
+      expect(fakeEmailTemplateRenderer.render).not.toHaveBeenCalled();
       expect(mockEmailSender.send).not.toHaveBeenCalled();
     });
 
@@ -89,10 +101,26 @@ describe('SendEmail Use Case', () => {
       vi.mocked(mockEmailSender.send).mockRejectedValue(
         new Error('Email send failed')
       );
-      const sut = new SendEmail(mockEmailSender);
+      const fakeEmailTemplateRenderer = createFakeEmailTemplateRenderer();
+      const sut = new SendEmail(mockEmailSender, fakeEmailTemplateRenderer);
       const input = createValidInput();
 
       await expect(sut.execute(input)).rejects.toThrow('Email send failed');
+    });
+
+    it('propagates error when template rendering fails', async () => {
+      const mockEmailSender = createMockEmailSender();
+      const fakeEmailTemplateRenderer = createFakeEmailTemplateRenderer();
+      vi.mocked(fakeEmailTemplateRenderer.render).mockImplementation(() => {
+        throw new Error('Template render failed');
+      });
+      const sut = new SendEmail(mockEmailSender, fakeEmailTemplateRenderer);
+      const input = createValidInput();
+
+      await expect(sut.execute(input)).rejects.toThrow(
+        'Template render failed'
+      );
+      expect(mockEmailSender.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/blog/modules/contact/use-cases/command/send-email/useCase.ts
+++ b/apps/blog/modules/contact/use-cases/command/send-email/useCase.ts
@@ -1,9 +1,6 @@
-import { format } from 'date-fns';
-import path from 'path';
-
-import { generateHtmlTemplate } from '../../../adapters/shared';
 import { Contact } from '../../../domain';
 import type { EmailSender } from './emailSender';
+import type { EmailTemplateRenderer } from './emailTemplateRenderer';
 
 export interface SendEmailInput {
   name: string;
@@ -17,20 +14,15 @@ export interface SendEmailInput {
  * Sends a confirmation email to the contact form submitter.
  */
 export class SendEmail {
-  constructor(private readonly emailSender: EmailSender) {}
+  constructor(
+    private readonly emailSender: EmailSender,
+    private readonly emailTemplateRenderer: EmailTemplateRenderer
+  ) {}
 
   async execute(input: SendEmailInput): Promise<void> {
     const contact = Contact.create(input);
 
-    const emailBody = generateHtmlTemplate(
-      path.join(process.cwd(), 'app', '_mail-templates', 'contact.hbs'),
-      {
-        name: contact.name.getValue(),
-        message: contact.message.getValue(),
-        year: format(new Date(), 'yyyy'),
-        companyLogoUrl: process.env.COMPANY_LOGO_URL ?? '',
-      }
-    );
+    const emailBody = this.emailTemplateRenderer.render(contact);
 
     const subject = `${contact.name.getValue()} 様。お問合せいただきありがとうございます。`;
 

--- a/apps/blog/modules/contact/use-cases/index.ts
+++ b/apps/blog/modules/contact/use-cases/index.ts
@@ -1,1 +1,6 @@
-export { type EmailSender, SendEmail, type SendEmailInput } from './command';
+export {
+  type EmailSender,
+  type EmailTemplateRenderer,
+  SendEmail,
+  type SendEmailInput,
+} from './command';

--- a/apps/blog/modules/media/adapters/output/external-sources/notion/externalImageSource.ts
+++ b/apps/blog/modules/media/adapters/output/external-sources/notion/externalImageSource.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@notionhq/client';
-import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type {
   ExternalImageSource,
   ImageSourceRecord,
@@ -36,8 +36,8 @@ export class NotionMediaExternalImageSource implements ExternalImageSource {
         },
       });
 
-      const sources = database.results
-        .map((page) => notionPageToImageSource(page as PageObjectResponse))
+      const sources = filterFullPageObjectResponses(database.results)
+        .map((page) => notionPageToImageSource(page))
         .filter((item): item is ImageSource => item !== null)
         .map((item) => ({
           id: item.id.getValue(),

--- a/apps/blog/modules/media/adapters/output/query-services/notion/fetchAllImageSourcesQueryService.ts
+++ b/apps/blog/modules/media/adapters/output/query-services/notion/fetchAllImageSourcesQueryService.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@notionhq/client';
-import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type { ImageSource } from '../../../../domain';
 import type { FetchAllImageSourcesQueryService } from '../../../../use-cases/query/fetch-all-image-sources/queryService';
 import {
@@ -31,8 +31,8 @@ export class NotionFetchAllImageSourcesQueryService
         },
       });
 
-      const sources = database.results
-        .map((page) => notionPageToImageSource(page as PageObjectResponse))
+      const sources = filterFullPageObjectResponses(database.results)
+        .map((page) => notionPageToImageSource(page))
         .filter((source): source is ImageSource => source !== null);
       mediaLogger.info(
         { count: sources.length },

--- a/apps/blog/modules/media/adapters/output/repositories/notion/mediaRepository.ts
+++ b/apps/blog/modules/media/adapters/output/repositories/notion/mediaRepository.ts
@@ -1,6 +1,7 @@
 import { APIResponseError, type Client } from '@notionhq/client';
 import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type {
   ImageSource,
   Media,
@@ -60,8 +61,8 @@ export class NotionMediaRepository implements MediaRepository {
         },
       });
 
-      const sources = database.results
-        .map((page) => notionPageToImageSource(page as PageObjectResponse))
+      const sources = filterFullPageObjectResponses(database.results)
+        .map((page) => notionPageToImageSource(page))
         .filter((source): source is ImageSource => source !== null);
       mediaLogger.info(
         { count: sources.length },

--- a/apps/blog/modules/post/adapters/output/external-sources/notion/externalImageSource.ts
+++ b/apps/blog/modules/post/adapters/output/external-sources/notion/externalImageSource.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@notionhq/client';
-import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type {
   ExternalImageSource,
   ImageSourceRecord,
@@ -29,8 +29,8 @@ export class NotionExternalImageSource implements ExternalImageSource {
         },
       });
 
-      const sources = database.results
-        .map((page) => notionPageToImageSource(page as PageObjectResponse))
+      const sources = filterFullPageObjectResponses(database.results)
+        .map((page) => notionPageToImageSource(page))
         .filter((item): item is ImageSourceRecord => item !== null);
       postLogger.info(
         { count: sources.length },

--- a/apps/blog/modules/post/adapters/output/external-sources/notion/externalPostSource.ts
+++ b/apps/blog/modules/post/adapters/output/external-sources/notion/externalPostSource.ts
@@ -1,6 +1,7 @@
 import type { Client } from '@notionhq/client';
 import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import type { NotionToMarkdown } from 'notion-to-md';
+import { filterFullPageObjectResponses } from '../../../../../../infrastructure/notion';
 import type { Post } from '../../../../domain';
 import type { ExternalPostSource } from '../../../../use-cases';
 import { ExternalSourceError, postLogger } from '../../../shared';
@@ -57,11 +58,10 @@ export class NotionExternalPostSource implements ExternalPostSource {
       });
 
       const posts = await Promise.all(
-        database.results.map(async (page) => {
-          const pageResponse = page as PageObjectResponse;
+        filterFullPageObjectResponses(database.results).map(async (page) => {
           const mdBlocks = await this.n2m.pageToMarkdown(page.id);
           const content = this.n2m.toMarkdownString(mdBlocks).parent;
-          return notionPageToPost(pageResponse, content);
+          return notionPageToPost(page, content);
         })
       );
 

--- a/apps/blog/modules/post/adapters/shared/testing/factories.ts
+++ b/apps/blog/modules/post/adapters/shared/testing/factories.ts
@@ -86,6 +86,8 @@ export function createNotionPageResponse(
     object: 'page',
     created_time: '2024-01-15T00:00:00.000Z',
     last_edited_time: '2024-01-15T00:00:00.000Z',
+    url: 'https://notion.so/page',
+    public_url: null,
     properties: {
       content: {
         type: 'title',


### PR DESCRIPTION
## Summary

Fixes two boundary violations in the blog app: a use case depending on filesystem infrastructure, and unguarded Notion `databases.query` casts.

### What changed?

- New `EmailTemplateRenderer` port (`modules/contact/domain/repositories/emailTemplateRenderer.ts`), mirroring the existing `EmailSender` pattern. `SendEmail` now receives it via constructor injection; `use-cases/command/send-email/useCase.ts` no longer imports `generateHtmlTemplate` (or anything fs-touching).
- New adapter `HandlebarsEmailTemplateRenderer` (`adapters/output/template-renderers/handlebars/`) wrapping the existing fs-based template generation, with failures wrapped in `RepositoryError` (new `adapters/shared/errors.ts` for the contact module). Wired in `infrastructure/di/contact.ts`.
- New shared guard `infrastructure/notion/pageGuards.ts` (`isFullPageObjectResponse` / `filterFullPageObjectResponses`, built on the SDK's `isFullPage`) applied to all 8 `databases.query` call sites across post/affiliate/media adapters — partial page objects are now filtered instead of flowing through typed code with missing fields.

### Why was this changed?

The 2026-07 audit flagged the use-case → fs dependency (violating `domain ← use-cases ← adapters`) and 8+ unguarded `as PageObjectResponse` casts that would break silently on a Notion integration permission change.

## Type of Change

- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

`pageGuards.test.ts` (`it.each` full vs partial page + filtering) and a rewritten `send-email/useCase.test.ts` with a fake renderer (success, validation failures, sender failure, renderer failure — AAA, `sut` naming).

### How to Test

1. `pnpm -F blog test`
2. `rg "as PageObjectResponse" apps/blog/modules` → only guarded flows remain

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

`pnpm typecheck` / `pnpm lint` / `pnpm -F blog test` (105 files, 951 tests) all pass. No dependency changes.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Related Issues

Closes #336

## Additional Context

Found in the 2026-07 repository audit. Related: #323 tracks the equivalent unchecked casts on the Drizzle path.
