### PR TITLE
🐛 Fix: #324 Discriminate post fetch errors and fail embeds soft

### DIFF
--- a/apps/blog/app/blog/[id]/[slug]/handlePostFetchError.test.ts
+++ b/apps/blog/app/blog/[id]/[slug]/handlePostFetchError.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PostNotFoundError,
+  UseCaseError,
+} from '../../../../modules/post/use-cases/shared';
+import { handlePostFetchError } from './handlePostFetchError';
+
+const { mockNotFound, mockWarn, mockError } = vi.hoisted(() => ({
+  mockNotFound: vi.fn(),
+  mockWarn: vi.fn(),
+  mockError: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: mockNotFound,
+}));
+
+vi.mock('../../../../modules/post/adapters/shared/logger', () => ({
+  postLogger: { warn: mockWarn, error: mockError },
+}));
+
+describe('handlePostFetchError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs a warning and calls notFound when the error is a UseCaseError', () => {
+    const postId = 'post-123';
+    const useCaseError = new PostNotFoundError(postId);
+
+    handlePostFetchError(useCaseError, postId);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      { err: useCaseError, id: postId },
+      'Post not found'
+    );
+    expect(mockError).not.toHaveBeenCalled();
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a bare UseCaseError as an expected not-found', () => {
+    const postId = 'post-123';
+    const useCaseError = new UseCaseError('boom');
+
+    handlePostFetchError(useCaseError, postId);
+
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('logs an error and calls notFound when the error is unexpected', () => {
+    const postId = 'post-123';
+    const unexpectedError = new Error('Database connection refused');
+
+    handlePostFetchError(unexpectedError, postId);
+
+    expect(mockError).toHaveBeenCalledWith(
+      { err: unexpectedError, id: postId },
+      'Failed to fetch post'
+    );
+    expect(mockWarn).not.toHaveBeenCalled();
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/blog/app/blog/[id]/[slug]/handlePostFetchError.ts
+++ b/apps/blog/app/blog/[id]/[slug]/handlePostFetchError.ts
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation';
+import { postLogger } from '../../../../modules/post/adapters/shared/logger';
+import { UseCaseError } from '../../../../modules/post/use-cases/shared';
+
+/**
+ * Discriminates a post fetch failure before falling back to `notFound()`:
+ * a `UseCaseError` (e.g. the post genuinely does not exist) is an expected
+ * application outcome and logs as a warning, while any other error is an
+ * unexpected infrastructure/mapping failure and logs as an error so an outage
+ * is never masked as a silent 404.
+ *
+ * @see .claude/rules/error-handling-guidelines.md (Next.js Page Boundary)
+ */
+export function handlePostFetchError(error: unknown, id: string): never {
+  if (error instanceof UseCaseError) {
+    postLogger.warn({ err: error, id }, 'Post not found');
+  } else {
+    postLogger.error({ err: error, id }, 'Failed to fetch post');
+  }
+
+  notFound();
+}

--- a/apps/blog/app/blog/[id]/[slug]/page.tsx
+++ b/apps/blog/app/blog/[id]/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import { ArticleHeading } from '../../../../components/article-heading/ArticleHeading';
 import { Markdown } from '../../../../components/markdown';
 import { PageLayout } from '../../../../components/page-layout';
@@ -14,6 +13,7 @@ import {
   createFetchPostUseCase,
   getDefaultOgImageUrl,
 } from '../../../../infrastructure/di';
+import { handlePostFetchError } from './handlePostFetchError';
 
 export const revalidate = 3600;
 
@@ -37,7 +37,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
 
   const fetchPost = createFetchPostUseCase();
-  const { post: article } = await fetchPost.execute({ id });
+  const { post: article } = await fetchPost
+    .execute({ id })
+    .catch((error) => handlePostFetchError(error, id));
 
   const ogImageUrl = article.ogImageUrl ?? getDefaultOgImageUrl();
 
@@ -72,9 +74,9 @@ export default async function Page({ params }: Props) {
 
   const fetchPost = createFetchPostUseCase();
 
-  const { post: article } = await fetchPost.execute({ id }).catch(() => {
-    notFound();
-  });
+  const { post: article } = await fetchPost
+    .execute({ id })
+    .catch((error) => handlePostFetchError(error, id));
 
   return (
     <PageLayout

--- a/apps/blog/components/instagram-timeline/InstagramTimeline.test.tsx
+++ b/apps/blog/components/instagram-timeline/InstagramTimeline.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaType } from '../../modules/social-feed/domain';
+import type { SocialPostOutput } from '../../modules/social-feed/use-cases/shared';
+import { InstagramTimeline } from './InstagramTimeline';
+
+const { mockExecute, mockLoggerError } = vi.hoisted(() => ({
+  mockExecute: vi.fn(),
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/di/social-feed', () => ({
+  createFetchFeedUseCase: () => ({ execute: mockExecute }),
+}));
+
+vi.mock('../../modules/social-feed/adapters/shared/logger', () => ({
+  socialFeedLogger: { error: mockLoggerError },
+}));
+
+vi.mock('next/image', () => ({
+  default: () => <div data-testid="instagram-image" />,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const createPostFixture = (id: string): SocialPostOutput => ({
+  id,
+  mediaUrl: `https://example.com/${id}.jpg`,
+  displayUrl: `https://example.com/${id}-display.jpg`,
+  permalink: `https://instagram.com/p/${id}`,
+  mediaType: MediaType.IMAGE,
+  timestamp: new Date('2026-01-01T00:00:00Z'),
+});
+
+describe('InstagramTimeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing and logs the cause when the feed fetch fails', async () => {
+    const fetchError = new Error('Instagram API is unavailable');
+    mockExecute.mockRejectedValue(fetchError);
+
+    const { container } = render(await InstagramTimeline());
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      { err: fetchError },
+      'Failed to fetch Instagram feed'
+    );
+  });
+
+  it('renders the empty-state message when the feed has no posts', async () => {
+    mockExecute.mockResolvedValue([]);
+
+    render(await InstagramTimeline());
+
+    expect(screen.getByText('新規投稿はありません')).toBeInTheDocument();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it('renders a link for each post when the feed loads', async () => {
+    const posts = [createPostFixture('post-1'), createPostFixture('post-2')];
+    mockExecute.mockResolvedValue(posts);
+
+    render(await InstagramTimeline());
+
+    expect(screen.getAllByRole('link')).toHaveLength(posts.length);
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/blog/components/instagram-timeline/InstagramTimeline.tsx
+++ b/apps/blog/components/instagram-timeline/InstagramTimeline.tsx
@@ -2,12 +2,22 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { createFetchFeedUseCase } from '../../infrastructure/di/social-feed';
+import { socialFeedLogger } from '../../modules/social-feed/adapters/shared/logger';
 
 const MAX_MEDIA_COUNT = 6;
 
 export async function InstagramTimeline() {
   const fetchFeed = createFetchFeedUseCase();
-  const posts = await fetchFeed.execute({ limit: MAX_MEDIA_COUNT });
+  const posts = await fetchFeed
+    .execute({ limit: MAX_MEDIA_COUNT })
+    .catch((error) => {
+      socialFeedLogger.error({ err: error }, 'Failed to fetch Instagram feed');
+      return null;
+    });
+
+  if (posts === null) {
+    return null;
+  }
 
   if (posts.length === 0) {
     return (

--- a/apps/blog/components/markdown/AffiliateEmb.test.tsx
+++ b/apps/blog/components/markdown/AffiliateEmb.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AffiliateType } from '../../modules/affiliate/domain';
+import type { AffiliateTextOutput } from '../../modules/affiliate/use-cases/shared';
+import { AffiliateEmb } from './AffiliateEmb';
+
+const { mockFetchAffiliate, mockFetchAffiliatesByIds, mockLoggerError } =
+  vi.hoisted(() => ({
+    mockFetchAffiliate: vi.fn(),
+    mockFetchAffiliatesByIds: vi.fn(),
+    mockLoggerError: vi.fn(),
+  }));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return { ...actual, cache: <T,>(fn: T): T => fn };
+});
+
+vi.mock('../../infrastructure/di/affiliate', () => ({
+  createFetchAffiliateUseCase: () => ({ execute: mockFetchAffiliate }),
+  createFetchAffiliatesByIdsUseCase: () => ({
+    execute: mockFetchAffiliatesByIds,
+  }),
+}));
+
+vi.mock('../../modules/affiliate/adapters/shared/logger', () => ({
+  affiliateLogger: { error: mockLoggerError },
+}));
+
+vi.mock('./AffiliateText', () => ({
+  AffiliateText: () => <div data-testid="affiliate-text" />,
+}));
+
+vi.mock('./AffiliateBanner', () => ({
+  AffiliateBanner: () => <div data-testid="affiliate-banner" />,
+}));
+
+vi.mock('./AffiliateProduct', () => ({
+  AffiliateProduct: () => <div data-testid="affiliate-product" />,
+}));
+
+const createTextAffiliateFixture = (): AffiliateTextOutput => ({
+  id: 'affiliate-1',
+  name: 'Sample affiliate',
+  type: AffiliateType.TEXT,
+  targetUrl: 'https://example.com',
+  provider: 'Example',
+});
+
+describe('AffiliateEmb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing and logs the cause when the affiliate fetch fails', async () => {
+    const id = 'affiliate-1';
+    const fetchError = new Error('Affiliate source is unavailable');
+    mockFetchAffiliate.mockRejectedValue(fetchError);
+
+    const { container } = render(await AffiliateEmb({ id }));
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      { err: fetchError, id },
+      'Failed to fetch affiliate embed'
+    );
+  });
+
+  it('renders the affiliate when the fetch succeeds', async () => {
+    const affiliate = createTextAffiliateFixture();
+    mockFetchAffiliate.mockResolvedValue({ affiliate });
+
+    render(await AffiliateEmb({ id: affiliate.id }));
+
+    expect(screen.getByTestId('affiliate-text')).toBeInTheDocument();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/blog/components/markdown/AffiliateEmb.tsx
+++ b/apps/blog/components/markdown/AffiliateEmb.tsx
@@ -3,6 +3,7 @@ import {
   createFetchAffiliatesByIdsUseCase,
   createFetchAffiliateUseCase,
 } from '../../infrastructure/di/affiliate';
+import { affiliateLogger } from '../../modules/affiliate/adapters/shared/logger';
 import { AffiliateType } from '../../modules/affiliate/domain';
 import { AffiliateBanner } from './AffiliateBanner';
 import { AffiliateProduct } from './AffiliateProduct';
@@ -38,12 +39,19 @@ interface SubProvider {
 export async function AffiliateEmb(props: AffiliateEmbProps) {
   const { id } = props;
 
-  const { affiliate } = await fetchAffiliateById(id);
+  const data = await loadAffiliateEmbData(id).catch((error) => {
+    affiliateLogger.error(
+      { err: error, id },
+      'Failed to fetch affiliate embed'
+    );
+    return null;
+  });
 
-  const affiliateSubProviders =
-    affiliate.type === AffiliateType.PRODUCT
-      ? await fetchSubProviders(affiliate.subProviderIds)
-      : [];
+  if (data === null) {
+    return null;
+  }
+
+  const { affiliate, affiliateSubProviders } = data;
 
   return (
     <div className="mt-8">
@@ -66,6 +74,21 @@ export async function AffiliateEmb(props: AffiliateEmbProps) {
       })()}
     </div>
   );
+}
+
+/**
+ * Loads the affiliate and, for product affiliates, its sub-providers.
+ * Isolated from rendering so the caller can fail soft on any fetch error.
+ */
+async function loadAffiliateEmbData(id: string) {
+  const { affiliate } = await fetchAffiliateById(id);
+
+  const affiliateSubProviders =
+    affiliate.type === AffiliateType.PRODUCT
+      ? await fetchSubProviders(affiliate.subProviderIds)
+      : [];
+
+  return { affiliate, affiliateSubProviders };
 }
 
 /**

--- a/apps/blog/components/markdown/MediaEmb.test.tsx
+++ b/apps/blog/components/markdown/MediaEmb.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaType } from '../../modules/media/domain';
+import type { MediaOutput } from '../../modules/media/use-cases';
+import { MediaEmb } from './MediaEmb';
+
+const { mockExecute, mockLoggerError } = vi.hoisted(() => ({
+  mockExecute: vi.fn(),
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('../../infrastructure/di/media', () => ({
+  createFetchMediaUseCase: () => ({ execute: mockExecute }),
+}));
+
+vi.mock('../../modules/media/adapters/shared/logger', () => ({
+  mediaLogger: { error: mockLoggerError },
+}));
+
+vi.mock('./MediaImage', () => ({
+  MediaImage: () => <div data-testid="media-image" />,
+}));
+
+vi.mock('./MediaVideo', () => ({
+  MediaVideo: () => <div data-testid="media-video" />,
+}));
+
+const createMediaFixture = (): MediaOutput => ({
+  id: 'media-1',
+  name: 'Sample media',
+  type: MediaType.IMAGE,
+  sourceFile: null,
+  sourceUrl: 'https://example.com/sample.png',
+  targetUrl: null,
+  width: 640,
+  height: 480,
+  extension: 'png',
+  effectiveSource: 'https://example.com/sample.png',
+});
+
+describe('MediaEmb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing and logs the cause when the media fetch fails', async () => {
+    const id = 'media-1';
+    const fetchError = new Error('Media source is unavailable');
+    mockExecute.mockRejectedValue(fetchError);
+
+    const { container } = render(await MediaEmb({ id }));
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      { err: fetchError, id },
+      'Failed to fetch media embed'
+    );
+  });
+
+  it('renders the media when the fetch succeeds', async () => {
+    const media = createMediaFixture();
+    mockExecute.mockResolvedValue({ media });
+
+    render(await MediaEmb({ id: media.id }));
+
+    expect(screen.getByTestId('media-image')).toBeInTheDocument();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/blog/components/markdown/MediaEmb.tsx
+++ b/apps/blog/components/markdown/MediaEmb.tsx
@@ -1,4 +1,5 @@
 import { createFetchMediaUseCase } from '../../infrastructure/di/media';
+import { mediaLogger } from '../../modules/media/adapters/shared/logger';
 import { MediaType } from '../../modules/media/domain';
 import { MediaImage } from './MediaImage';
 import { MediaVideo } from './MediaVideo';
@@ -11,7 +12,16 @@ export async function MediaEmb(props: MediaEmbProps) {
   const { id } = props;
 
   const fetchMedia = createFetchMediaUseCase();
-  const { media } = await fetchMedia.execute({ id });
+  const result = await fetchMedia.execute({ id }).catch((error) => {
+    mediaLogger.error({ err: error, id }, 'Failed to fetch media embed');
+    return null;
+  });
+
+  if (result === null) {
+    return null;
+  }
+
+  const { media } = result;
 
   return (
     <div className="flex justify-center mt-4">

--- a/apps/blog/infrastructure/di/post.ts
+++ b/apps/blog/infrastructure/di/post.ts
@@ -12,6 +12,7 @@ import {
   DrizzlePostBatchRepository,
   DrizzleSearchPostSummariesQueryService,
 } from '../../modules/post/adapters/output';
+import { postLogger } from '../../modules/post/adapters/shared';
 import { NotionMediaExternalImageSource } from '../../modules/media/adapters/output';
 import { NotionAffiliateExternalImageSource } from '../../modules/affiliate/adapters/output';
 import { FetchAllSlugs } from '../../modules/post/use-cases/query/fetch-all-slugs';
@@ -82,6 +83,7 @@ export function createSyncHeroImagesUseCase(): SyncHeroImages {
       new NotionMediaExternalImageSource(notionClient),
       new NotionAffiliateExternalImageSource(notionClient),
     ],
-    new CloudinaryImageRepository(cloudinary)
+    new CloudinaryImageRepository(cloudinary),
+    postLogger
   );
 }

--- a/apps/blog/modules/post/use-cases/index.ts
+++ b/apps/blog/modules/post/use-cases/index.ts
@@ -39,6 +39,7 @@ export {
 export {
   InvalidPaginationError,
   InvalidSearchQueryError,
+  type Logger,
   type OgImageUrlGenerator,
   type PaginatedResult,
   type PaginationInput,

--- a/apps/blog/modules/post/use-cases/shared/index.ts
+++ b/apps/blog/modules/post/use-cases/shared/index.ts
@@ -5,6 +5,7 @@ export {
   SyncError,
   UseCaseError,
 } from './errors';
+export type { Logger } from './logger';
 export type { OgImageUrlGenerator } from './ogImageUrlGenerator';
 export { toPostOutput } from './postOutputMapper';
 export type {

--- a/apps/blog/modules/post/use-cases/shared/logger.ts
+++ b/apps/blog/modules/post/use-cases/shared/logger.ts
@@ -1,0 +1,6 @@
+/**
+ * Port for recording use-case events without depending on a logging implementation.
+ */
+export interface Logger {
+  error(context: Record<string, unknown>, message: string): void;
+}

--- a/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.test.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { SyncError } from '../../shared';
+import { describe, expect, it, vi } from 'vitest';
+import { type Logger, SyncError } from '../../shared';
 import type {
   ExternalImageSource,
   ImageSourceRecord,
@@ -7,19 +7,7 @@ import type {
 import type { ImageRepository } from './imageRepository';
 import { SyncHeroImages } from './useCase';
 
-const { mockLoggerError } = vi.hoisted(() => ({
-  mockLoggerError: vi.fn(),
-}));
-
-vi.mock('../../../../shared/logger', () => ({
-  logger: { child: () => ({ error: mockLoggerError }) },
-}));
-
 describe('SyncHeroImages', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   const createMockImageSource = (
     images: ImageSourceRecord[] = []
   ): ExternalImageSource => ({
@@ -39,12 +27,20 @@ describe('SyncHeroImages', () => {
       url: `https://example.com/image-${i}.jpg`,
     }));
 
+  const createMockLogger = (): Logger => ({
+    error: vi.fn(),
+  });
+
   describe('execute', () => {
     it('collects and uploads images from all sources', async () => {
       const source1 = createMockImageSource(createImageRecords(2));
       const source2 = createMockImageSource(createImageRecords(3));
       const imageRepository = createMockImageRepository();
-      const sut = new SyncHeroImages([source1, source2], imageRepository);
+      const sut = new SyncHeroImages(
+        [source1, source2],
+        imageRepository,
+        createMockLogger()
+      );
 
       const result = await sut.execute();
 
@@ -57,7 +53,11 @@ describe('SyncHeroImages', () => {
       const source = createMockImageSource(images);
       const uploadImage = vi.fn().mockResolvedValue(undefined);
       const imageRepository = createMockImageRepository({ uploadImage });
-      const sut = new SyncHeroImages([source], imageRepository);
+      const sut = new SyncHeroImages(
+        [source],
+        imageRepository,
+        createMockLogger()
+      );
 
       await sut.execute();
 
@@ -69,7 +69,11 @@ describe('SyncHeroImages', () => {
     it('handles empty sources', async () => {
       const source = createMockImageSource([]);
       const imageRepository = createMockImageRepository();
-      const sut = new SyncHeroImages([source], imageRepository);
+      const sut = new SyncHeroImages(
+        [source],
+        imageRepository,
+        createMockLogger()
+      );
 
       const result = await sut.execute();
 
@@ -86,7 +90,11 @@ describe('SyncHeroImages', () => {
         .mockRejectedValueOnce(new Error('Upload failed'))
         .mockResolvedValueOnce(undefined);
       const imageRepository = createMockImageRepository({ uploadImage });
-      const sut = new SyncHeroImages([source], imageRepository);
+      const sut = new SyncHeroImages(
+        [source],
+        imageRepository,
+        createMockLogger()
+      );
 
       const result = await sut.execute();
 
@@ -99,7 +107,11 @@ describe('SyncHeroImages', () => {
         fetchImageSources: vi.fn().mockRejectedValue(new Error('Source error')),
       };
       const imageRepository = createMockImageRepository();
-      const sut = new SyncHeroImages([source], imageRepository);
+      const sut = new SyncHeroImages(
+        [source],
+        imageRepository,
+        createMockLogger()
+      );
 
       await expect(sut.execute()).rejects.toThrow(SyncError);
       await expect(sut.execute()).rejects.toThrow('Source error');
@@ -117,7 +129,8 @@ describe('SyncHeroImages', () => {
       const imageRepository = createMockImageRepository();
       const sut = new SyncHeroImages(
         [source1, source2, source3],
-        imageRepository
+        imageRepository,
+        createMockLogger()
       );
 
       const result = await sut.execute();
@@ -130,7 +143,11 @@ describe('SyncHeroImages', () => {
       const source = createMockImageSource(images);
       const uploadImage = vi.fn().mockRejectedValue(new Error('Upload failed'));
       const imageRepository = createMockImageRepository({ uploadImage });
-      const sut = new SyncHeroImages([source], imageRepository);
+      const sut = new SyncHeroImages(
+        [source],
+        imageRepository,
+        createMockLogger()
+      );
 
       const result = await sut.execute();
 
@@ -145,11 +162,12 @@ describe('SyncHeroImages', () => {
       const uploadError = new Error('Upload failed');
       const uploadImage = vi.fn().mockRejectedValue(uploadError);
       const imageRepository = createMockImageRepository({ uploadImage });
-      const sut = new SyncHeroImages([source], imageRepository);
+      const logger = createMockLogger();
+      const sut = new SyncHeroImages([source], imageRepository, logger);
 
       await sut.execute();
 
-      expect(mockLoggerError).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         { err: uploadError, imageId: images[0].id },
         'Failed to upload hero image'
       );

--- a/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.test.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SyncError } from '../../shared';
 import type {
   ExternalImageSource,
@@ -7,7 +7,19 @@ import type {
 import type { ImageRepository } from './imageRepository';
 import { SyncHeroImages } from './useCase';
 
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('../../../../shared/logger', () => ({
+  logger: { child: () => ({ error: mockLoggerError }) },
+}));
+
 describe('SyncHeroImages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   const createMockImageSource = (
     images: ImageSourceRecord[] = []
   ): ExternalImageSource => ({
@@ -125,6 +137,22 @@ describe('SyncHeroImages', () => {
       expect(result.count).toBe(0);
       expect(result.failedCount).toBe(2);
       expect(result.uploadedImages).toEqual([]);
+    });
+
+    it('logs the caught cause when an individual upload fails', async () => {
+      const images = createImageRecords(1);
+      const source = createMockImageSource(images);
+      const uploadError = new Error('Upload failed');
+      const uploadImage = vi.fn().mockRejectedValue(uploadError);
+      const imageRepository = createMockImageRepository({ uploadImage });
+      const sut = new SyncHeroImages([source], imageRepository);
+
+      await sut.execute();
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        { err: uploadError, imageId: images[0].id },
+        'Failed to upload hero image'
+      );
     });
   });
 });

--- a/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.ts
@@ -1,9 +1,12 @@
+import { logger } from '../../../../shared/logger';
 import { SyncError } from '../../shared';
 import type {
   ExternalImageSource,
   ImageSourceRecord,
 } from './externalImageSource';
 import type { ImageRepository } from './imageRepository';
+
+const syncHeroImagesLogger = logger.child({ module: 'post' });
 
 export interface SyncHeroImagesOutput {
   uploadedImages: ImageSourceRecord[];
@@ -65,7 +68,11 @@ export class SyncHeroImages {
         try {
           await this.imageRepository.uploadImage(image.id, image.url);
           return { image, success: true };
-        } catch {
+        } catch (error) {
+          syncHeroImagesLogger.error(
+            { err: error, imageId: image.id },
+            'Failed to upload hero image'
+          );
           return { image, success: false };
         }
       })

--- a/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-hero-images/useCase.ts
@@ -1,12 +1,9 @@
-import { logger } from '../../../../shared/logger';
-import { SyncError } from '../../shared';
+import { type Logger, SyncError } from '../../shared';
 import type {
   ExternalImageSource,
   ImageSourceRecord,
 } from './externalImageSource';
 import type { ImageRepository } from './imageRepository';
-
-const syncHeroImagesLogger = logger.child({ module: 'post' });
 
 export interface SyncHeroImagesOutput {
   uploadedImages: ImageSourceRecord[];
@@ -22,7 +19,8 @@ export interface SyncHeroImagesOutput {
 export class SyncHeroImages {
   constructor(
     private readonly imageSources: ExternalImageSource[],
-    private readonly imageRepository: ImageRepository
+    private readonly imageRepository: ImageRepository,
+    private readonly logger: Logger
   ) {}
 
   async execute(): Promise<SyncHeroImagesOutput> {
@@ -69,7 +67,7 @@ export class SyncHeroImages {
           await this.imageRepository.uploadImage(image.id, image.url);
           return { image, success: true };
         } catch (error) {
-          syncHeroImagesLogger.error(
+          this.logger.error(
             { err: error, imageId: image.id },
             'Failed to upload hero image'
           );


### PR DESCRIPTION
## Summary

Stops the blog masking infrastructure failures as silent 404s, logs discarded error causes, and makes article embeds fail soft instead of taking down the whole page.

### What changed?

- `app/blog/[id]/[slug]/page.tsx`: the blanket `.catch(() => notFound())` is gone. A new `handlePostFetchError(error, id): never` helper discriminates `UseCaseError` → `postLogger.warn`, anything else → `postLogger.error`, then `notFound()` — applied SYMMETRICALLY in the page component and `generateMetadata` (which previously had no catch at all and 500ed on the same failure the page turned into a 404). Covered by co-located tests.
- `modules/post/use-cases/sync/sync-hero-images/useCase.ts`: the silent per-image `catch` now logs the cause before recording `{ image, success: false }` (test asserts the logging).
- Embed fail-soft (scope addition): `InstagramTimeline`, `MediaEmb`, `AffiliateEmb` catch their own fetch failures, log via their module loggers, and render nothing — one deleted/unshared Notion page, expired Instagram token, or API outage no longer 500s the entire article. Each has a new co-located test (renders nothing + logs on failure).

### Why was this changed?

Per `.claude/rules/error-handling-guidelines.md` (#321): a DB outage rendered as an unlogged 404, per-image sync failures were discarded without causes, and any single broken embed crashed the article route. The discriminating pattern already existed in the search/category pages — this aligns the remaining page and the embeds with it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated

`handlePostFetchError.test.ts`, `InstagramTimeline.test.tsx`, `MediaEmb.test.tsx`, `AffiliateEmb.test.tsx` (new), `sync-hero-images/useCase.test.ts` (logging assertions added).

### How to Test

1. `pnpm -F blog test`
2. `grep -rn "catch(() =>" apps/blog/app` → no blanket catches remain
3. Break one embed id in a dev article → the article still renders, the embed logs and disappears

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

`pnpm typecheck`, `pnpm lint`, `pnpm -F blog test` (108 files / 958 tests) all green — re-verified independently by the orchestrator.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

Intentional behavior change: infrastructure failures on the post page now log as errors (still render 404 to the visitor), and broken embeds degrade to nothing instead of a 500.

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Related Issues

Closes #324

## Additional Context

Spec: `.claude/rules/error-handling-guidelines.md` (#321). #176 (TTFB caching) stacks on this branch — the caching wrappers sit inside these fail-soft boundaries.
