### PR TITLE
🐛 Fix: #347 Map Badge to real design tokens and export it from the barrel

### DIFF
--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,4 +1,5 @@
 export { Avatar } from './src/components/Avatar';
+export { Badge } from './src/components/Badge';
 export { Button, buttonVariants } from './src/components/Button';
 export { Dialog } from './src/components/Dialog';
 export { Drawer } from './src/components/Drawer';

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -4,6 +4,20 @@ import { Icon } from '../Icon';
 
 import { Badge } from '.';
 
+const colors = [
+  'main',
+  'accent',
+  'inherit',
+  'success',
+  'info',
+  'error',
+  'warning',
+  'dark',
+  'light',
+] as const;
+
+const variants = ['default', 'outline'] as const;
+
 const meta = {
   component: Badge,
   args: {
@@ -74,6 +88,29 @@ export const Border: Story = {
     variant: 'outline',
     color: 'error',
   },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-spacious p-4">
+      {variants.map((variant) => (
+        <div key={variant} className="flex flex-wrap items-center gap-normal">
+          {colors.map((color) => (
+            <span
+              key={`${variant}-${color}`}
+              className={`rounded-md p-2 ${
+                color === 'light' ? 'bg-base-black' : 'bg-base-white'
+              }`}
+            >
+              <Badge variant={variant} color={color}>
+                {color}
+              </Badge>
+            </span>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
 };
 
 // Regression coverage for the `render` prop: the rendered element must keep

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { twMerge } from 'tailwind-merge';
 
 const badgeVariants = cva(
-  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-main-default focus-visible:ring-main-default/30 focus-visible:ring-[3px] aria-invalid:border-error aria-invalid:ring-error/20 transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

Makes `Badge` actually usable: its variant styles referenced design tokens that don't exist in this design system, and it was missing from the package barrel.

### What changed?

- `Badge.tsx`: shadcn-derived token references replaced with real k2bg tokens — `focus-visible:border-ring focus-visible:ring-ring/50` → `focus-visible:border-main-default focus-visible:ring-main-default/30`, and `aria-invalid:*-destructive*` → `aria-invalid:border-error aria-invalid:ring-error/20` (the `error` semantic token). Variant API unchanged.
- `packages/ui/index.ts`: `Badge` exported from the barrel — `import { Badge } from 'ui'` now works.
- `Badge.stories.tsx`: new `Variants` story rendering every variant side by side to prove visible styling.

### Why was this changed?

The 2026-07 audit found the component effectively dead as shipped: unreachable from the public API and with focus/destructive styles resolving to nothing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Affected Applications

- [x] 🎨 UI package (`packages/ui/`)

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] No tests needed (explain why below)

`packages/ui` has no unit-test infrastructure on this branch (#340 adds it separately); variants are covered by the new Storybook story.

### How to Test

1. `pnpm -F ui storybook` → Badge → Variants story shows visible styling per variant
2. `import { Badge } from 'ui'` resolves

### Test Results

- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

`pnpm typecheck` and `pnpm -F ui lint` pass; `pnpm -F ui build-storybook` builds successfully. (One pre-existing unrelated type error in `HelperText.stories.tsx` under a strict direct `tsc --noEmit`, present before this change.)

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Storybook stories added/updated

## Related Issues

Closes #347

## Additional Context

Found in the 2026-07 repository audit. An initial broader `white` → `base-white` sweep was deliberately reverted to stay consistent with the Button sibling convention — the wider token cleanup is #349's scope.
