### PR TITLE
✨ Feat: #380 Add scene-studio Remotion app with brand demo composition

### DIFF
--- a/.claude/rules/remotion-template-guidelines.md
+++ b/.claude/rules/remotion-template-guidelines.md
@@ -1,0 +1,100 @@
+---
+paths: apps/scene-studio/**/*,packages/scene-ui/**/*
+---
+
+# Remotion Template Design & Naming Guidelines
+
+How to decide the granularity and names of Remotion templates, compositions, and
+components in the video platform (`apps/scene-studio`, `packages/scene-ui`). <!-- docs-check-ignore: scene-ui lands in #381 --> These
+rules are use-case-agnostic: they apply equally to travel videos, AI-generated
+graphics, 3D works, tech explainers, blog-to-video, and brand/product intros.
+
+Do not fix a definitive template list or final package layout up front. Build real
+videos, observe actual duplication, and evolve the design incrementally.
+
+## Three-layer structure
+
+```
+Layer 1: generic primitives     — small video parts (scene-ui)
+        ↓
+Layer 2: generic patterns       — video structures reusable across use cases
+        ↓
+Layer 3: use-case compositions  — finished videos with a fixed purpose
+```
+
+### Layer 1 — generic primitives
+
+Small building blocks: `VideoTitle`, `Caption`, `SafeArea`, `GradientOverlay`,
+`Logo`, `MediaFrame`, `BrandOutro`, transitions. **Never** encode a use case,
+material, or platform in a primitive's name — no `TravelTitle`, `ArtworkCaption`,
+`InstagramLogo`. Primitives must work for every video genre.
+
+### Layer 2 — generic patterns
+
+Structures reusable across use cases, named after the **structure or viewing
+experience**, not the material: `VisualShowcase`, `MediaSequence`, `BeforeAfter`,
+`NarratedSequence`. `VisualShowcase` works for travel photos, AI images, 3D works,
+portfolio pieces, product shots alike.
+
+### Layer 3 — use-case compositions
+
+Finished videos with a clear purpose: `TravelHighlight`, `ArtworkReveal`,
+`BlogSummary`, `ProductFeature`. The name tells viewers-facing intent.
+**Do not create these up front.** Run layer-2 patterns with different real
+materials first; split into a use-case composition only when a use case
+repeatedly needs its own structure (e.g. travel always needs place + map,
+AI artwork always needs prompt + process).
+
+## Naming rules
+
+- Names express **structure / role / viewing experience**, never the material
+  type (`TravelVideo`, `PhotoVideo` → bad) or the implementation technology
+  (`ThreeJsVideo` → bad; `ThreeIntro`, `ParticleReveal` → good).
+- No `Template` suffix (`VisualShowcaseTemplate` → bad). A `templates/` or
+  `patterns/` directory already says it. Use suffixes only to disambiguate
+  colliding roles in one domain (`…Input` vs `…Preview`).
+- Composition IDs: kebab-case, unique, readable by humans, the CLI, and logs
+  (`visual-showcase`, `brand-demo`). Avoid `template-1`, `main-video`,
+  `test-video`, `final-video`.
+- No platform names in compositions (`instagram-video`, `tiktok-template` → bad).
+  Platform differences are props/variants (aspect ratio, safe-area preset),
+  not separate compositions.
+
+## No universal templates
+
+Do not build a schema that can express "any video" (scene lists with free-form
+`type` / `layout` / `component` strings and `z.record(z.unknown())` props). That
+is a DSL, not a template: weak types, unstable AI output, untestable. Constrain
+each schema to one structure (e.g. `visualShowcaseSchema` = title + items with
+`mediaType`/`src`/`caption`). Extend from real requirements when expressiveness
+runs out.
+
+## Abstraction criteria
+
+Commonize when: the same structure appears 3+ times; the same change/bug-fix hits
+multiple compositions; the same layout or animation serves multiple use cases;
+brand changes need a single point of application.
+
+Do not rush when: requirements are still vague; something is used once; "might
+need it later"; commonizing forces prop bloat or many booleans switching
+behavior; story structure genuinely differs per use case. A component like
+`<GenericVideo isTravel showPrompt={false} useThreeJs …>` is the signal to split
+into use-case compositions.
+
+Decision flow for a new video:
+
+1. Can an existing composition express it? → add props / input data only.
+2. Can existing generic patterns be combined? → create just a new composition.
+3. Would a new generic pattern serve multiple use cases? → add the pattern.
+4. Otherwise → implement inside a use-case composition; revisit commonization
+   when the same structure recurs.
+
+## AI agents and templates
+
+Humans/code own: available compositions and primitives, schemas, brand rules,
+display limits, safe areas, output specs. AI agents own: choosing a composition,
+generating schema-conforming input data, ordering materials, writing captions,
+tuning display times, picking allowed variants. Default flow is *AI selects an
+existing composition → generates valid input JSON → renders*. AI-generated
+composition code is allowed only for experiments and requires human review
+before it joins the stable set.

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,12 @@ dist
 ds-bundle/
 packages/ui/.ds-tailwind.css
 .design-sync/*.log
+
+# scene-studio (Remotion) — user-supplied media, never committed
+apps/scene-studio/public/assets/*
+!apps/scene-studio/public/assets/README.md
+apps/scene-studio/**/*.mp4
+apps/scene-studio/**/*.mov
+apps/scene-studio/**/*.webm
+apps/scene-studio/**/*.mp3
+apps/scene-studio/**/*.wav

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ selection, engineering trade-offs, writing tone).
 ## Project Structure & Module Organization
 
 - Monorepo managed by pnpm workspaces and Turborepo.
-- Apps: `apps/blog` (Next.js + Drizzle ORM + Hono API server, port 3000) and
-  `apps/portfolio` (Next.js, multilingual, port 3001).
+- Apps: `apps/blog` (Next.js + Drizzle ORM + Hono API server, port 3000),
+  `apps/portfolio` (Next.js, multilingual, port 3001), and `apps/scene-studio`
+  (Remotion Studio for programmatic short-form videos, port 3002).
 - Packages: `packages/ui` (shared React components + Storybook), `packages/test-utils`
   (Vitest helpers), `packages/tailwind-config` (design tokens), `packages/biome-config`,
   `packages/tsconfig`.
@@ -30,6 +31,8 @@ selection, engineering trade-offs, writing tone).
 - Test: `pnpm test` or `pnpm test:watch` (Vitest in Blog and Test Utils).
 - Component scaffolding: `pnpm generate:component`, `pnpm generate:style`.
 - Storybook (UI): `pnpm -F ui storybook` (port 6006); Chromatic via CI.
+- Video (Scene Studio): `pnpm -F scene-studio dev` (Remotion Studio, port 3002);
+  render locally via `pnpm -F scene-studio render <composition-id>`.
 
 ## Architecture
 
@@ -88,6 +91,21 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
 - Next.js 16 renamed `middleware.ts` to `proxy.ts`, but the portfolio deliberately keeps
   `middleware.ts` because i18n locale detection requires the edge runtime — do not rename it.
   Use `proxy.ts` only when adding new middleware to the blog app.
+
+### Scene Studio (Video Generation)
+
+- `apps/scene-studio` renders short-form vertical videos (1080×1920) with
+  [Remotion](https://www.remotion.dev/): compositions are React components driven by
+  props/JSON, styled with Tailwind v4 reusing `packages/tailwind-config` tokens.
+- Animations must be deterministic: derive all state from `useCurrentFrame()` and props —
+  never `requestAnimationFrame`, unseeded randomness, or the current time.
+- Media assets are never committed; `apps/scene-studio/public/assets/` is gitignored
+  (reference files via `staticFile()`). Rendering is local-macOS-only for now (brand
+  system fonts are unavailable on Linux/CI).
+- All `remotion` / `@remotion/*` packages stay on one identical exact-pinned version;
+  bump them together in a single commit.
+- Template/composition design and naming (three-layer structure, no universal
+  templates): `.claude/rules/remotion-template-guidelines.md`.
 
 ### Key Integrations
 

--- a/apps/scene-studio/README.md
+++ b/apps/scene-studio/README.md
@@ -1,0 +1,66 @@
+# scene-studio
+
+Remotion Studio app for programmatic short-form videos ("scenes"). A video is
+treated as *template + brand rules + assets + composition data* — compositions
+are React components driven by props, rendered deterministically from frame
+numbers.
+
+Template design and naming rules live in
+`.claude/rules/remotion-template-guidelines.md` (three-layer structure:
+generic primitives → generic patterns → use-case compositions).
+
+## Commands
+
+```bash
+pnpm -F scene-studio dev                  # Remotion Studio on http://localhost:3002
+pnpm -F scene-studio render brand-demo    # render an MP4 to out/<composition-id>.mp4
+pnpm -F scene-studio build                # bundle (webpack smoke test, outputs build/)
+pnpm -F scene-studio lint                 # biome check
+pnpm -F scene-studio typecheck            # tsc --noEmit
+```
+
+Rendered files (`out/`), bundles (`build/`), and media assets are gitignored.
+
+## Assets
+
+Media files are **never committed**. Put local photos/videos into
+`public/assets/` (gitignored, see the README there) and reference them via
+`staticFile('assets/<file>')` or composition props. Remote `http(s)` URLs also
+work but require network access at preview/render time.
+
+## Rendering constraints
+
+- **Local macOS only (for now).** Text uses the brand system-font stack
+  (`--font-original`: Menlo / YuGothic / Hiragino…). Those fonts do not exist
+  on Linux/CI hosts, so rendering elsewhere silently substitutes fonts.
+  Revisit with `@remotion/google-fonts` if cloud rendering is ever needed.
+- **Animations must be deterministic.** Derive all state from
+  `useCurrentFrame()` / props. Never use `requestAnimationFrame`,
+  `Math.random()` without a seed prop, or `new Date()`.
+
+## Why webpack (and not Vite)
+
+webpack is not this app's choice — it is Remotion's built-in toolchain.
+`remotion studio`, `remotion render`, and `remotion bundle` all go through
+`@remotion/bundler`, which bundles with webpack; `renderMedia()` only accepts a
+serve URL produced by that bundler, so there is no supported Vite path.
+
+The webpack usage is fully encapsulated in this app: no own webpack config, no
+direct webpack dependency, and nothing leaks into the rest of the monorepo
+(blog/portfolio stay on Turbopack, the ui Storybook stays on Vite). The single
+touchpoint is the composable override in `remotion.config.ts`. If rendering
+speed ever becomes an issue, try Remotion's experimental Rspack mode
+(`--experimental-rspack`).
+
+## Dependency policy
+
+All `remotion` / `@remotion/*` packages must stay on **one identical exact
+version** (no caret) across the monorepo — Remotion requires it. When
+upgrading, bump every Remotion package together in a single commit.
+
+## Future notes
+
+- Three.js integration (`@remotion/three`) requires React Three Fiber 9.1.2+
+  and three 0.171.0+ (React 19). The webpack override in `remotion.config.ts`
+  is written as a composable function so additional overrides can chain onto
+  `enableTailwind`.

--- a/apps/scene-studio/biome.jsonc
+++ b/apps/scene-studio/biome.jsonc
@@ -1,0 +1,19 @@
+{
+  "root": false,
+  "extends": ["biome-config/biome.jsonc"],
+
+  "files": {
+    "includes": ["src/**/*.{ts,tsx}", "*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}"]
+  },
+
+  "overrides": [
+    {
+      "includes": ["*.config.*", "*.d.ts"],
+      "linter": {
+        "rules": {
+          "style": { "noDefaultExport": "off" }
+        }
+      }
+    }
+  ]
+}

--- a/apps/scene-studio/package.json
+++ b/apps/scene-studio/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "scene-studio",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "remotion studio --port 3002",
+    "build": "remotion bundle",
+    "render": "remotion render",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit",
+    "format": "biome format --write ."
+  },
+  "dependencies": {
+    "@remotion/cli": "4.0.488",
+    "react": "^19.0.1",
+    "react-dom": "^19.0.1",
+    "remotion": "4.0.488"
+  },
+  "devDependencies": {
+    "@remotion/tailwind-v4": "4.0.488",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "biome-config": "workspace:*",
+    "tailwind-config": "workspace:*",
+    "tailwindcss": "^4.0.9",
+    "tsconfig": "workspace:*"
+  }
+}

