### PR TITLE
♻️ Refactor: #349 Replace raw palette colors with tokens and enforce barrel imports

### DIFF
--- a/apps/blog/components/markdown/MediaVideo.tsx
+++ b/apps/blog/components/markdown/MediaVideo.tsx
@@ -1,5 +1,5 @@
-import { VideoFilePlayer } from 'ui/src/components/Media/VideoFilePlayer';
-import { VideoStreamingPlayer } from 'ui/src/components/Media/VideoStreamingPlayer';
+import { VideoFilePlayer, VideoStreamingPlayer } from 'ui';
+
 import type { MediaOutput } from '../../modules/media/use-cases';
 
 interface MediaVideoProps {

--- a/apps/portfolio/components/ScrollHelper.tsx
+++ b/apps/portfolio/components/ScrollHelper.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useLayoutEffect, useState } from 'react';
-import { Icon } from 'ui';
-import { twMerge } from 'ui/src/utils/extendTailwindMerge';
+import { Icon, twMerge } from 'ui';
 
 import { useMatchMedia } from '../hooks/useMatchMedia';
 

--- a/apps/portfolio/components/Slider.tsx
+++ b/apps/portfolio/components/Slider.tsx
@@ -1,4 +1,5 @@
-import { twMerge } from 'ui/src/utils/extendTailwindMerge';
+import { twMerge } from 'ui';
+
 import styles from './Slider.module.css';
 
 type Props = React.ComponentPropsWithoutRef<'div'>;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.0",
   "main": "./index.ts",
   "types": "./index.ts",