--- a/apps/scene-studio/package.json
+++ b/apps/scene-studio/package.json
@@ -8,7 +8,9 @@
     "render": "remotion render",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@remotion/cli": "4.0.488",
@@ -23,6 +25,7 @@
     "biome-config": "workspace:*",
     "tailwind-config": "workspace:*",
     "tailwindcss": "^4.0.9",
-    "tsconfig": "workspace:*"
+    "tsconfig": "workspace:*",
+    "vitest": "^3.1.1"
   }
 }

--- a/apps/scene-studio/public/assets/README.md
+++ b/apps/scene-studio/public/assets/README.md
@@ -1,0 +1,13 @@
+# Local media assets
+
+This directory holds local photos, videos, and audio used by compositions.
+Everything here except this README is **gitignored — never commit media files**.
+
+Usage:
+
+1. Drop files here, e.g. `public/assets/harbor.jpg`.
+2. Reference them from composition props or code via Remotion's
+   `staticFile('assets/harbor.jpg')`.
+
+Keep originals in your own photo library or storage; this directory is a
+disposable working copy.

--- a/apps/scene-studio/remotion.config.ts
+++ b/apps/scene-studio/remotion.config.ts
@@ -1,0 +1,10 @@
+import { Config } from '@remotion/cli/config';
+import { enableTailwind } from '@remotion/tailwind-v4';
+
+Config.setEntryPoint('./src/index.ts');
+// Keep webpack overrides composable so future integrations (e.g. Three.js
+// GLSL loaders) can chain onto the Tailwind override.
+Config.overrideWebpackConfig((currentConfiguration) =>
+  enableTailwind(currentConfiguration)
+);
+Config.setOverwriteOutput(true);

--- a/apps/scene-studio/src/Root.tsx
+++ b/apps/scene-studio/src/Root.tsx
@@ -1,0 +1,24 @@
+import { Composition, Folder } from 'remotion';
+
+import { BrandDemo } from './compositions/BrandDemo';
+
+import './style.css';
+
+const SCENE_WIDTH = 1080;
+const SCENE_HEIGHT = 1920;
+const SCENE_FPS = 30;
+
+export function RemotionRoot() {
+  return (
+    <Folder name="demo">
+      <Composition
+        id="brand-demo"
+        component={BrandDemo}
+        width={SCENE_WIDTH}
+        height={SCENE_HEIGHT}
+        fps={SCENE_FPS}
+        durationInFrames={450}
+      />
+    </Folder>
+  );
+}

--- a/apps/scene-studio/src/Root.tsx
+++ b/apps/scene-studio/src/Root.tsx
@@ -1,6 +1,7 @@
 import { Composition, Folder } from 'remotion';
 
 import { BrandDemo } from './compositions/BrandDemo';
+import { getBrandDemoDurationInFrames } from './compositions/BrandDemo/scenes';
 
 import './style.css';
 
@@ -17,7 +18,7 @@ export function RemotionRoot() {
         width={SCENE_WIDTH}
         height={SCENE_HEIGHT}
         fps={SCENE_FPS}
-        durationInFrames={450}
+        durationInFrames={getBrandDemoDurationInFrames()}
       />
     </Folder>
   );

--- a/apps/scene-studio/src/compositions/BrandDemo/TitleScene.tsx
+++ b/apps/scene-studio/src/compositions/BrandDemo/TitleScene.tsx
@@ -1,0 +1,43 @@
+import {
+  AbsoluteFill,
+  interpolate,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from 'remotion';
+
+export function TitleScene() {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const enter = spring({ frame, fps, config: { damping: 200 } });
+  const underlineProgress = interpolate(frame, [15, 45], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill className="items-center justify-center gap-10 bg-base-black">
+      <h1
+        className="font-original font-bold text-base-white"
+        style={{
+          fontSize: 160,
+          opacity: enter,
+          transform: `translateY(${(1 - enter) * 80}px)`,
+        }}
+      >
+        k2gb
+      </h1>
+      <div
+        className="h-3 bg-main-default"
+        style={{ width: underlineProgress * 480 }}
+      />
+      <p
+        className="font-original text-base-white"
+        style={{ fontSize: 40, opacity: underlineProgress }}
+      >
+        scene-studio
+      </p>
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/BrandDemo/TokenScene.tsx
+++ b/apps/scene-studio/src/compositions/BrandDemo/TokenScene.tsx
@@ -1,0 +1,58 @@
+import {
+  AbsoluteFill,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from 'remotion';
+
+const BRAND_COLORS = [
+  { name: 'main-default', hex: '#b8d200', swatchClassName: 'bg-main-default' },
+  {
+    name: 'accent-default',
+    hex: '#f8b500',
+    swatchClassName: 'bg-accent-default',
+  },
+  { name: 'base-white', hex: '#f3f3f2', swatchClassName: 'bg-base-white' },
+  { name: 'base-black', hex: '#474a4d', swatchClassName: 'bg-base-black' },
+] as const;
+
+const STAGGER_IN_FRAMES = 8;
+
+export function TokenScene() {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  return (
+    <AbsoluteFill className="items-center justify-center gap-14 bg-base-black">
+      <h2 className="font-original text-base-white" style={{ fontSize: 56 }}>
+        Color Tokens
+      </h2>
+      {BRAND_COLORS.map((color, index) => {
+        const enter = spring({
+          frame: frame - index * STAGGER_IN_FRAMES,
+          fps,
+          config: { damping: 200 },
+        });
+
+        return (
+          <div
+            key={color.name}
+            className="flex w-[560px] items-center gap-10"
+            style={{
+              opacity: enter,
+              transform: `translateX(${(1 - enter) * 120}px)`,
+            }}
+          >
+            <div
+              className={`h-32 w-32 rounded-2xl border-2 border-base-white ${color.swatchClassName}`}
+            />
+            <div className="font-original text-base-white">
+              <p style={{ fontSize: 36 }}>{color.name}</p>
+              <p style={{ fontSize: 30, opacity: 0.6 }}>{color.hex}</p>
+            </div>
+          </div>
+        );
+      })}
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/BrandDemo/TypographyScene.tsx
+++ b/apps/scene-studio/src/compositions/BrandDemo/TypographyScene.tsx
@@ -1,0 +1,47 @@
+import { AbsoluteFill, interpolate, useCurrentFrame } from 'remotion';
+
+const TYPE_SAMPLES = [
+  { token: 'advert', sampleClassName: 'text-advert' },
+  { token: 'slogan', sampleClassName: 'text-slogan' },
+  { token: 'big-header', sampleClassName: 'text-big-header' },
+  { token: 'heading-1', sampleClassName: 'text-heading-1' },
+  { token: 'body-r-md', sampleClassName: 'text-body-r-md' },
+] as const;
+
+const STAGGER_IN_FRAMES = 10;
+
+export function TypographyScene() {
+  const frame = useCurrentFrame();
+
+  return (
+    <AbsoluteFill className="justify-center gap-12 bg-base-black px-20">
+      <h2 className="font-original text-base-white" style={{ fontSize: 56 }}>
+        Typography
+      </h2>
+      {TYPE_SAMPLES.map((sample, index) => {
+        const opacity = interpolate(
+          frame - index * STAGGER_IN_FRAMES,
+          [0, 20],
+          [0, 1],
+          { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
+        );
+
+        return (
+          <div key={sample.token} style={{ opacity }}>
+            <p
+              className="font-original text-main-default"
+              style={{ fontSize: 28 }}
+            >
+              {sample.token}
+            </p>
+            <p
+              className={`font-original text-base-white ${sample.sampleClassName}`}
+            >
+              Whereas disregard and contempt for human rights have resulted
+            </p>
+          </div>
+        );
+      })}
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/BrandDemo/index.tsx
+++ b/apps/scene-studio/src/compositions/BrandDemo/index.tsx
@@ -1,24 +1,19 @@
 import { AbsoluteFill, Series } from 'remotion';
 
-import { TitleScene } from './TitleScene';
-import { TokenScene } from './TokenScene';
-import { TypographyScene } from './TypographyScene';
-
-const SCENE_DURATION_IN_FRAMES = 150;
+import { brandDemoScenes, SCENE_DURATION_IN_FRAMES } from './scenes';
 
 export function BrandDemo() {
   return (
     <AbsoluteFill className="bg-base-black">
       <Series>
-        <Series.Sequence durationInFrames={SCENE_DURATION_IN_FRAMES}>
-          <TitleScene />
-        </Series.Sequence>
-        <Series.Sequence durationInFrames={SCENE_DURATION_IN_FRAMES}>
-          <TokenScene />
-        </Series.Sequence>
-        <Series.Sequence durationInFrames={SCENE_DURATION_IN_FRAMES}>
-          <TypographyScene />
-        </Series.Sequence>
+        {brandDemoScenes.map((scene) => (
+          <Series.Sequence
+            key={scene.name}
+            durationInFrames={SCENE_DURATION_IN_FRAMES}
+          >
+            <scene.component />
+          </Series.Sequence>
+        ))}
       </Series>
     </AbsoluteFill>
   );

--- a/apps/scene-studio/src/compositions/BrandDemo/index.tsx
+++ b/apps/scene-studio/src/compositions/BrandDemo/index.tsx
@@ -1,0 +1,25 @@
+import { AbsoluteFill, Series } from 'remotion';
+
+import { TitleScene } from './TitleScene';
+import { TokenScene } from './TokenScene';
+import { TypographyScene } from './TypographyScene';
+
+const SCENE_DURATION_IN_FRAMES = 150;
+
+export function BrandDemo() {
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <Series>
+        <Series.Sequence durationInFrames={SCENE_DURATION_IN_FRAMES}>
+          <TitleScene />
+        </Series.Sequence>
+        <Series.Sequence durationInFrames={SCENE_DURATION_IN_FRAMES}>
+          <TokenScene />
+        </Series.Sequence>
+        <Series.Sequence durationInFrames={SCENE_DURATION_IN_FRAMES}>
+          <TypographyScene />
+        </Series.Sequence>
+      </Series>
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/BrandDemo/scenes.test.ts
+++ b/apps/scene-studio/src/compositions/BrandDemo/scenes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  brandDemoScenes,
+  getBrandDemoDurationInFrames,
+  SCENE_DURATION_IN_FRAMES,
+} from './scenes';
+
+describe('brandDemoScenes', () => {
+  it('orders scenes as title, tokens, typography', () => {
+    const sceneNames = brandDemoScenes.map((scene) => scene.name);
+
+    expect(sceneNames).toEqual(['title', 'tokens', 'typography']);
+  });
+
+  it('gives every scene the shared scene duration', () => {
+    const expectedSceneDurationInFrames = 150;
+
+    expect(SCENE_DURATION_IN_FRAMES).toBe(expectedSceneDurationInFrames);
+  });
+});
+
+describe('getBrandDemoDurationInFrames', () => {
+  it('keeps the demo at 15 seconds at 30fps', () => {
+    const expectedDurationInFrames = 450;
+
+    const result = getBrandDemoDurationInFrames();
+
+    expect(result).toBe(expectedDurationInFrames);
+  });
+});

--- a/apps/scene-studio/src/compositions/BrandDemo/scenes.ts
+++ b/apps/scene-studio/src/compositions/BrandDemo/scenes.ts
@@ -1,0 +1,20 @@
+import type { ComponentType } from 'react';
+
+import { TitleScene } from './TitleScene';
+import { TokenScene } from './TokenScene';
+import { TypographyScene } from './TypographyScene';
+
+export const SCENE_DURATION_IN_FRAMES = 150;
+
+export const brandDemoScenes = [
+  { name: 'title', component: TitleScene },
+  { name: 'tokens', component: TokenScene },
+  { name: 'typography', component: TypographyScene },
+] as const satisfies ReadonlyArray<{
+  name: string;
+  component: ComponentType;
+}>;
+
+export function getBrandDemoDurationInFrames(): number {
+  return brandDemoScenes.length * SCENE_DURATION_IN_FRAMES;
+}

--- a/apps/scene-studio/src/index.ts
+++ b/apps/scene-studio/src/index.ts
@@ -1,0 +1,5 @@
+import { registerRoot } from 'remotion';
+
+import { RemotionRoot } from './Root';
+
+registerRoot(RemotionRoot);

--- a/apps/scene-studio/src/style.css
+++ b/apps/scene-studio/src/style.css
@@ -1,0 +1,12 @@
+@source './**/*.{ts,tsx}';
+@import 'tailwindcss';
+@import 'tailwind-config/design-token/variables.css';
+
+@theme {
+  /* NOTE: duplicated from packages/ui/src/globals.css — keep in sync manually.
+     Importing ui's globals would pull web-only base styles and tw-animate-css
+     into video compositions. */
+  --font-original: 'Menlo', 'YuGothic', 'Hiragino Kaku Gothic ProN',
+    'Hiragino Sans', 'Meiryo', 'ui-monospace', 'SFMono-Regular', 'Monaco',
+    'Consolas', 'Liberation Mono', 'Courier New', 'monospace';
+}

--- a/apps/scene-studio/tsconfig.json
+++ b/apps/scene-studio/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "tsconfig/react-library.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "remotion.config.ts"],
+  "exclude": ["node_modules", "build", "out"]
+}

--- a/apps/scene-studio/turbo.json
+++ b/apps/scene-studio/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["build/**"]
+    }
+  }
+}

--- a/apps/scene-studio/vitest.config.mts
+++ b/apps/scene-studio/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,7 +325,7 @@ importers:
     dependencies:
       '@remotion/cli':
         specifier: 4.0.488
-        version: 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+        version: 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
       react:
         specifier: ^19.0.1
         version: 19.2.1
@@ -338,7 +338,7 @@ importers:
     devDependencies:
       '@remotion/tailwind-v4':
         specifier: 4.0.488
-        version: 4.0.488(@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+        version: 4.0.488(@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.10
@@ -357,6 +357,9 @@ importers:
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      vitest:
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@18.19.130)(jiti@2.7.0)(jsdom@26.0.0)(lightningcss@1.32.0)(msw@2.12.7(@types/node@18.19.130)(typescript@5.5.4))(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
 
   packages/biome-config:
     devDependencies:
@@ -12159,7 +12162,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
+  '@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@remotion/media-parser': 4.0.488
       '@remotion/studio': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -12167,14 +12170,14 @@ snapshots:
       '@remotion/timeline-utils': 4.0.488
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
-      css-loader: 7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      css-loader: 7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
       esbuild: 0.25.2
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       react-refresh: 0.18.0
       remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
-      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
+      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -12200,14 +12203,14 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@remotion/cli@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
+  '@remotion/cli@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
     dependencies:
-      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
       '@remotion/media-utils': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@remotion/player': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@remotion/renderer': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@remotion/studio': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@remotion/studio-server': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/studio-server': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
       '@remotion/studio-shared': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       dotenv: 17.3.1
       minimist: 1.2.6
@@ -12295,11 +12298,11 @@ snapshots:
 
   '@remotion/streaming@4.0.488': {}
 
-  '@remotion/studio-server@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
+  '@remotion/studio-server@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/parser': 7.24.1
       '@babel/types': 7.24.0
-      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
       '@remotion/renderer': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@remotion/studio-shared': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       memfs: 3.4.3
@@ -12358,12 +12361,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@remotion/tailwind-v4@4.0.488(@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))':
+  '@remotion/tailwind-v4@4.0.488(@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
-      '@tailwindcss/webpack': 4.2.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
-      css-loader: 7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
-      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@tailwindcss/webpack': 4.2.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
+      css-loader: 7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
+      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
       tailwindcss: 4.2.0
     transitivePeerDependencies:
       - '@rspack/core'
@@ -13719,13 +13722,13 @@ snapshots:
       tailwindcss: 4.3.1
       vite: 7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
 
-  '@tailwindcss/webpack@4.2.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))':
+  '@tailwindcss/webpack@4.2.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.0
       '@tailwindcss/oxide': 4.2.0
       tailwindcss: 4.2.0
-      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)
 
   '@tanstack/query-core@5.70.0': {}
 
@@ -15157,7 +15160,7 @@ snapshots:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
       webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
 
-  css-loader@7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)):
+  css-loader@7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -15169,7 +15172,7 @@ snapshots:
       semver: 7.7.3
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
-      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)
 
   css-prefers-color-scheme@9.0.1(postcss@8.5.3):
     dependencies:
@@ -18967,9 +18970,9 @@ snapshots:
     dependencies:
       webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
 
-  style-loader@4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)):
+  style-loader@4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
-      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)
 
   style-loader@4.0.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
     dependencies:
@@ -19114,7 +19117,6 @@ snapshots:
       esbuild: 0.25.2
       lightningcss: 1.32.0
       postcss: 8.5.15
-    optional: true
 
   terser-webpack-plugin@5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
     dependencies:
@@ -19128,18 +19130,6 @@ snapshots:
       esbuild: 0.25.2
       lightningcss: 1.32.0
       postcss: 8.5.3
-
-  terser-webpack-plugin@5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.31.3
-      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
-    optionalDependencies:
-      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
-      esbuild: 0.25.2
-      postcss: 8.5.15
 
   terser@5.16.9:
     dependencies:
@@ -19852,7 +19842,6 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
-    optional: true
 
   webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3):
     dependencies:
@@ -19879,47 +19868,6 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.3
       terser-webpack-plugin: 5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.6
-      es-module-lexer: 2.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.2
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
     devDependencies:
       '@storybook/nextjs':
         specifier: ^10.1.11
-        version: 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+        version: 10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.5.4)
@@ -198,7 +198,7 @@ importers:
         version: 0.0.5
       storybook:
         specifier: ^10.1.11
-        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwind-config:
         specifier: workspace:*
         version: link:../../packages/tailwind-config
@@ -241,16 +241,16 @@ importers:
         version: 1.17.3(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(wrangler@4.76.0)
       '@storybook/addon-a11y':
         specifier: ^10.1.11
-        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/addon-docs':
         specifier: ^10.1.11
-        version: 10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+        version: 10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       '@storybook/addon-onboarding':
         specifier: ^10.1.11
-        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/nextjs':
         specifier: ^10.1.11
-        version: 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+        version: 10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.5.4)
@@ -277,7 +277,7 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
-        version: 3.9.0(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
+        version: 3.9.0(@swc/helpers@0.5.15)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.19(postcss@8.5.3)
@@ -298,7 +298,7 @@ importers:
         version: 9.6.0(postcss@8.5.3)
       storybook:
         specifier: ^10.1.11
-        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwind-config:
         specifier: workspace:*
         version: link:../../packages/tailwind-config
@@ -320,6 +320,43 @@ importers:
       wrangler:
         specifier: ^4.76.0
         version: 4.76.0
+
+  apps/scene-studio:
+    dependencies:
+      '@remotion/cli':
+        specifier: 4.0.488
+        version: 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      react:
+        specifier: ^19.0.1
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.0.1
+        version: 19.2.1(react@19.2.1)
+      remotion:
+        specifier: 4.0.488
+        version: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+    devDependencies:
+      '@remotion/tailwind-v4':
+        specifier: 4.0.488
+        version: 4.0.488(@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      '@types/react':
+        specifier: ^19.0.10
+        version: 19.0.10
+      '@types/react-dom':
+        specifier: ^19.0.4
+        version: 19.0.4(@types/react@19.0.10)
+      biome-config:
+        specifier: workspace:*
+        version: link:../../packages/biome-config
+      tailwind-config:
+        specifier: workspace:*
+        version: link:../../packages/tailwind-config
+      tailwindcss:
+        specifier: ^4.0.9
+        version: 4.3.1
+      tsconfig:
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
 
   packages/biome-config:
     devDependencies:
@@ -410,25 +447,25 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.1.2
-        version: 5.1.2(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 5.1.2(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/addon-a11y':
         specifier: ^10.3.5
-        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/addon-docs':
         specifier: ^10.3.5
-        version: 10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+        version: 10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/addon-links':
         specifier: ^10.3.5
-        version: 10.3.5(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 10.3.5(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/addon-mcp':
         specifier: ^0.6.0
-        version: 0.6.0(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+        version: 0.6.0(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
       '@storybook/addon-onboarding':
         specifier: ^10.3.5
-        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/react-vite':
         specifier: 10.3.5
-        version: 10.3.5(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+        version: 10.3.5(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
       '@tailwindcss/vite':
         specifier: ^4.0.9
         version: 4.3.1(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
@@ -449,7 +486,7 @@ importers:
         version: 11.7.1
       storybook:
         specifier: ^10.3.5
-        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwind-config:
         specifier: workspace:*
         version: link:../tailwind-config
@@ -874,6 +911,11 @@ packages:
   '@babel/helpers@7.28.4':
     resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.24.1':
+    resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
@@ -1395,6 +1437,10 @@ packages:
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.24.0':
+    resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
@@ -1899,8 +1945,14 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/is-prop-valid@1.4.0':
     resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
@@ -2374,9 +2426,45 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@mediabunny/aac-encoder@1.50.8':
+    resolution: {integrity: sha512-A5Se/LZd6RmYq/h36lBMSEsHvsyW8d0toR7FrAwpsFYbK+DVQYf90KiBT1Aw/mzLXx8/ypIOORJnd1sVZqOvJQ==}
+    peerDependencies:
+      mediabunny: ^1.0.0
+
+  '@mediabunny/flac-encoder@1.50.8':
+    resolution: {integrity: sha512-4cfN03SbEoQaG+eBeYFUAb1R1ALaAHzf43dXFzQTr/oO5ueqzTgBoG3coKrIvBaAMU7Vv36mrBKLX8bvTppdAQ==}
+    peerDependencies:
+      mediabunny: ^1.0.0
+
+  '@mediabunny/mp3-encoder@1.50.8':
+    resolution: {integrity: sha512-eBT/H30tTu8AmZXqZ5RTpJ9VmwVlwednajuOrrWp0GS6cbGXsGMQ60Qvr3ZMIE0QDiadlEzb8/ozR+doP+MC1g==}
+    peerDependencies:
+      mediabunny: ^1.0.0
+
+  '@module-federation/error-codes@0.22.0':
+    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
+
+  '@module-federation/runtime-core@0.22.0':
+    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
+
+  '@module-federation/runtime-tools@0.22.0':
+    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
+
+  '@module-federation/runtime@0.22.0':
+    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
+
+  '@module-federation/sdk@0.22.0':
+    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
+
   '@mswjs/interceptors@0.40.0':
     resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
     engines: {node: '>=18'}
+
+  '@napi-rs/wasm-runtime@1.0.7':
+    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
 
   '@neoconfetti/react@1.0.0':
     resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
@@ -2587,6 +2675,120 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@remotion/bundler@4.0.488':
+    resolution: {integrity: sha512-HBBH+IRRSuGjgc23e4uujOJffKvPcMhDiMrl9X3TJJXCO/qc9CqUQzW4yH4m04yecUBEZjogmrXLBoSVNYhZcw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/canvas-capture@4.0.488':
+    resolution: {integrity: sha512-K5unf3W3yRlzoERZ1Kd+3k6NZJZdKupSEb1O0oPf5VEkct9PI5DpuK1b/AGPULwSop14GHb7GoYlRFse9rAiDA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/cli@4.0.488':
+    resolution: {integrity: sha512-7886AKWzvNd1xrIsNPuG0zIlARMUZpHPOzCnAPMFKFRgxG++sES9PNRQ1OrK5oEjt4pLFIBXqlFFtOST9uMfqA==}
+    hasBin: true
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/compositor-darwin-arm64@4.0.488':
+    resolution: {integrity: sha512-FP4FY4zPEMQ/EQYBfs20TYfs2kyHlwpypaR+BRk2zYV29r3klNi+vzrlxk0P480g3QiX0sxKZ8AFDeBZdbP6UA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@remotion/compositor-darwin-x64@4.0.488':
+    resolution: {integrity: sha512-5GBn7Oqx2eAMJfXikrRAGcdjtJwT2/zHpguLuoNzbepuc7AAb1Sj7iqzj+kMLQU7Dc4/iiVdvN7SOVc4adFbgA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@remotion/compositor-linux-arm64-gnu@4.0.488':
+    resolution: {integrity: sha512-kHfWTF3W/N6q1ZTCXiFhJGcDZB4GB2ZnglbK90k/b3os0IyJvz8n44qFNz0PS3HKCerG9vO8aYLTRNg41g56Og==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@remotion/compositor-linux-arm64-musl@4.0.488':
+    resolution: {integrity: sha512-ySrF9LfJDjc+yqenfWMGvPVoINJe7grxlT0i9DjcPX6XS+yfDSQQSFnDfNB0jdHiuD8NJjjaJ0AGhOozKIQLlg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@remotion/compositor-linux-x64-gnu@4.0.488':
+    resolution: {integrity: sha512-xXzFkWAjWVJNl9/lYuEgqVYJQd+yNaxM03gLaG2CYEK3yq03+PHwdDrs9W2gTHs1l8P1XkMuiOGXmtlAO6W9Zg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@remotion/compositor-linux-x64-musl@4.0.488':
+    resolution: {integrity: sha512-bu2JPr0UTufzYpMzt8jBmC93RxKI9iqOVSzISW7bUDDZzuUMdcUJNDeauWuI9b6B17bn3j3VoDbOrZ/kKeb4/w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@remotion/compositor-win32-x64-msvc@4.0.488':
+    resolution: {integrity: sha512-iljgUki6NBoTIfxRyOEhMhyVBbo0Yot2sb6El8qeUBDrNc3Ctl3ixBT2lZZJmdq3gaY46gKH9lYENvE2kGQALA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@remotion/licensing@4.0.488':
+    resolution: {integrity: sha512-5jVmxoOzpeZMnLX7qLQUteOA0vbj+uPYHH8G3nuD87xnPPWDGMy/t8bA8GuImfLn55aM6jaNLP4ngi3IorlvgA==}
+
+  '@remotion/media-parser@4.0.488':
+    resolution: {integrity: sha512-g4Q2S/Iso87h/ZMWniv3QyZEV45iVg6wwlPSd2ukXAVCh3Gz5e333/y4exNT/MZ2l45WPaNN9CA4EV3qsLu8bw==}
+
+  '@remotion/media-utils@4.0.488':
+    resolution: {integrity: sha512-Q5Q02PtGmGLIb2pjUiAQt/2dZDHezpjF57hNmV/XMzM7RBw+RiaPJMMRtuJ5hSgOWSJouGMUvtNnlKO/H0L6CA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/player@4.0.488':
+    resolution: {integrity: sha512-bP9y6PFHtP79ikR2zxFiMwR11Cc5BoN9+PEP1YEdMXhkf4o+zDj6PzNw/Va2SjWhozrOTgVshgs1QZfQYleEkg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/renderer@4.0.488':
+    resolution: {integrity: sha512-gChcGkdrp4/0hmJDUU75bmvOk6RSO+xbzpQM82DvGbBEKHd/PmfEObsPXW9biMvJ2PG9IUAbfNhCBLJZMOTL6A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/streaming@4.0.488':
+    resolution: {integrity: sha512-/l+drcbhtg6ot4y6ApPolkBjsO0cZx20KtFBnCrzxufnNHRKOp7RzeOHxLXNVLMP/Bz2cf31sQYXbalXk16sjQ==}
+
+  '@remotion/studio-server@4.0.488':
+    resolution: {integrity: sha512-Zo3kfIJoIlJymVjtH41qmKktMSqYTFLz8ekLxRTV/5LGkn4Rt62wulNR1qFlxEci2DDgLUPJJPdLi4nhWR5IdQ==}
+
+  '@remotion/studio-shared@4.0.488':
+    resolution: {integrity: sha512-QPLJEteenroRRPJ3z9gxffycGJanYNC/XvGJbpSlcELYMyZBkE/+LYq6bNV2Xso5FoGO50GUd9lt/fCKJR3F0A==}
+
+  '@remotion/studio@4.0.488':
+    resolution: {integrity: sha512-LVuW1usvzqz3GRVf0jL9jYT0XzYglS/TGuyW5ee5o3hmz47ksiwCUYYt6zv9x0DzlyZtK6dzfYzbvPVwSIQkiQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/tailwind-v4@4.0.488':
+    resolution: {integrity: sha512-ZlWS1YbsfrWYiSgcU+LI5S2Rs4EManNzLM1yKsFq9jr/m1mgUTcsAdNgJyk5QN71rrFbFBtU3WSXDe02ci8+jg==}
+    peerDependencies:
+      '@remotion/bundler': 4.0.488
+
+  '@remotion/timeline-utils@4.0.488':
+    resolution: {integrity: sha512-TwC4bPkJHm9hwtzI2pVjERKCmcsw82FoGSecc7c7Bwo9az+1l0KenTg1HznMVhqJRtMTTyDSZvkiD7Lat1TFdg==}
+
+  '@remotion/web-renderer@4.0.488':
+    resolution: {integrity: sha512-9hzmwPGRUvlXs0pjdlI4kIS3nogVOa6Wheoob+S7PxaFLK2wobxbNtTAKNidoLJXfv/chCo65v1ThPJFsyb5qw==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@remotion/zod-types@4.0.488':
+    resolution: {integrity: sha512-2XdHInhWUX5DhaMNxVaOsv/T6po4siPOJ8EcU0AA8nBbwIgTpFSE/R6XwMRQGwEtCknY3EOJBORhVfWh0tXOCQ==}
 
   '@rollup/pluginutils@5.4.0':
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
@@ -2845,6 +3047,83 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@rspack/binding-darwin-arm64@1.7.11':
+    resolution: {integrity: sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.7.11':
+    resolution: {integrity: sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@1.7.11':
+    resolution: {integrity: sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@1.7.11':
+    resolution: {integrity: sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@1.7.11':
+    resolution: {integrity: sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@1.7.11':
+    resolution: {integrity: sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@1.7.11':
+    resolution: {integrity: sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@1.7.11':
+    resolution: {integrity: sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.7.11':
+    resolution: {integrity: sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@1.7.11':
+    resolution: {integrity: sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@1.7.11':
+    resolution: {integrity: sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==}
+
+  '@rspack/core@1.7.11':
+    resolution: {integrity: sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/lite-tapable@1.1.0':
+    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
+
+  '@rspack/plugin-react-refresh@1.6.1':
+    resolution: {integrity: sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw==}
+    peerDependencies:
+      react-refresh: '>=0.10.0 <1.0.0'
+      webpack-hot-middleware: 2.x
+    peerDependenciesMeta:
+      webpack-hot-middleware:
+        optional: true
 
   '@shikijs/core@3.12.1':
     resolution: {integrity: sha512-j9+UDQ6M50xvaSR/e9lg212H0Fqxy3lYd39Q6YITYQxfrb5VYNUKPLZp4PN9f+YmRcdpyNAm3obn/tIZ2WkUWg==}
@@ -3421,12 +3700,21 @@ packages:
   '@tailwindcss/node@4.0.9':
     resolution: {integrity: sha512-tOJvdI7XfJbARYhxX+0RArAhmuDcczTC46DGCEziqxzzbIaPnfYaIyRT31n4u8lROrsO7Q6u/K9bmQHL2uL1bQ==}
 
+  '@tailwindcss/node@4.2.0':
+    resolution: {integrity: sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q==}
+
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
   '@tailwindcss/oxide-android-arm64@4.0.9':
     resolution: {integrity: sha512-YBgy6+2flE/8dbtrdotVInhMVIxnHJPbAwa7U1gX4l2ThUIaPUp18LjB9wEH8wAGMBZUb//SzLtdXXNBHPUl6Q==}
     engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-android-arm64@4.2.0':
+    resolution: {integrity: sha512-F0QkHAVaW/JNBWl4CEKWdZ9PMb0khw5DCELAOnu+RtjAfx5Zgw+gqCHFvqg3AirU1IAd181fwOtJQ5I8Yx5wtw==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
@@ -3442,6 +3730,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@tailwindcss/oxide-darwin-arm64@4.2.0':
+    resolution: {integrity: sha512-I0QylkXsBsJMZ4nkUNSR04p6+UptjcwhcVo3Zu828ikiEqHjVmQL9RuQ6uT/cVIiKpvtVA25msu/eRV97JeNSA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@tailwindcss/oxide-darwin-arm64@4.3.1':
     resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
     engines: {node: '>= 20'}
@@ -3451,6 +3745,12 @@ packages:
   '@tailwindcss/oxide-darwin-x64@4.0.9':
     resolution: {integrity: sha512-4Dq3lKp0/C7vrRSkNPtBGVebEyWt9QPPlQctxJ0H3MDyiQYvzVYf8jKow7h5QkWNe8hbatEqljMj/Y0M+ERYJg==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.0':
+    resolution: {integrity: sha512-6TmQIn4p09PBrmnkvbYQ0wbZhLtbaksCDx7Y7R3FYYx0yxNA7xg5KP7dowmQ3d2JVdabIHvs3Hx4K3d5uCf8xg==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
@@ -3466,6 +3766,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@tailwindcss/oxide-freebsd-x64@4.2.0':
+    resolution: {integrity: sha512-qBudxDvAa2QwGlq9y7VIzhTvp2mLJ6nD/G8/tI70DCDoneaUeLWBJaPcbfzqRIWraj+o969aDQKvKW9dvkUizw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@tailwindcss/oxide-freebsd-x64@4.3.1':
     resolution: {integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==}
     engines: {node: '>= 20'}
@@ -3478,6 +3784,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0':
+    resolution: {integrity: sha512-7XKkitpy5NIjFZNUQPeUyNJNJn1CJeV7rmMR+exHfTuOsg8rxIO9eNV5TSEnqRcaOK77zQpsyUkBWmPy8FgdSg==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
     resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
     engines: {node: '>= 20'}
@@ -3487,6 +3799,13 @@ packages:
   '@tailwindcss/oxide-linux-arm64-gnu@4.0.9':
     resolution: {integrity: sha512-jk90UZ0jzJl3Dy1BhuFfRZ2KP9wVKMXPjmCtY4U6fF2LvrjP5gWFJj5VHzfzHonJexjrGe1lMzgtjriuZkxagg==}
     engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.0':
+    resolution: {integrity: sha512-Mff5a5Q3WoQR01pGU1gr29hHM1N93xYrKkGXfPw/aRtK4bOc331Ho4Tgfsm5WDGvpevqMpdlkCojT3qlCQbCpA==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3505,6 +3824,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
+    resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
@@ -3515,6 +3841,13 @@ packages:
   '@tailwindcss/oxide-linux-x64-gnu@4.0.9':
     resolution: {integrity: sha512-v0D8WqI/c3WpWH1kq/HP0J899ATLdGZmENa2/emmNjubT0sWtEke9W9+wXeEoACuGAhF9i3PO5MeyditpDCiWQ==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
+    resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3533,12 +3866,31 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@tailwindcss/oxide-linux-x64-musl@4.2.0':
+    resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.0':
+    resolution: {integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -3558,6 +3910,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.0':
+    resolution: {integrity: sha512-2UU/15y1sWDEDNJXxEIrfWKC2Yb4YgIW5Xz2fKFqGzFWfoMHWFlfa1EJlGO2Xzjkq/tvSarh9ZTjvbxqWvLLXA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
     resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
     engines: {node: '>= 20'}
@@ -3567,6 +3925,12 @@ packages:
   '@tailwindcss/oxide-win32-x64-msvc@4.0.9':
     resolution: {integrity: sha512-dpc05mSlqkwVNOUjGu/ZXd5U1XNch1kHFJ4/cHkZFvaW1RzbHmRt24gvM8/HC6IirMxNarzVw4IXVtvrOoZtxA==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.0':
+    resolution: {integrity: sha512-CrFadmFoc+z76EV6LPG1jx6XceDsaCG3lFhyLNo/bV9ByPrE+FnBPckXQVP4XRkN76h3Fjt/a+5Er/oA/nCBvQ==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
@@ -3580,6 +3944,10 @@ packages:
     resolution: {integrity: sha512-eLizHmXFqHswJONwfqi/WZjtmWZpIalpvMlNhTM99/bkHtUs6IqgI1XQ0/W5eO2HiRQcIlXUogI2ycvKhVLNcA==}
     engines: {node: '>= 10'}
 
+  '@tailwindcss/oxide@4.2.0':
+    resolution: {integrity: sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ==}
+    engines: {node: '>= 20'}
+
   '@tailwindcss/oxide@4.3.1':
     resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
     engines: {node: '>= 20'}
@@ -3591,6 +3959,11 @@ packages:
     resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tailwindcss/webpack@4.2.0':
+    resolution: {integrity: sha512-TohlILOzF/3l+Yolll9iD2b5bsLG/1TuxAXPTxJcA77YAgPyKKc5RIwj4vIjg4l9DFMidekx2Z0BWyPAle9TUA==}
+    peerDependencies:
+      webpack: ^5
 
   '@tanstack/query-core@5.70.0':
     resolution: {integrity: sha512-ZkkjQAZjI6nS5OyAmaSQafQXK180Xvp0lZYk4BzrnskkTV8On3zSJUxOIXnh0h/8EgqRkCA9i879DiJovA1kGw==}
@@ -3721,6 +4094,9 @@ packages:
     resolution: {integrity: sha512-3uYg2b5TWCiupetbDFMbBFMHl33xQTvp5DNg0fZSYal73Z9AlFH9yWabHWMYw6ywmwM1evkYRpTVA2n7GgqT5A==}
     hasBin: true
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -3756,6 +4132,12 @@ packages:
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
+  '@types/dom-mediacapture-transform@0.1.12':
+    resolution: {integrity: sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==}
+
+  '@types/dom-webcodecs@0.1.13':
+    resolution: {integrity: sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -3920,47 +4302,92 @@ packages:
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
 
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
   '@webassemblyjs/floating-point-hex-parser@1.11.6':
     resolution: {integrity: sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
 
   '@webassemblyjs/helper-api-error@1.11.6':
     resolution: {integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==}
 
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
   '@webassemblyjs/helper-buffer@1.12.1':
     resolution: {integrity: sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
 
   '@webassemblyjs/helper-numbers@1.11.6':
     resolution: {integrity: sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==}
 
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
   '@webassemblyjs/helper-wasm-bytecode@1.11.6':
     resolution: {integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
 
   '@webassemblyjs/helper-wasm-section@1.12.1':
     resolution: {integrity: sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==}
 
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
   '@webassemblyjs/ieee754@1.11.6':
     resolution: {integrity: sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
 
   '@webassemblyjs/leb128@1.11.6':
     resolution: {integrity: sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==}
 
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
   '@webassemblyjs/utf8@1.11.6':
     resolution: {integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
 
   '@webassemblyjs/wasm-edit@1.12.1':
     resolution: {integrity: sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==}
 
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
   '@webassemblyjs/wasm-gen@1.12.1':
     resolution: {integrity: sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
 
   '@webassemblyjs/wasm-opt@1.12.1':
     resolution: {integrity: sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==}
 
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
   '@webassemblyjs/wasm-parser@1.12.1':
     resolution: {integrity: sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==}
 
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
   '@webassemblyjs/wast-printer@1.12.1':
     resolution: {integrity: sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
@@ -3983,6 +4410,12 @@ packages:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
 
   acorn-walk@8.3.3:
     resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
@@ -4828,6 +5261,18 @@ packages:
       webpack:
         optional: true
 
+  css-loader@7.1.4:
+    resolution: {integrity: sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
+      webpack: ^5.27.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
   css-prefers-color-scheme@9.0.1:
     resolution: {integrity: sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g==}
     engines: {node: ^14 || ^16 || >=18}
@@ -4933,6 +5378,10 @@ packages:
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -5051,6 +5500,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   drizzle-kit@0.31.10:
@@ -5241,6 +5694,9 @@ packages:
 
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -5506,6 +5962,9 @@ packages:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
 
+  fs-monkey@1.0.3:
+    resolution: {integrity: sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==}
+
   fs-monkey@1.0.6:
     resolution: {integrity: sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==}
 
@@ -5724,6 +6183,9 @@ packages:
   html-entities@2.5.2:
     resolution: {integrity: sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==}
     engines: {node: '>=12'}
@@ -5875,6 +6337,11 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5954,6 +6421,10 @@ packages:
 
   is-upper-case@1.1.2:
     resolution: {integrity: sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -6059,6 +6530,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -6071,6 +6546,12 @@ packages:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
 
+  lightningcss-android-arm64@1.31.1:
+    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -6079,6 +6560,12 @@ packages:
 
   lightningcss-darwin-arm64@1.29.1:
     resolution: {integrity: sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.31.1:
+    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -6095,6 +6582,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.31.1:
+    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-darwin-x64@1.32.0:
     resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
     engines: {node: '>= 12.0.0'}
@@ -6103,6 +6596,12 @@ packages:
 
   lightningcss-freebsd-x64@1.29.1:
     resolution: {integrity: sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.31.1:
+    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -6119,6 +6618,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm-gnueabihf@1.32.0:
     resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
@@ -6127,6 +6632,13 @@ packages:
 
   lightningcss-linux-arm64-gnu@1.29.1:
     resolution: {integrity: sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -6146,6 +6658,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.31.1:
+    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
@@ -6155,6 +6674,13 @@ packages:
 
   lightningcss-linux-x64-gnu@1.29.1:
     resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -6174,6 +6700,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.31.1:
+    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
@@ -6183,6 +6716,12 @@ packages:
 
   lightningcss-win32-arm64-msvc@1.29.1:
     resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -6199,6 +6738,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.31.1:
+    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss-win32-x64-msvc@1.32.0:
     resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
@@ -6207,6 +6752,10 @@ packages:
 
   lightningcss@1.29.1:
     resolution: {integrity: sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.31.1:
+    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
   lightningcss@1.32.0:
@@ -6226,6 +6775,10 @@ packages:
 
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
+    engines: {node: '>=6.11.5'}
+
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   loader-utils@2.0.4:
@@ -6295,6 +6848,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -6387,6 +6944,13 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  mediabunny@1.50.8:
+    resolution: {integrity: sha512-LgykLyQzhdpo0V2yw3UXmOpj+b4JAGdpHBwsPE6kjSt8Za0d1VllD+FV7EGHBcdV4+oHUAo+yrqbVAWxNSDCPQ==}
+
+  memfs@3.4.3:
+    resolution: {integrity: sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==}
+    engines: {node: '>= 4.0.0'}
 
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
@@ -6551,6 +7115,9 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -6796,6 +7363,10 @@ packages:
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
+
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
 
   openapi3-ts@4.5.0:
     resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
@@ -7233,9 +7804,9 @@ packages:
     resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
     engines: {node: '>=12'}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-error@4.0.0:
@@ -7254,6 +7825,10 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
@@ -7386,6 +7961,10 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
   react@19.2.1:
     resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
@@ -7411,6 +7990,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   recast@0.23.9:
     resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
@@ -7484,6 +8067,12 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remotion@4.0.488:
+    resolution: {integrity: sha512-V+2GQChZQkrBWrT2+bqpvu9Q/8mAri08vdZEdWsl5hy5j8/3z2DAr+Fw81K4RHmLKgKbZY21AJv7hUD+DKOdhA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
@@ -7641,6 +8230,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -7727,6 +8321,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -7974,6 +8571,9 @@ packages:
   tailwindcss@4.0.9:
     resolution: {integrity: sha512-12laZu+fv1ONDRoNR9ipTOpUD7RN9essRVkX36sjxuRUInpN7hIiHN4lBd/SIFjbISvnXzp8h/hXzmU8SQQYhw==}
 
+  tailwindcss@4.2.0:
+    resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
+
   tailwindcss@4.3.1:
     resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
 
@@ -8013,6 +8613,49 @@ packages:
       '@swc/core':
         optional: true
       esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+
+  terser-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
         optional: true
       uglify-js:
         optional: true
@@ -8123,6 +8766,10 @@ packages:
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
     engines: {node: '>= 0.4'}
+
+  to-fast-properties@2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -8538,6 +9185,10 @@ packages:
     resolution: {integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==}
     engines: {node: '>=10.13.0'}
 
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
+    engines: {node: '>=10.13.0'}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -8574,8 +9225,22 @@ packages:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
 
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
+    engines: {node: '>=10.13.0'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  webpack@5.105.0:
+    resolution: {integrity: sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
 
   webpack@5.93.0:
     resolution: {integrity: sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==}
@@ -8674,6 +9339,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -8695,6 +9372,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
@@ -8741,6 +9421,9 @@ packages:
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -9737,6 +10420,10 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
 
+  '@babel/parser@7.24.1':
+    dependencies:
+      '@babel/types': 7.28.5
+
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
@@ -10400,6 +11087,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/types@7.24.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      to-fast-properties: 2.0.0
+
   '@babel/types@7.28.5':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
@@ -10518,13 +11211,13 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.11':
     optional: true
 
-  '@chromatic-com/storybook@5.1.2(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@chromatic-com/storybook@5.1.2(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 13.3.5
       filesize: 10.1.4
       jsonfile: 6.1.0
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -10833,7 +11526,18 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11215,6 +11919,43 @@ snapshots:
       '@types/react': 19.0.10
       react: 19.2.1
 
+  '@mediabunny/aac-encoder@1.50.8(mediabunny@1.50.8)':
+    dependencies:
+      mediabunny: 1.50.8
+
+  '@mediabunny/flac-encoder@1.50.8(mediabunny@1.50.8)':
+    dependencies:
+      mediabunny: 1.50.8
+
+  '@mediabunny/mp3-encoder@1.50.8(mediabunny@1.50.8)':
+    dependencies:
+      mediabunny: 1.50.8
+
+  '@module-federation/error-codes@0.22.0': {}
+
+  '@module-federation/runtime-core@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
+  '@module-federation/runtime-tools@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/webpack-bundler-runtime': 0.22.0
+
+  '@module-federation/runtime@0.22.0':
+    dependencies:
+      '@module-federation/error-codes': 0.22.0
+      '@module-federation/runtime-core': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
+  '@module-federation/sdk@0.22.0': {}
+
+  '@module-federation/webpack-bundler-runtime@0.22.0':
+    dependencies:
+      '@module-federation/runtime': 0.22.0
+      '@module-federation/sdk': 0.22.0
+
   '@mswjs/interceptors@0.40.0':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -11223,6 +11964,13 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+
+  '@napi-rs/wasm-runtime@1.0.7':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
 
   '@neoconfetti/react@1.0.0': {}
 
@@ -11362,7 +12110,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.37.1
@@ -11372,7 +12120,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
     optionalDependencies:
       type-fest: 2.19.0
       webpack-hot-middleware: 2.26.1
@@ -11410,6 +12158,238 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
+    dependencies:
+      '@remotion/media-parser': 4.0.488
+      '@remotion/studio': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/studio-shared': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/timeline-utils': 4.0.488
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
+      '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)
+      css-loader: 7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      esbuild: 0.25.2
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-refresh: 0.18.0
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@swc/html'
+      - bufferutil
+      - clean-css
+      - cssnano
+      - csso
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+      - webpack-hot-middleware
+
+  '@remotion/canvas-capture@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      mediabunny: 1.50.8
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+
+  '@remotion/cli@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
+    dependencies:
+      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/media-utils': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/player': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/renderer': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/studio': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/studio-server': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/studio-shared': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      dotenv: 17.3.1
+      minimist: 1.2.6
+      prompts: 2.4.2
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@swc/html'
+      - bufferutil
+      - clean-css
+      - cssnano
+      - csso
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+      - webpack-hot-middleware
+
+  '@remotion/compositor-darwin-arm64@4.0.488':
+    optional: true
+
+  '@remotion/compositor-darwin-x64@4.0.488':
+    optional: true
+
+  '@remotion/compositor-linux-arm64-gnu@4.0.488':
+    optional: true
+
+  '@remotion/compositor-linux-arm64-musl@4.0.488':
+    optional: true
+
+  '@remotion/compositor-linux-x64-gnu@4.0.488':
+    optional: true
+
+  '@remotion/compositor-linux-x64-musl@4.0.488':
+    optional: true
+
+  '@remotion/compositor-win32-x64-msvc@4.0.488':
+    optional: true
+
+  '@remotion/licensing@4.0.488': {}
+
+  '@remotion/media-parser@4.0.488': {}
+
+  '@remotion/media-utils@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      mediabunny: 1.50.8
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+
+  '@remotion/player@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+
+  '@remotion/renderer@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@remotion/licensing': 4.0.488
+      '@remotion/streaming': 4.0.488
+      execa: 5.1.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      source-map: 0.8.0-beta.0
+      ws: 8.21.0
+    optionalDependencies:
+      '@remotion/compositor-darwin-arm64': 4.0.488
+      '@remotion/compositor-darwin-x64': 4.0.488
+      '@remotion/compositor-linux-arm64-gnu': 4.0.488
+      '@remotion/compositor-linux-arm64-musl': 4.0.488
+      '@remotion/compositor-linux-x64-gnu': 4.0.488
+      '@remotion/compositor-linux-x64-musl': 4.0.488
+      '@remotion/compositor-win32-x64-msvc': 4.0.488
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@remotion/streaming@4.0.488': {}
+
+  '@remotion/studio-server@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
+    dependencies:
+      '@babel/parser': 7.24.1
+      '@babel/types': 7.24.0
+      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/renderer': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/studio-shared': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      memfs: 3.4.3
+      open: 8.4.2
+      prettier: 3.8.1
+      recast: 0.23.11
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      semver: 7.5.3
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@swc/html'
+      - bufferutil
+      - clean-css
+      - cssnano
+      - csso
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - react
+      - react-dom
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+      - webpack-hot-middleware
+
+  '@remotion/studio-shared@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@remotion/studio@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@remotion/canvas-capture': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/media-utils': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/player': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/renderer': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/studio-shared': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/timeline-utils': 4.0.488
+      '@remotion/web-renderer': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@remotion/zod-types': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      mediabunny: 1.50.8
+      memfs: 3.4.3
+      open: 8.4.2
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      semver: 7.5.3
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@remotion/tailwind-v4@4.0.488(@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))':
+    dependencies:
+      '@remotion/bundler': 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@tailwindcss/webpack': 4.2.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      css-loader: 7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      style-loader: 4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      tailwindcss: 4.2.0
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@remotion/timeline-utils@4.0.488':
+    dependencies:
+      mediabunny: 1.50.8
+
+  '@remotion/web-renderer@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@mediabunny/aac-encoder': 1.50.8(mediabunny@1.50.8)
+      '@mediabunny/flac-encoder': 1.50.8(mediabunny@1.50.8)
+      '@mediabunny/mp3-encoder': 1.50.8(mediabunny@1.50.8)
+      '@remotion/licensing': 4.0.488
+      mediabunny: 1.50.8
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+
+  '@remotion/zod-types@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
     dependencies:
@@ -11553,6 +12533,69 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
+
+  '@rspack/binding-darwin-arm64@1.7.11':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.7.11':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@1.7.11':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.7.11':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@1.7.11':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.7.11':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@1.7.11':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.7.11':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@1.7.11':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.7.11':
+    optional: true
+
+  '@rspack/binding@1.7.11':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.7.11
+      '@rspack/binding-darwin-x64': 1.7.11
+      '@rspack/binding-linux-arm64-gnu': 1.7.11
+      '@rspack/binding-linux-arm64-musl': 1.7.11
+      '@rspack/binding-linux-x64-gnu': 1.7.11
+      '@rspack/binding-linux-x64-musl': 1.7.11
+      '@rspack/binding-wasm32-wasi': 1.7.11
+      '@rspack/binding-win32-arm64-msvc': 1.7.11
+      '@rspack/binding-win32-ia32-msvc': 1.7.11
+      '@rspack/binding-win32-x64-msvc': 1.7.11
+
+  '@rspack/core@1.7.11(@swc/helpers@0.5.15)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.22.0
+      '@rspack/binding': 1.7.11
+      '@rspack/lite-tapable': 1.1.0
+    optionalDependencies:
+      '@swc/helpers': 0.5.15
+
+  '@rspack/lite-tapable@1.1.0': {}
+
+  '@rspack/plugin-react-refresh@1.6.1(react-refresh@0.18.0)(webpack-hot-middleware@2.26.1)':
+    dependencies:
+      error-stack-parser: 2.1.4
+      html-entities: 2.6.0
+      react-refresh: 0.18.0
+    optionalDependencies:
+      webpack-hot-middleware: 2.26.1
 
   '@shikijs/core@3.12.1':
     dependencies:
@@ -11936,21 +12979,21 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/addon-a11y@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.0
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.0.10)(react@19.2.1)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11959,15 +13002,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.0.10)(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.0.10)(react@19.2.1)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/icons': 2.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11976,34 +13019,34 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-links@10.3.5(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/addon-links@10.3.5(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     optionalDependencies:
       react: 19.2.1
 
-  '@storybook/addon-mcp@0.6.0(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
+  '@storybook/addon-mcp@0.6.0(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
     dependencies:
       '@storybook/mcp': 0.7.0(typescript@5.5.4)
       '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.5.4))(valibot@1.2.0(typescript@5.5.4))
       '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.5.4))
       picoquery: 2.5.0
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tmcp: 1.19.3(typescript@5.5.4)
       valibot: 1.2.0(typescript@5.5.4)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/addon-onboarding@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/addon-onboarding@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-dedent: 2.2.0
       vite: 7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -12011,18 +13054,18 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-webpack5@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
+  '@storybook/builder-webpack5@10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
-      css-loader: 7.1.2(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      css-loader: 7.1.2(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       es-module-lexer: 1.6.0
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      html-webpack-plugin: 5.6.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      html-webpack-plugin: 5.6.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       magic-string: 0.30.17
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       style-loader: 4.0.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       terser-webpack-plugin: 5.3.14(@swc/core@1.13.5)(esbuild@0.25.2)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       ts-dedent: 2.2.0
@@ -12041,18 +13084,18 @@ snapshots:
       - vite
       - webpack-cli
 
-  '@storybook/builder-webpack5@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
+  '@storybook/builder-webpack5@10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
-      css-loader: 7.1.2(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      css-loader: 7.1.2(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       es-module-lexer: 1.6.0
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      html-webpack-plugin: 5.6.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      html-webpack-plugin: 5.6.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       magic-string: 0.30.17
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       style-loader: 4.0.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       terser-webpack-plugin: 5.3.14(@swc/core@1.13.5)(esbuild@0.25.2)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       ts-dedent: 2.2.0
@@ -12071,30 +13114,30 @@ snapshots:
       - vite
       - webpack-cli
 
-  '@storybook/core-webpack@10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/core-webpack@10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))':
     dependencies:
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.25.2
       rollup: 4.62.2
       vite: 6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.25.2
       rollup: 4.62.2
       vite: 7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)
 
   '@storybook/global@5.0.0': {}
 
@@ -12113,7 +13156,7 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/nextjs@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/nextjs@10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
@@ -12128,33 +13171,33 @@ snapshots:
       '@babel/preset-react': 7.24.7(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.28.5)
       '@babel/runtime': 7.29.2
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      '@storybook/builder-webpack5': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
-      '@storybook/preset-react-webpack': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
-      '@storybook/react': 10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
+      '@storybook/builder-webpack5': 10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
+      '@storybook/preset-react-webpack': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+      '@storybook/react': 10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      css-loader: 6.11.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
+      css-loader: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       image-size: 2.0.2
       loader-utils: 3.3.1
       next: 16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       postcss: 8.5.3
-      postcss-loader: 8.2.0(postcss@8.5.3)(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      postcss-loader: 8.2.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.5.4)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.6(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      sass-loader: 16.0.6(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       semver: 7.7.3
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      style-loader: 3.3.4(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      style-loader: 3.3.4(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.5.4
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -12175,7 +13218,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/nextjs@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/nextjs@10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(next@16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@2.19.0)(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
@@ -12190,33 +13233,33 @@ snapshots:
       '@babel/preset-react': 7.24.7(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.28.5)
       '@babel/runtime': 7.29.2
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      '@storybook/builder-webpack5': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
-      '@storybook/preset-react-webpack': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
-      '@storybook/react': 10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
+      '@storybook/builder-webpack5': 10.1.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.13.5)(esbuild@0.25.2)(msw@2.12.7(@types/node@17.0.45)(typescript@5.5.4))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
+      '@storybook/preset-react-webpack': 10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+      '@storybook/react': 10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      css-loader: 6.11.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
+      css-loader: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       image-size: 2.0.2
       loader-utils: 3.3.1
       next: 16.2.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       postcss: 8.5.3
-      postcss-loader: 8.2.0(postcss@8.5.3)(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      postcss-loader: 8.2.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.5.4)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.6(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      sass-loader: 16.0.6(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       semver: 7.7.3
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      style-loader: 3.3.4(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      style-loader: 3.3.4(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.5.4
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -12237,9 +13280,9 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
+  '@storybook/preset-react-webpack@10.1.11(@swc/core@1.13.5)(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
     dependencies:
-      '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/core-webpack': 10.1.11(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
       '@types/semver': 7.7.1
       magic-string: 0.30.17
@@ -12248,7 +13291,7 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       resolve: 1.22.11
       semver: 7.7.3
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tsconfig-paths: 4.2.0
       webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
     optionalDependencies:
@@ -12274,31 +13317,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/react-dom-shim@10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@storybook/react-dom-shim@10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/react-dom-shim@10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))':
+  '@storybook/react-vite@10.3.5(esbuild@0.25.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.5.4)(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2))
-      '@storybook/react': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
+      '@storybook/builder-vite': 10.3.5(esbuild@0.25.2)(rollup@4.62.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/react': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.1
       react-docgen: 8.0.2
       react-dom: 19.2.1(react@19.2.1)
       resolve: 1.22.11
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tsconfig-paths: 4.2.0
       vite: 7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -12308,28 +13351,28 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
+  '@storybook/react@10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/react-dom-shim': 10.1.11(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       react: 19.2.1
       react-docgen: 8.0.2
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react@10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
+  '@storybook/react@10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.5.4)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       react: 19.2.1
       react-docgen: 8.0.2
       react-docgen-typescript: 2.2.2(typescript@5.5.4)
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -12458,7 +13501,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.13.5':
     optional: true
 
-  '@swc/core@1.13.5':
+  '@swc/core@1.13.5(@swc/helpers@0.5.15)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.25
@@ -12473,6 +13516,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.13.5
       '@swc/core-win32-ia32-msvc': 1.13.5
       '@swc/core-win32-x64-msvc': 1.13.5
+      '@swc/helpers': 0.5.15
 
   '@swc/counter@0.1.3': {}
 
@@ -12490,6 +13534,16 @@ snapshots:
       jiti: 2.6.0
       tailwindcss: 4.0.9
 
+  '@tailwindcss/node@4.2.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.31.1
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.0
+
   '@tailwindcss/node@4.3.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -12503,10 +13557,16 @@ snapshots:
   '@tailwindcss/oxide-android-arm64@4.0.9':
     optional: true
 
+  '@tailwindcss/oxide-android-arm64@4.2.0':
+    optional: true
+
   '@tailwindcss/oxide-android-arm64@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.0.9':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.0':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.3.1':
@@ -12515,10 +13575,16 @@ snapshots:
   '@tailwindcss/oxide-darwin-x64@4.0.9':
     optional: true
 
+  '@tailwindcss/oxide-darwin-x64@4.2.0':
+    optional: true
+
   '@tailwindcss/oxide-darwin-x64@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.0.9':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.0':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.3.1':
@@ -12527,10 +13593,16 @@ snapshots:
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.0.9':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.0.9':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.0':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
@@ -12539,10 +13611,16 @@ snapshots:
   '@tailwindcss/oxide-linux-arm64-musl@4.0.9':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.0.9':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
@@ -12551,7 +13629,13 @@ snapshots:
   '@tailwindcss/oxide-linux-x64-musl@4.0.9':
     optional: true
 
+  '@tailwindcss/oxide-linux-x64-musl@4.2.0':
+    optional: true
+
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
@@ -12560,10 +13644,16 @@ snapshots:
   '@tailwindcss/oxide-win32-arm64-msvc@4.0.9':
     optional: true
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.0':
+    optional: true
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-win32-x64-msvc@4.0.9':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.0':
     optional: true
 
   '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
@@ -12582,6 +13672,21 @@ snapshots:
       '@tailwindcss/oxide-linux-x64-musl': 4.0.9
       '@tailwindcss/oxide-win32-arm64-msvc': 4.0.9
       '@tailwindcss/oxide-win32-x64-msvc': 4.0.9
+
+  '@tailwindcss/oxide@4.2.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.0
+      '@tailwindcss/oxide-darwin-arm64': 4.2.0
+      '@tailwindcss/oxide-darwin-x64': 4.2.0
+      '@tailwindcss/oxide-freebsd-x64': 4.2.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.0
 
   '@tailwindcss/oxide@4.3.1':
     optionalDependencies:
@@ -12613,6 +13718,14 @@ snapshots:
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
       vite: 7.3.5(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
+
+  '@tailwindcss/webpack@4.2.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.2.0
+      '@tailwindcss/oxide': 4.2.0
+      tailwindcss: 4.2.0
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
 
   '@tanstack/query-core@5.70.0': {}
 
@@ -12756,6 +13869,11 @@ snapshots:
       semver: 7.7.3
       update-check: 1.5.4
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -12803,6 +13921,12 @@ snapshots:
       '@types/ssh2': 1.15.5
 
   '@types/doctrine@0.0.9': {}
+
+  '@types/dom-mediacapture-transform@0.1.12':
+    dependencies:
+      '@types/dom-webcodecs': 0.1.13
+
+  '@types/dom-webcodecs@0.1.13': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -12910,16 +14034,16 @@ snapshots:
     dependencies:
       valibot: 1.2.0(typescript@5.5.4)
 
-  '@vitejs/plugin-react-swc@3.9.0(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react-swc@3.9.0(@swc/helpers@0.5.15)(vite@6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
-      '@swc/core': 1.13.5
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
       vite: 6.2.6(@types/node@17.0.45)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
   '@vitejs/plugin-react-swc@3.9.0(vite@6.2.6(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2))':
     dependencies:
-      '@swc/core': 1.13.5
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
       vite: 6.2.6(@types/node@18.19.130)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.31.3)(tsx@4.22.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -13019,11 +14143,22 @@ snapshots:
       '@webassemblyjs/helper-numbers': 1.11.6
       '@webassemblyjs/helper-wasm-bytecode': 1.11.6
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
   '@webassemblyjs/floating-point-hex-parser@1.11.6': {}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
 
   '@webassemblyjs/helper-api-error@1.11.6': {}
 
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
   '@webassemblyjs/helper-buffer@1.12.1': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
 
   '@webassemblyjs/helper-numbers@1.11.6':
     dependencies:
@@ -13031,7 +14166,15 @@ snapshots:
       '@webassemblyjs/helper-api-error': 1.11.6
       '@xtuc/long': 4.2.2
 
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
   '@webassemblyjs/helper-wasm-bytecode@1.11.6': {}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
 
   '@webassemblyjs/helper-wasm-section@1.12.1':
     dependencies:
@@ -13040,7 +14183,18 @@ snapshots:
       '@webassemblyjs/helper-wasm-bytecode': 1.11.6
       '@webassemblyjs/wasm-gen': 1.12.1
 
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
   '@webassemblyjs/ieee754@1.11.6':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/ieee754@1.13.2':
     dependencies:
       '@xtuc/ieee754': 1.2.0
 
@@ -13048,7 +14202,13 @@ snapshots:
     dependencies:
       '@xtuc/long': 4.2.2
 
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
   '@webassemblyjs/utf8@1.11.6': {}
+
+  '@webassemblyjs/utf8@1.13.2': {}
 
   '@webassemblyjs/wasm-edit@1.12.1':
     dependencies:
@@ -13061,6 +14221,17 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.12.1
       '@webassemblyjs/wast-printer': 1.12.1
 
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
   '@webassemblyjs/wasm-gen@1.12.1':
     dependencies:
       '@webassemblyjs/ast': 1.12.1
@@ -13069,12 +14240,27 @@ snapshots:
       '@webassemblyjs/leb128': 1.11.6
       '@webassemblyjs/utf8': 1.11.6
 
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
   '@webassemblyjs/wasm-opt@1.12.1':
     dependencies:
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/helper-buffer': 1.12.1
       '@webassemblyjs/wasm-gen': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
 
   '@webassemblyjs/wasm-parser@1.12.1':
     dependencies:
@@ -13085,9 +14271,23 @@ snapshots:
       '@webassemblyjs/leb128': 1.11.6
       '@webassemblyjs/utf8': 1.11.6
 
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
   '@webassemblyjs/wast-printer@1.12.1':
     dependencies:
       '@webassemblyjs/ast': 1.12.1
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
   '@webcontainer/env@1.1.1': {}
@@ -13106,6 +14306,10 @@ snapshots:
       negotiator: 1.0.0
 
   acorn-import-attributes@1.9.5(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn-import-phases@1.0.4(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
@@ -13278,12 +14482,12 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
     dependencies:
@@ -13925,7 +15129,7 @@ snapshots:
       postcss-selector-parser: 6.1.1
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -13936,20 +15140,36 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
+
+  css-loader@7.1.2(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.15)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.5.15)
+      postcss-modules-scope: 3.2.0(postcss@8.5.15)
+      postcss-modules-values: 4.0.0(postcss@8.5.15)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.3
+    optionalDependencies:
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
       webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
 
-  css-loader@7.1.2(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  css-loader@7.1.4(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.3)
-      postcss: 8.5.3
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.5.3)
-      postcss-modules-scope: 3.2.0(postcss@8.5.3)
-      postcss-modules-values: 4.0.0(postcss@8.5.3)
+      icss-utils: 5.1.0(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.15)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.5.15)
+      postcss-modules-scope: 3.2.0(postcss@8.5.15)
+      postcss-modules-values: 4.0.0(postcss@8.5.15)
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
 
   css-prefers-color-scheme@9.0.1(postcss@8.5.3):
     dependencies:
@@ -14047,6 +15267,8 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
 
@@ -14189,6 +15411,8 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dotenv@17.3.1: {}
+
   drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
@@ -14290,6 +15514,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.6.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -14619,6 +15845,8 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.1
 
+  fs-monkey@1.0.3: {}
+
   fs-monkey@1.0.6: {}
 
   fs.realpath@1.0.0: {}
@@ -14926,6 +16154,8 @@ snapshots:
 
   html-entities@2.5.2: {}
 
+  html-entities@2.6.0: {}
+
   html-minifier-terser@6.1.0:
     dependencies:
       camel-case: 4.1.2
@@ -14944,7 +16174,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  html-webpack-plugin@5.6.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14952,6 +16182,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
       webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
 
   htmlparser2@6.1.0:
@@ -15016,6 +16247,10 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  icss-utils@5.1.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
 
   icss-utils@5.1.0(postcss@8.5.3):
     dependencies:
@@ -15108,6 +16343,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@2.2.1: {}
+
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
@@ -15164,6 +16401,10 @@ snapshots:
   is-upper-case@1.1.2:
     dependencies:
       upper-case: 1.1.3
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   is-wsl@3.1.0:
     dependencies:
@@ -15267,6 +16508,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@3.0.3: {}
+
   kleur@4.1.5: {}
 
   kysely@0.29.2: {}
@@ -15275,10 +16518,16 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  lightningcss-android-arm64@1.31.1:
+    optional: true
+
   lightningcss-android-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-arm64@1.29.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.31.1:
     optional: true
 
   lightningcss-darwin-arm64@1.32.0:
@@ -15287,10 +16536,16 @@ snapshots:
   lightningcss-darwin-x64@1.29.1:
     optional: true
 
+  lightningcss-darwin-x64@1.31.1:
+    optional: true
+
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
   lightningcss-freebsd-x64@1.29.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.31.1:
     optional: true
 
   lightningcss-freebsd-x64@1.32.0:
@@ -15299,10 +16554,16 @@ snapshots:
   lightningcss-linux-arm-gnueabihf@1.29.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    optional: true
+
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.29.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.32.0:
@@ -15311,10 +16572,16 @@ snapshots:
   lightningcss-linux-arm64-musl@1.29.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.31.1:
+    optional: true
+
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.29.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-x64-gnu@1.32.0:
@@ -15323,16 +16590,25 @@ snapshots:
   lightningcss-linux-x64-musl@1.29.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.31.1:
+    optional: true
+
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.29.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.31.1:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.29.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.31.1:
     optional: true
 
   lightningcss-win32-x64-msvc@1.32.0:
@@ -15352,6 +16628,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.29.1
       lightningcss-win32-arm64-msvc: 1.29.1
       lightningcss-win32-x64-msvc: 1.29.1
+
+  lightningcss@1.31.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.31.1
+      lightningcss-darwin-arm64: 1.31.1
+      lightningcss-darwin-x64: 1.31.1
+      lightningcss-freebsd-x64: 1.31.1
+      lightningcss-linux-arm-gnueabihf: 1.31.1
+      lightningcss-linux-arm64-gnu: 1.31.1
+      lightningcss-linux-arm64-musl: 1.31.1
+      lightningcss-linux-x64-gnu: 1.31.1
+      lightningcss-linux-x64-musl: 1.31.1
+      lightningcss-win32-arm64-msvc: 1.31.1
+      lightningcss-win32-x64-msvc: 1.31.1
 
   lightningcss@1.32.0:
     dependencies:
@@ -15376,6 +16668,8 @@ snapshots:
   load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.0: {}
+
+  loader-runner@4.3.2: {}
 
   loader-utils@2.0.4:
     dependencies:
@@ -15435,6 +16729,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lru-cache@7.18.3: {}
 
@@ -15639,6 +16937,15 @@ snapshots:
   mdn-data@2.0.30: {}
 
   media-typer@1.1.0: {}
+
+  mediabunny@1.50.8:
+    dependencies:
+      '@types/dom-mediacapture-transform': 0.1.12
+      '@types/dom-webcodecs': 0.1.13
+
+  memfs@3.4.3:
+    dependencies:
+      fs-monkey: 1.0.3
 
   memfs@3.5.3:
     dependencies:
@@ -15913,6 +17220,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimist@1.2.6: {}
+
   minimist@1.2.8: {}
 
   minipass@4.2.8: {}
@@ -16089,7 +17398,7 @@ snapshots:
       mkdirp: 0.5.6
       resolve: 1.22.11
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -16116,7 +17425,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
 
   node-releases@2.0.27: {}
 
@@ -16195,6 +17504,12 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   openapi3-ts@4.5.0:
     dependencies:
@@ -16551,14 +17866,15 @@ snapshots:
       tsx: 4.22.0
       yaml: 2.8.2
 
-  postcss-loader@8.2.0(postcss@8.5.3)(typescript@5.5.4)(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  postcss-loader@8.2.0(@rspack/core@1.7.11(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.5.4)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.5.4)
       jiti: 2.6.0
       postcss: 8.5.3
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
     transitivePeerDependencies:
       - typescript
 
@@ -16567,9 +17883,20 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
   postcss-modules-extract-imports@3.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-modules-local-by-default@4.0.5(postcss@8.5.15):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.1
+      postcss-value-parser: 4.2.0
 
   postcss-modules-local-by-default@4.0.5(postcss@8.5.3):
     dependencies:
@@ -16578,10 +17905,20 @@ snapshots:
       postcss-selector-parser: 6.1.1
       postcss-value-parser: 4.2.0
 
+  postcss-modules-scope@3.2.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.1
+
   postcss-modules-scope@3.2.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.1
+
+  postcss-modules-values@4.0.0(postcss@8.5.15):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.15)
+      postcss: 8.5.15
 
   postcss-modules-values@4.0.0(postcss@8.5.3):
     dependencies:
@@ -16719,8 +18056,7 @@ snapshots:
 
   postgres@3.4.9: {}
 
-  prettier@2.8.8:
-    optional: true
+  prettier@3.8.1: {}
 
   pretty-error@4.0.0:
     dependencies:
@@ -16738,6 +18074,11 @@ snapshots:
   process-warning@5.0.0: {}
 
   process@0.11.10: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -16920,6 +18261,8 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-refresh@0.18.0: {}
+
   react@19.2.1: {}
 
   readable-stream@2.3.8:
@@ -16953,6 +18296,14 @@ snapshots:
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   recast@0.23.9:
     dependencies:
@@ -17071,6 +18422,11 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.0
       unified: 11.0.5
+
+  remotion@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   renderkid@3.0.0:
     dependencies:
@@ -17223,11 +18579,12 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.6(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  sass-loader@16.0.6(@rspack/core@1.7.11(@swc/helpers@0.5.15))(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
 
   saxes@6.0.0:
     dependencies:
@@ -17251,6 +18608,10 @@ snapshots:
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
+
+  semver@7.5.3:
+    dependencies:
+      lru-cache: 6.0.0
 
   semver@7.7.3: {}
 
@@ -17403,6 +18764,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sisteransi@1.0.5: {}
+
   slash@3.0.0: {}
 
   smart-buffer@4.2.0: {}
@@ -17484,7 +18847,7 @@ snapshots:
 
   std-env@3.9.0: {}
 
-  storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -17500,7 +18863,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.1)
       ws: 8.18.0
     optionalDependencies:
-      prettier: 2.8.8
+      prettier: 3.8.1
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
@@ -17600,9 +18963,13 @@ snapshots:
       lodash: 4.17.21
       tinycolor2: 1.6.0
 
-  style-loader@3.3.4(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
+  style-loader@3.3.4(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
     dependencies:
-      webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
+
+  style-loader@4.0.0(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)):
+    dependencies:
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
 
   style-loader@4.0.0(webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)):
     dependencies:
@@ -17670,6 +19037,8 @@ snapshots:
 
   tailwindcss@4.0.9: {}
 
+  tailwindcss@4.2.0: {}
+
   tailwindcss@4.3.1: {}
 
   tapable@2.2.1: {}
@@ -17730,8 +19099,47 @@ snapshots:
       terser: 5.31.3
       webpack: 5.93.0(@swc/core@1.13.5)(esbuild@0.25.2)
     optionalDependencies:
-      '@swc/core': 1.13.5
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
       esbuild: 0.25.2
+
+  terser-webpack-plugin@5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.31.3
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)
+    optionalDependencies:
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
+      esbuild: 0.25.2
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+    optional: true
+
+  terser-webpack-plugin@5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.31.3
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)
+    optionalDependencies:
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
+      esbuild: 0.25.2
+      lightningcss: 1.32.0
+      postcss: 8.5.3
+
+  terser-webpack-plugin@5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.31.3
+      webpack: 5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)
+    optionalDependencies:
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
+      esbuild: 0.25.2
+      postcss: 8.5.15
 
   terser@5.16.9:
     dependencies:
@@ -17866,6 +19274,8 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
+  to-fast-properties@2.0.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -17918,7 +19328,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.13.5
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
 
   ts-tqdm@0.8.6: {}
 
@@ -17958,7 +19368,7 @@ snapshots:
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.13.5
+      '@swc/core': 1.13.5(@swc/helpers@0.5.15)
       postcss: 8.5.15
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -18362,6 +19772,10 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
+  watchpack@2.5.2:
+    dependencies:
+      graceful-fs: 4.2.11
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -18394,7 +19808,133 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
+  webpack-sources@3.5.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.6
+      es-module-lexer: 2.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.15))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+    optional: true
+
+  webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.6
+      es-module-lexer: 2.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(lightningcss@1.32.0)(postcss@8.5.3))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.6
+      es-module-lexer: 2.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15)(webpack@5.105.0(@swc/core@1.13.5)(esbuild@0.25.2)(postcss@8.5.15))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   webpack@5.93.0(@swc/core@1.13.5)(esbuild@0.25.2):
     dependencies:
@@ -18526,6 +20066,8 @@ snapshots:
 
   ws@8.18.0: {}
 
+  ws@8.21.0: {}
+
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.0
@@ -18539,6 +20081,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.8.2: {}
 
@@ -18591,6 +20135,8 @@ snapshots:
       readable-stream: 4.7.0
 
   zod@3.23.8: {}
+
+  zod@4.3.6: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
## Summary

Adds `apps/scene-studio`, a Remotion-based app for programmatic short-form video generation (Phase 1 of the video platform plan). Includes an asset-free `brand-demo` composition (1080×1920, 30fps, 15s), full monorepo integration, media `.gitignore` rules, and the template design & naming guidelines.

### What changed?

- New workspace `apps/scene-studio`: Remotion Studio (`dev`, port 3002), local rendering (`render`), bundling (`build`), wired into Turborepo/Biome/tsconfig conventions (package-level `turbo.json` for `build/**` outputs)
- `brand-demo` composition: 3 scenes (title, color tokens, typography) built only from CSS/text — works right after clone with zero media assets
- Tailwind v4 via `@remotion/tailwind-v4` (composable webpack override), reusing `packages/tailwind-config` design tokens and the `--font-original` brand font stack
- Root `.gitignore`: `apps/scene-studio/public/assets/` and media file extensions are never committed
- New `.claude/rules/remotion-template-guidelines.md` (3-layer template structure, naming rules, no universal templates), linked from `AGENTS.md`
- `AGENTS.md`: scene-studio in Project Structure / Commands + new "Scene Studio (Video Generation)" section

### Why was this changed?

- Brand videos are currently hand-made per post; this makes videos *template + brand rules + assets + composition data*, reproducible and eventually generatable by AI agents (#380)
- Note: webpack is Remotion's built-in toolchain (`@remotion/bundler`), not a project choice — it is fully encapsulated in this app (no own webpack config; blog/portfolio stay on Turbopack, ui Storybook on Vite). Rationale documented in the app README

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] 📦 Dependency updates
- [x] 🏗️ Build/CI changes

## Affected Applications

- [x] 🏗️ Build configuration (Turborepo, configs)

New app `apps/scene-studio/` (not in the list above); blog / portfolio / ui are untouched.

## Testing

### Test Coverage

- [x] Manual testing completed
- [x] No tests needed (explain why below)

No unit-testable logic in this PR (scaffold + demo composition). Schema/timeline unit tests arrive with the data-driven pattern in #382.

### How to Test

1. `pnpm install`
2. `pnpm -F scene-studio dev` → Remotion Studio on http://localhost:3002, scrub `demo/brand-demo`
3. `pnpm -F scene-studio render brand-demo` → MP4 at `apps/scene-studio/out/brand-demo.mp4`
4. `pnpm lint && pnpm typecheck && pnpm test && pnpm docs:check`
5. Drop a dummy `.mp4` into `apps/scene-studio/public/assets/` and confirm `git status` stays clean

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

Verified locally: MP4 render succeeds (450 frames), still frames confirm design tokens (#b8d200 underline, brand swatches) and the Menlo/YuGothic font stack are applied.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Screenshots/Videos

### Before

n/a (new app)

### After

`pnpm -F scene-studio render brand-demo` produces `out/brand-demo.mp4` — title scene (K2BG + main-default underline), color-token scene, typography scene.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

Rendering is local-macOS-only for now (brand system fonts are unavailable on Linux/CI) — documented in the app README.

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings
- [x] Performance impact considered

## Related Issues

Closes #380
Relates to #381, #382

## Additional Context

All `remotion` / `@remotion/*` packages are exact-pinned to one identical version (Remotion requirement); bump them together in a single commit. The webpack override in `remotion.config.ts` is written as a composable function so future integrations (e.g. Three.js loaders) can chain onto `enableTailwind`.

## Reviewer Notes

- The `docs-check-ignore` comment in `.claude/rules/remotion-template-guidelines.md` covers the forward reference to `packages/scene-ui` (created in #381); it will be removed there
- `.claude/rules/remotion-template-guidelines.md` encodes the agreed template philosophy (generic primitives → generic patterns → use-case compositions) — worth a close read since future work builds on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)