+  "exports": {
+    ".": {
+      "types": "./index.ts",
+      "default": "./index.ts"
+    },
+    "./src/globals.css": "./src/globals.css"
+  },
   "license": "MIT",
   "scripts": {
     "lint": "biome check .",

--- a/packages/ui/src/components/Avatar/Fallback.tsx
+++ b/packages/ui/src/components/Avatar/Fallback.tsx
@@ -10,7 +10,7 @@ export function Fallback({
     <AvatarPrimitive.Fallback
       {...rest}
       className={cn(
-        'flex h-full w-full items-center justify-center rounded-full bg-gray-200',
+        'flex h-full w-full items-center justify-center rounded-full bg-base-light',
         className
       )}
     />

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -41,7 +41,7 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'main',
-        class: 'bg-main-default text-white hover:bg-main-default/90',
+        class: 'bg-main-default text-base-white hover:bg-main-default/90',
       },
       {
         variant: 'outline',
@@ -57,7 +57,7 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'accent',
-        class: 'bg-accent-default text-white hover:bg-accent-default/90',
+        class: 'bg-accent-default text-base-white hover:bg-accent-default/90',
       },
       {
         variant: 'outline',
@@ -88,7 +88,7 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'error',
-        class: 'bg-error text-white hover:bg-error/90',
+        class: 'bg-error text-base-white hover:bg-error/90',
       },
       {
         variant: 'outline',
@@ -103,7 +103,7 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'warning',
-        class: 'bg-warning text-white hover:bg-warning/90',
+        class: 'bg-warning text-base-white hover:bg-warning/90',
       },
       {
         variant: 'outline',
@@ -118,7 +118,7 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'info',
-        class: 'bg-info text-white hover:bg-info/90',
+        class: 'bg-info text-base-white hover:bg-info/90',
       },
       {
         variant: 'outline',
@@ -133,7 +133,7 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'success',
-        class: 'bg-success text-white hover:bg-success/90',
+        class: 'bg-success text-base-white hover:bg-success/90',
       },
       {
         variant: 'outline',
@@ -148,7 +148,7 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'dark',
-        class: 'bg-base-black text-white hover:bg-base-black/90',
+        class: 'bg-base-black text-base-white hover:bg-base-black/90',
       },
       {
         variant: 'outline',
@@ -163,17 +163,17 @@ export const buttonVariants = cva(
       {
         variant: 'default',
         color: 'light',
-        class: 'bg-white text-base-black hover:bg-white/90',
+        class: 'bg-base-white text-base-black hover:bg-base-white/90',
       },
       {
         variant: 'outline',
         color: 'light',
-        class: 'border-white/20 text-white hover:bg-white/10',
+        class: 'border-base-white/20 text-base-white hover:bg-base-white/10',
       },
       {
         variant: 'ghost',
         color: 'light',
-        class: 'text-white hover:bg-white/10',
+        class: 'text-base-white hover:bg-base-white/10',
       },
     ],
     defaultVariants: {

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -4,6 +4,8 @@ import { Button } from '../Button';
 
 import { Dialog } from '.';
 
+// `bg-gray-500` below is a decorative video-placeholder box (not real
+// component styling) and has no reasonable base-* token match; kept as-is.
 const meta = {
   component: Dialog,
   argTypes: {

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -26,8 +26,8 @@ export function Dialog({
     <DialogPrimitive.Root {...rest}>
       {isValidElement(trigger) && <DialogPrimitive.Trigger render={trigger} />}
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Backdrop className="fixed bg-black/50 inset-0" />
-        <DialogPrimitive.Popup className="flex flex-col gap-6 fixed top-[50%] left-[50%] w-max max-w-[calc(100%-2rem)] h-max max-h-[calc(100%-4rem)] translate-x-[-50%] translate-y-[-50%] rounded-xl p-normal bg-white focus:outline-hidden md:p-6">
+        <DialogPrimitive.Backdrop className="fixed bg-base-black/50 inset-0" />
+        <DialogPrimitive.Popup className="flex flex-col gap-6 fixed top-[50%] left-[50%] w-max max-w-[calc(100%-2rem)] h-max max-h-[calc(100%-4rem)] translate-x-[-50%] translate-y-[-50%] rounded-xl p-normal bg-base-white focus:outline-hidden md:p-6">
           <DialogPrimitive.Title
             className={twMerge(
               'text-body-r-sm leading-body-r-sm font-bold',

--- a/packages/ui/src/components/Drawer/Drawer.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.tsx
@@ -28,12 +28,12 @@ export function Drawer({
     <DrawerPrimitive.Root swipeDirection="right">
       {isValidElement(trigger) && <DrawerPrimitive.Trigger render={trigger} />}
       <DrawerPrimitive.Portal>
-        <DrawerPrimitive.Backdrop className="fixed bg-black/50 inset-0" />
+        <DrawerPrimitive.Backdrop className="fixed bg-base-black/50 inset-0" />
         <DrawerPrimitive.Viewport>
           <DrawerPrimitive.Popup
             {...rest}
             className={twMerge(
-              'grid auto-rows-max gap-5 fixed top-0 right-0 w-max h-full rounded-xl bg-white drop-shadow-xl',
+              'grid auto-rows-max gap-5 fixed top-0 right-0 w-max h-full rounded-xl bg-base-white drop-shadow-xl',
               styles.popup,
               className
             )}

--- a/packages/ui/src/components/DropdownMenu/Popup.tsx
+++ b/packages/ui/src/components/DropdownMenu/Popup.tsx
@@ -4,6 +4,8 @@ import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 
 import { cn } from '../../utils/cn';
 
+// `border-slate-100` is a deliberate exception: base-light's warm tint
+// differs enough from slate-100's cool tint that it is not a reasonable match.
 type Props = MenuPrimitive.Popup.Props;
 
 export function Popup({ children, className, ...rest }: Props) {
@@ -11,7 +13,7 @@ export function Popup({ children, className, ...rest }: Props) {
     <MenuPrimitive.Popup
       {...rest}
       className={cn(
-        'grid gap-normal p-normal min-w-56 bg-white border-2 border-slate-100 rounded-md shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]',
+        'grid gap-normal p-normal min-w-56 bg-base-white border-2 border-slate-100 rounded-md shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]',
         className
       )}
     >

--- a/packages/ui/src/components/Form/HelperText/HelperText.tsx
+++ b/packages/ui/src/components/Form/HelperText/HelperText.tsx
@@ -2,11 +2,13 @@ import { cva } from 'class-variance-authority';
 import { twMerge } from '../../../utils/extendTailwindMerge';
 import { type FormProps, useFormContext } from '../Control/Context';
 
+// `text-neutral-300` (disabled) is a deliberate exception: no base-* token is
+// a visually reasonable match for this disabled-state gray.
 const helperTextVariants = cva('text-caption leading-none', {
   variants: {
     color: {
       dark: 'text-base-default',
-      light: 'text-white',
+      light: 'text-base-white',
     },
     error: {
       true: ['text-error'],

--- a/packages/ui/src/components/Form/Input/Input.tsx
+++ b/packages/ui/src/components/Form/Input/Input.tsx
@@ -5,6 +5,8 @@ import type React from 'react';
 import { twMerge } from '../../../utils/extendTailwindMerge';
 import { type FormProps, useFormContext } from '../Control/Context';
 
+// `neutral-300` (disabled) is a deliberate exception: no base-* token is a
+// visually reasonable match for this disabled-state gray.
 const inputVariants = cva(
   'appearance-none focus-visible:border-ring focus-visible:ring-[3px] border rounded-md px-2 py-3 w-full text-body-r-sm leading-none',
   {
@@ -12,7 +14,7 @@ const inputVariants = cva(
       color: {
         dark: 'focus-visible:ring-base-default/30 border-base-default/50 text-base-default placeholder-base-default/50',
         light:
-          'focus-visible:ring-white/30 border-white/50 text-white placeholder-white/50',
+          'focus-visible:ring-base-white/30 border-base-white/50 text-base-white placeholder-base-white/50',
       },
       error: {
         true: ['border-error focus-visible:ring-error/30'],

--- a/packages/ui/src/components/Form/Label/Label.tsx
+++ b/packages/ui/src/components/Form/Label/Label.tsx
@@ -4,11 +4,13 @@ import { cva } from 'class-variance-authority';
 import { twMerge } from '../../../utils/extendTailwindMerge';
 import { type FormProps, useFormContext } from '../Control/Context';
 
+// `text-neutral-300` (disabled) is a deliberate exception: no base-* token is
+// a visually reasonable match for this disabled-state gray.
 const labelVariants = cva('text-body-b-sm font-bold', {
   variants: {
     color: {
       dark: 'text-base-black',
-      light: 'text-white',
+      light: 'text-base-white',
     },
     error: {
       true: ['text-error'],

--- a/packages/ui/src/components/Form/Textarea/Textarea.tsx
+++ b/packages/ui/src/components/Form/Textarea/Textarea.tsx
@@ -4,6 +4,8 @@ import { cva } from 'class-variance-authority';
 import { twMerge } from '../../../utils/extendTailwindMerge';
 import { type FormProps, useFormContext } from '../Control/Context';
 
+// `neutral-300` (disabled) is a deliberate exception: no base-* token is a
+// visually reasonable match for this disabled-state gray.
 const inputVariants = cva(
   'appearance-none focus-visible:border-ring focus-visible:ring-[3px] border rounded-md px-2 py-3 w-full min-h-[3lh] max-h-[10lh] text-body-r-sm field-sizing-content',
   {
@@ -11,7 +13,7 @@ const inputVariants = cva(
       color: {
         dark: 'focus-visible:ring-base-default/30 border-base-default/50 text-base-default placeholder-base-default/50',
         light:
-          'focus-visible:ring-white/30 border-white/50 text-white placeholder-white/50',
+          'focus-visible:ring-base-white/30 border-base-white/50 text-base-white placeholder-base-white/50',
       },
       error: {
         true: ['border-error focus-visible:ring-error/30'],

--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -3,6 +3,9 @@ import { Button } from '../Button';
 
 import { Popover } from '.';
 
+// `text-slate-500` below is decorative demo copy only (not real component
+// styling) and has no reasonable base-* token match; kept as-is.
+
 const meta = {
   component: Popover,
   argTypes: {
@@ -152,7 +155,7 @@ export const Dark: Story = {
             <div className="grid gap-4">
               <div className="space-y-2">
                 <h4 className="font-medium leading-none">Dimensions</h4>
-                <p className="text-sm text-white/60">
+                <p className="text-sm text-base-white/60">
                   Set the dimensions for the layer.
                 </p>
               </div>
@@ -180,7 +183,7 @@ export const DarkWithForm: Story = {
             <div className="grid gap-4">
               <div className="space-y-2">
                 <h4 className="font-medium leading-none">Dimensions</h4>
-                <p className="text-sm text-white/60">
+                <p className="text-sm text-base-white/60">
                   Set the dimensions for the layer.
                 </p>
               </div>
@@ -192,7 +195,7 @@ export const DarkWithForm: Story = {
                   <input
                     id="darkWidth"
                     defaultValue="100%"
-                    className="col-span-2 h-8 rounded-md border border-white/30 bg-transparent px-3 text-sm text-white placeholder-white/50"
+                    className="col-span-2 h-8 rounded-md border border-base-white/30 bg-transparent px-3 text-sm text-base-white placeholder-base-white/50"
                   />
                 </div>
                 <div className="grid grid-cols-3 items-center gap-4">
@@ -202,7 +205,7 @@ export const DarkWithForm: Story = {
                   <input
                     id="darkMaxWidth"
                     defaultValue="300px"
-                    className="col-span-2 h-8 rounded-md border border-white/30 bg-transparent px-3 text-sm text-white placeholder-white/50"
+                    className="col-span-2 h-8 rounded-md border border-base-white/30 bg-transparent px-3 text-sm text-base-white placeholder-base-white/50"
                   />
                 </div>
                 <div className="grid grid-cols-3 items-center gap-4">
@@ -212,7 +215,7 @@ export const DarkWithForm: Story = {
                   <input
                     id="darkHeight"
                     defaultValue="25px"
-                    className="col-span-2 h-8 rounded-md border border-white/30 bg-transparent px-3 text-sm text-white placeholder-white/50"
+                    className="col-span-2 h-8 rounded-md border border-base-white/30 bg-transparent px-3 text-sm text-base-white placeholder-base-white/50"
                   />
                 </div>
               </div>

--- a/packages/ui/src/components/Popover/Popup.tsx
+++ b/packages/ui/src/components/Popover/Popup.tsx
@@ -10,8 +10,8 @@ const variants = cva(
   {
     variants: {
       color: {
-        light: 'bg-white border-base-default/20 text-base-black',
-        dark: 'bg-base-black border-base-black/50 text-white',
+        light: 'bg-base-white border-base-default/20 text-base-black',
+        dark: 'bg-base-black border-base-black/50 text-base-white',
       },
     },
     defaultVariants: {

--- a/packages/ui/src/components/ScrollArea/ScrollBar/ScrollBar.tsx
+++ b/packages/ui/src/components/ScrollArea/ScrollBar/ScrollBar.tsx
@@ -27,7 +27,7 @@ export function ScrollBar({
         className
       )}
     >
-      <ScrollAreaPrimitive.Thumb className="relative flex-1 rounded-full bg-neutral-500/40" />
+      <ScrollAreaPrimitive.Thumb className="relative flex-1 rounded-full bg-base-default/40" />
     </ScrollAreaPrimitive.Scrollbar>
   );
 }

--- a/packages/ui/src/components/Skelton/Box/Box.tsx
+++ b/packages/ui/src/components/Skelton/Box/Box.tsx
@@ -1,5 +1,9 @@
 import { twMerge } from '../../../utils/extendTailwindMerge';
 
+// `bg-gray-300` is a deliberate exception to the design-token color rule: no
+// base-* token is a visually reasonable match (base-light is much lighter,
+// base-default/base-dark are much darker/warmer). See packages/ui/src/components/Skelton/Round/Round.tsx
+// for the same exception.
 type LineProps = React.ComponentPropsWithoutRef<'div'>;
 
 export function Box(props: LineProps) {

--- a/packages/ui/src/components/Skelton/Line/Line.tsx
+++ b/packages/ui/src/components/Skelton/Line/Line.tsx
@@ -6,6 +6,6 @@ export function Line(props: Props) {
   const { className = 'py-0.5' } = props;
 
   return (
-    <div {...props} className={twMerge('bg-gray-200 rounded-5', className)} />
+    <div {...props} className={twMerge('bg-base-light rounded-5', className)} />
   );
 }

--- a/packages/ui/src/components/Skelton/Round/Round.tsx
+++ b/packages/ui/src/components/Skelton/Round/Round.tsx
@@ -1,5 +1,7 @@
 import { twMerge } from '../../../utils/extendTailwindMerge';
 
+// `bg-gray-300` is a deliberate exception to the design-token color rule: no
+// base-* token is a visually reasonable match. See Skelton/Box/Box.tsx.
 type Props = React.PropsWithChildren & React.HTMLAttributes<HTMLDivElement>;
 
 export function Round(props: Props) {

--- a/packages/ui/src/components/Skelton/Skelton.stories.tsx
+++ b/packages/ui/src/components/Skelton/Skelton.stories.tsx
@@ -4,6 +4,8 @@ import { Icon } from '../Icon';
 
 import { Skelton } from '.';
 
+// `border-gray-200` below is a decorative demo card border (not real
+// component styling) and has no reasonable base-* token match; kept as-is.
 const meta = {
   component: Skelton,
   parameters: {

--- a/packages/ui/src/components/Toaster/Toaster.tsx
+++ b/packages/ui/src/components/Toaster/Toaster.tsx
@@ -12,7 +12,7 @@ export function Toaster(props: ToasterProps) {
       className="toaster group !font-original !text-button-r-sm"
       toastOptions={{
         classNames: {
-          toast: 'group toast !backdrop-blur-sm !bg-white/10',
+          toast: 'group toast !backdrop-blur-sm !bg-base-white/10',
         },
       }}
       icons={{

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -44,6 +44,11 @@
     cursor: pointer;
   }
 
+  /*
+   * `--color-gray-200` here is Tailwind's own v4 upgrade-guide recipe for
+   * restoring the v3 default border color, not a component color choice —
+   * deliberately left as-is (no base-* token substitution).
+   */
   *,
   ::after,
   ::before,


### PR DESCRIPTION
## Summary

Brings color usage and package entry points back under the design system's control: raw Tailwind palette classes replaced with design tokens (or documented as deliberate exceptions), deep `ui/src/...` imports fixed, and an `exports` map that makes them fail at resolution time.

### What changed?

- **Token replacements** across `packages/ui/src` (Toaster, Skelton.Line, Avatar.Fallback, Form Label/HelperText/Input/Textarea, Drawer, Dialog, Popover, DropdownMenu, Button, ScrollBar, and dark-demo story blocks): `white`/`black` classes → `base-white`/`base-black` equivalents; `gray-200` placeholder surfaces → `base-light`; `neutral-500/40` scrollbar thumb → `base-default/40`.
  - Note on values: `base-white` is `#f3f3f2` (~3/255 off pure white — imperceptible) and `base-black` is the design system's ink color `#474a4d`, already paired with raw white/black in production Button/Popover as the paper/ink surface pair, so this aligns usage with the established token semantics. Chromatic may show subtle diffs on Dialog/Drawer backdrops (`bg-black/50` → `bg-base-black/50`) — expected and intended.
- **Documented exceptions** (kept raw, one-line comment in each file): Skelton Box/Round `gray-300` (no token within range), disabled-state `neutral-300` in Form controls, DropdownMenu `border-slate-100` (cool tint has no warm-token match), `globals.css` `--color-gray-200` border-color reset (Tailwind v4's own upgrade-guide recipe), and story-only decorative colors.
- **Deep imports fixed** (all four occurrences): `MediaVideo.tsx` (blog), `ScrollHelper.tsx` / `Slider.tsx` (portfolio) now import from the `ui` barrel.
- **`exports` map** on `packages/ui`: `"."` → `./index.ts` plus `"./src/globals.css"` (both apps `@import` it — a subpath the audit's file count missed). Deep `ui/src/...` imports now fail typecheck: verified with a probe import producing `TS2307: Cannot find module 'ui/src/utils/extendTailwindMerge'`.
- Badge untouched (its token fix is #347).

### Why was this changed?

The 2026-07 audit found hardcoded palette classes (theme changes wouldn't propagate; Figma token set drifts from code) and unenforced package entry points.

## Type of Change

- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

Breaking only for out-of-repo consumers using deep `ui/src/...` paths; all in-repo usages are migrated in this PR.

## Affected Applications

- [x] 🎨 UI package (`packages/ui/`)
- [x] 📝 Blog app (`apps/blog/`)
- [x] 💼 Portfolio app (`apps/portfolio/`)

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] No tests needed (explain why below)

Class-string refactor with visual parity; Storybook/Chromatic is the verification surface. Resolution enforcement proven via the typecheck probe.

### How to Test

1. `pnpm typecheck && pnpm lint`
2. Add `import { twMerge } from 'ui/src/utils/extendTailwindMerge'` anywhere → typecheck fails with TS2307
3. Review Chromatic diffs (backdrop tint expected)

### Test Results

- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

`pnpm typecheck` (2/2), `pnpm lint` (4/4), `pnpm -F ui build-storybook` pass; `pnpm -F portfolio build` full production build passes (proves the `globals.css` exports subpath under Turbopack); blog compiles + typechecks (its static-page generation stops on a locally-missing `BLOG_SITE_BASE_URL`, unrelated).

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

**Breaking changes:** deep `ui/src/...` imports fail at resolution for any out-of-repo consumer. Migration: import from the `ui` barrel (everything previously deep-imported is re-exported there); CSS stays available at `ui/src/globals.css`.

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

Exceptions are documented inline where they live.

## Related Issues

Closes #349

## Additional Context

Found in the 2026-07 repository audit. Related: #347 (Badge tokens, parallel branch), #352 (Skelton→Skeleton rename touches the same directory on a parallel branch — merge-order rebase may be needed).
