### PR TITLE
✨ Feat: #382 Add VisualShowcase pattern

### DIFF
--- a/apps/scene-studio/README.md
+++ b/apps/scene-studio/README.md
@@ -14,6 +14,7 @@ generic primitives → generic patterns → use-case compositions).
 ```bash
 pnpm -F scene-studio dev                  # Remotion Studio on http://localhost:3002
 pnpm -F scene-studio render brand-demo    # render an MP4 to out/<composition-id>.mp4
+pnpm -F scene-studio render visual-showcase --props=./data/visual-showcase.sample.json
 pnpm -F scene-studio build                # bundle (webpack smoke test, outputs build/)
 pnpm -F scene-studio lint                 # biome check
 pnpm -F scene-studio typecheck            # tsc --noEmit
@@ -30,6 +31,9 @@ Rendered files (`out/`), bundles (`build/`), and media assets are gitignored.
   safe-area tokens.
 - `src/compositions/` — compositions registered in Studio, including one demo
   composition per primitive (`primitives` folder in the sidebar).
+- `src/patterns/VisualShowcase/` — the layer-2, data-driven vertical media
+  showcase pattern. Its schema-conforming sample input lives at
+  `data/visual-showcase.sample.json`.
 
 Layer rules live in `.claude/rules/remotion-template-guidelines.md`. The layers
 are app-internal directories on purpose — extract one into a `packages/`-level

--- a/apps/scene-studio/data/visual-showcase.sample.json
+++ b/apps/scene-studio/data/visual-showcase.sample.json
@@ -1,0 +1,25 @@
+{
+  "title": "Quiet Forms",
+  "subtitle": "A visual study in light and structure",
+  "items": [
+    {
+      "mediaType": "image",
+      "src": "https://images.unsplash.com/photo-1497366754035-f200968a6e72?auto=format&fit=crop&w=1080&q=80",
+      "durationInSeconds": 4,
+      "caption": "A room shaped by morning light"
+    },
+    {
+      "mediaType": "image",
+      "src": "https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&w=1080&q=80",
+      "durationInSeconds": 4,
+      "caption": "Details that invite a second look"
+    },
+    {
+      "mediaType": "image",
+      "src": "https://images.unsplash.com/photo-1497366811353-6870744d04b2?auto=format&fit=crop&w=1080&q=80",
+      "durationInSeconds": 4,
+      "caption": "A place for deliberate work"
+    }
+  ],
+  "cta": "Explore more work"
+}

--- a/apps/scene-studio/package.json
+++ b/apps/scene-studio/package.json
@@ -14,11 +14,13 @@
   },
   "dependencies": {
     "@remotion/cli": "4.0.488",
+    "@remotion/transitions": "4.0.488",
     "clsx": "^2.1.1",
     "react": "^19.0.1",
     "react-dom": "^19.0.1",
     "remotion": "4.0.488",
-    "tailwind-merge": "^2.5.3"
+    "tailwind-merge": "^2.5.3",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@remotion/tailwind-v4": "4.0.488",

--- a/apps/scene-studio/src/Root.tsx
+++ b/apps/scene-studio/src/Root.tsx
@@ -1,17 +1,25 @@
 import { Composition, Folder } from 'remotion';
-
+import visualShowcaseSample from '../data/visual-showcase.sample.json';
 import { BrandDemo } from './compositions/BrandDemo';
 import { getBrandDemoDurationInFrames } from './compositions/BrandDemo/scenes';
 import {
   PRIMITIVE_DEMO_DURATION_IN_FRAMES,
   primitiveDemos,
 } from './compositions/primitives/demos';
+import { VisualShowcase } from './patterns/VisualShowcase';
+import {
+  calculateVisualShowcaseMetadata,
+  getVisualShowcaseDurationInFrames,
+} from './patterns/VisualShowcase/timeline';
+import { visualShowcaseSchema } from './schemas/visualShowcase';
 
 import './style.css';
 
 const SCENE_WIDTH = 1080;
 const SCENE_HEIGHT = 1920;
 const SCENE_FPS = 30;
+const visualShowcaseDefaultProps =
+  visualShowcaseSchema.parse(visualShowcaseSample);
 
 export function RemotionRoot() {
   return (
@@ -38,6 +46,21 @@ export function RemotionRoot() {
             durationInFrames={PRIMITIVE_DEMO_DURATION_IN_FRAMES}
           />
         ))}
+      </Folder>
+      <Folder name="patterns">
+        <Composition
+          id="visual-showcase"
+          component={VisualShowcase}
+          width={SCENE_WIDTH}
+          height={SCENE_HEIGHT}
+          fps={SCENE_FPS}
+          durationInFrames={getVisualShowcaseDurationInFrames(
+            visualShowcaseDefaultProps
+          )}
+          defaultProps={visualShowcaseDefaultProps}
+          schema={visualShowcaseSchema}
+          calculateMetadata={calculateVisualShowcaseMetadata}
+        />
       </Folder>
     </>
   );

--- a/apps/scene-studio/src/patterns/VisualShowcase/VisualShowcase.test.tsx
+++ b/apps/scene-studio/src/patterns/VisualShowcase/VisualShowcase.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { VisualShowcase } from './VisualShowcase';
+
+vi.mock('remotion', () => ({
+  AbsoluteFill: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  interpolate: (
+    input: number,
+    [inputStart, inputEnd]: [number, number],
+    [outputStart, outputEnd]: [number, number]
+  ) =>
+    outputStart +
+    ((Math.min(Math.max(input, inputStart), inputEnd) - inputStart) /
+      (inputEnd - inputStart)) *
+      (outputEnd - outputStart),
+  Sequence: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  useCurrentFrame: () => 30,
+  useVideoConfig: () => ({ fps: 30 }),
+}));
+
+vi.mock('@remotion/transitions', () => {
+  const TransitionSeries = ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  );
+
+  TransitionSeries.Sequence = ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  );
+  TransitionSeries.Transition = () => <div data-testid="transition" />;
+
+  return {
+    linearTiming: vi.fn(),
+    TransitionSeries,
+  };
+});
+
+vi.mock('@remotion/transitions/fade', () => ({ fade: vi.fn() }));
+
+vi.mock('../../primitives', () => ({
+  BrandOutro: ({ cta }: { cta?: string }) => (
+    <div data-testid="brand-outro">{cta}</div>
+  ),
+  Caption: ({ text }: { text: string }) => <p data-testid="caption">{text}</p>,
+  GradientOverlay: () => <div data-testid="gradient-overlay" />,
+  Logo: () => <div data-testid="logo" />,
+  MediaFrame: ({
+    mediaType,
+    src,
+    startFromInFrames,
+  }: {
+    mediaType: string;
+    src: string;
+    startFromInFrames?: number;
+  }) => (
+    <div
+      data-testid="media-frame"
+      data-media-type={mediaType}
+      data-src={src}
+      data-start-from-in-frames={startFromInFrames}
+    />
+  ),
+  SafeArea: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  VideoTitle: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('VisualShowcase', () => {
+  it('renders the supplied media, caption, title, subtitle, and outro call to action', () => {
+    render(
+      <VisualShowcase
+        title="Quiet Forms"
+        subtitle="A visual study"
+        cta="Explore more work"
+        items={[
+          {
+            mediaType: 'image',
+            src: 'https://example.com/first.jpg',
+            durationInSeconds: 4,
+            caption: 'Morning light',
+          },
+          {
+            mediaType: 'video',
+            src: 'https://example.com/second.mp4',
+            durationInSeconds: 3,
+            startFromInSeconds: 1.5,
+          },
+        ]}
+      />
+    );
+
+    const mediaFrames = screen.getAllByTestId('media-frame');
+
+    expect(screen.getByRole('heading', { name: 'Quiet Forms' })).toBeDefined();
+    expect(screen.getByText('A visual study')).toBeDefined();
+    expect(screen.getByText('Morning light')).toBeDefined();
+    expect(screen.getByTestId('gradient-overlay')).toBeDefined();
+    expect(screen.getByTestId('brand-outro').textContent).toBe(
+      'Explore more work'
+    );
+    expect(screen.getByTestId('logo')).toBeDefined();
+    expect(mediaFrames).toHaveLength(2);
+    expect(mediaFrames[0]?.getAttribute('data-src')).toBe(
+      'https://example.com/first.jpg'
+    );
+    expect(mediaFrames[1]?.getAttribute('data-media-type')).toBe('video');
+    expect(mediaFrames[1]?.getAttribute('data-start-from-in-frames')).toBe(
+      '45'
+    );
+    expect(screen.getAllByTestId('transition')).toHaveLength(2);
+  });
+
+  it('omits optional text and caption treatment when no optional props are supplied', () => {
+    render(
+      <VisualShowcase
+        title="Quiet Forms"
+        items={[
+          {
+            mediaType: 'image',
+            src: 'https://example.com/first.jpg',
+            durationInSeconds: 4,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Quiet Forms' })).toBeDefined();
+    expect(screen.queryByTestId('caption')).toBeNull();
+    expect(screen.queryByTestId('gradient-overlay')).toBeNull();
+    expect(screen.getByTestId('brand-outro').childElementCount).toBe(0);
+    expect(screen.getByTestId('brand-outro').textContent).toBe('');
+    expect(screen.getAllByTestId('transition')).toHaveLength(1);
+  });
+});

--- a/apps/scene-studio/src/patterns/VisualShowcase/VisualShowcase.tsx
+++ b/apps/scene-studio/src/patterns/VisualShowcase/VisualShowcase.tsx
@@ -1,0 +1,114 @@
+import { linearTiming, TransitionSeries } from '@remotion/transitions';
+import { fade } from '@remotion/transitions/fade';
+import { Fragment } from 'react';
+import {
+  AbsoluteFill,
+  Sequence,
+  useCurrentFrame,
+  useVideoConfig,
+} from 'remotion';
+
+import {
+  BrandOutro,
+  Caption,
+  GradientOverlay,
+  Logo,
+  MediaFrame,
+  SafeArea,
+  VideoTitle,
+} from '../../primitives';
+import type { VisualShowcaseProps } from '../../schemas/visualShowcase';
+import { durationsInFrames } from '../../tokens/motion';
+import { getKenBurnsTransform } from './kenBurns';
+import {
+  getItemDurationInFrames,
+  VISUAL_SHOWCASE_TRANSITION_DURATION_IN_FRAMES,
+} from './timeline';
+
+interface ItemProps {
+  item: VisualShowcaseProps['items'][number];
+  itemIndex: number;
+}
+
+function VisualShowcaseItem({ item, itemIndex }: ItemProps) {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const durationInFrames = getItemDurationInFrames(item.durationInSeconds);
+
+  return (
+    <AbsoluteFill>
+      <MediaFrame
+        mediaType={item.mediaType}
+        src={item.src}
+        startFromInFrames={
+          item.startFromInSeconds === undefined
+            ? undefined
+            : Math.round(item.startFromInSeconds * fps)
+        }
+        transform={getKenBurnsTransform({
+          frame,
+          durationInFrames,
+          itemIndex,
+        })}
+      />
+      {item.caption === undefined ? null : (
+        <>
+          <GradientOverlay />
+          <SafeArea className="flex flex-col justify-end">
+            <Caption
+              text={item.caption}
+              exitAtFrame={durationInFrames - durationsInFrames.fast}
+            />
+          </SafeArea>
+        </>
+      )}
+    </AbsoluteFill>
+  );
+}
+
+export function VisualShowcase(props: VisualShowcaseProps) {
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <TransitionSeries>
+        {props.items.map((item, itemIndex) => (
+          <Fragment key={`${item.src}-${itemIndex}`}>
+            <TransitionSeries.Sequence
+              durationInFrames={getItemDurationInFrames(item.durationInSeconds)}
+            >
+              <VisualShowcaseItem item={item} itemIndex={itemIndex} />
+            </TransitionSeries.Sequence>
+            {itemIndex === props.items.length - 1 ? null : (
+              <TransitionSeries.Transition
+                presentation={fade()}
+                timing={linearTiming({
+                  durationInFrames:
+                    VISUAL_SHOWCASE_TRANSITION_DURATION_IN_FRAMES,
+                })}
+              />
+            )}
+          </Fragment>
+        ))}
+        <TransitionSeries.Transition
+          presentation={fade()}
+          timing={linearTiming({
+            durationInFrames: VISUAL_SHOWCASE_TRANSITION_DURATION_IN_FRAMES,
+          })}
+        />
+        <TransitionSeries.Sequence durationInFrames={durationsInFrames.outro}>
+          <BrandOutro cta={props.cta} />
+        </TransitionSeries.Sequence>
+      </TransitionSeries>
+      <SafeArea>
+        <Logo />
+      </SafeArea>
+      <Sequence durationInFrames={durationsInFrames.titleHold}>
+        <SafeArea className="flex flex-col justify-center gap-8">
+          <VideoTitle title={props.title} />
+          {props.subtitle === undefined ? null : (
+            <Caption text={props.subtitle} enterDelayInFrames={10} />
+          )}
+        </SafeArea>
+      </Sequence>
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/patterns/VisualShowcase/index.ts
+++ b/apps/scene-studio/src/patterns/VisualShowcase/index.ts
@@ -1,0 +1,1 @@
+export { VisualShowcase } from './VisualShowcase';

--- a/apps/scene-studio/src/patterns/VisualShowcase/kenBurns.test.ts
+++ b/apps/scene-studio/src/patterns/VisualShowcase/kenBurns.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { getKenBurnsTransform } from './kenBurns';
+
+describe('getKenBurnsTransform', () => {
+  it('starts each item at its unscaled position', () => {
+    const result = getKenBurnsTransform({
+      frame: 0,
+      durationInFrames: 120,
+      itemIndex: 0,
+    });
+
+    expect(result).toBe('scale(1) translate(0%, 0%)');
+  });
+
+  it('applies a deterministic zoom and pan for each item index', () => {
+    const result = getKenBurnsTransform({
+      frame: 120,
+      durationInFrames: 120,
+      itemIndex: 1,
+    });
+
+    expect(result).toBe('scale(1.08) translate(2%, -2%)');
+  });
+
+  it('clamps motion outside an item duration', () => {
+    const result = getKenBurnsTransform({
+      frame: 200,
+      durationInFrames: 120,
+      itemIndex: 2,
+    });
+
+    expect(result).toBe('scale(1.08) translate(-2%, 2%)');
+  });
+});

--- a/apps/scene-studio/src/patterns/VisualShowcase/kenBurns.ts
+++ b/apps/scene-studio/src/patterns/VisualShowcase/kenBurns.ts
@@ -1,0 +1,32 @@
+import { interpolate } from 'remotion';
+
+interface KenBurnsTransformInput {
+  frame: number;
+  durationInFrames: number;
+  itemIndex: number;
+}
+
+const PAN_DIRECTIONS = [
+  { x: -2, y: -2 },
+  { x: 2, y: -2 },
+  { x: -2, y: 2 },
+  { x: 2, y: 2 },
+] as const;
+
+export function getKenBurnsTransform({
+  frame,
+  durationInFrames,
+  itemIndex,
+}: KenBurnsTransformInput): string {
+  const progress = interpolate(frame, [0, durationInFrames], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+  const panDirection =
+    PAN_DIRECTIONS[itemIndex % PAN_DIRECTIONS.length] ?? PAN_DIRECTIONS[0];
+  const scale = interpolate(progress, [0, 1], [1, 1.08]);
+  const translateX = interpolate(progress, [0, 1], [0, panDirection.x]);
+  const translateY = interpolate(progress, [0, 1], [0, panDirection.y]);
+
+  return `scale(${scale}) translate(${translateX}%, ${translateY}%)`;
+}

--- a/apps/scene-studio/src/patterns/VisualShowcase/timeline.test.ts
+++ b/apps/scene-studio/src/patterns/VisualShowcase/timeline.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  calculateVisualShowcaseMetadata,
+  getItemDurationInFrames,
+  getVisualShowcaseDurationInFrames,
+  VISUAL_SHOWCASE_TRANSITION_DURATION_IN_FRAMES,
+} from './timeline';
+
+const props = {
+  title: 'Quiet Forms',
+  items: [
+    {
+      mediaType: 'image' as const,
+      src: 'https://images.example.com/one.jpg',
+      durationInSeconds: 4,
+    },
+    {
+      mediaType: 'video' as const,
+      src: 'https://videos.example.com/two.mp4',
+      durationInSeconds: 3,
+    },
+  ],
+};
+
+describe('VisualShowcase timeline', () => {
+  it('converts item seconds to frames at the scene frame rate', () => {
+    const result = getItemDurationInFrames(2.5);
+
+    expect(result).toBe(75);
+  });
+
+  it('overlaps each item transition and appends the brand outro', () => {
+    const result = getVisualShowcaseDurationInFrames(props);
+
+    expect(result).toBe(
+      4 * 30 + 3 * 30 - VISUAL_SHOWCASE_TRANSITION_DURATION_IN_FRAMES * 2 + 75
+    );
+  });
+
+  it('parses metadata props before deriving the duration', () => {
+    const result = calculateVisualShowcaseMetadata({
+      props,
+      defaultProps: props,
+      abortSignal: new AbortController().signal,
+      compositionId: 'visual-showcase',
+      isRendering: false,
+    });
+
+    expect(result).toEqual({ durationInFrames: 255 });
+  });
+
+  it('fails with Zod details when metadata props are invalid', () => {
+    const invalidProps = { ...props, items: [] };
+
+    expect(() =>
+      calculateVisualShowcaseMetadata({
+        props: invalidProps,
+        defaultProps: props,
+        abortSignal: new AbortController().signal,
+        compositionId: 'visual-showcase',
+        isRendering: false,
+      })
+    ).toThrow('Array must contain at least 1 element');
+  });
+});

--- a/apps/scene-studio/src/patterns/VisualShowcase/timeline.ts
+++ b/apps/scene-studio/src/patterns/VisualShowcase/timeline.ts
@@ -1,0 +1,38 @@
+import type { CalculateMetadataFunction } from 'remotion';
+
+import {
+  type VisualShowcaseProps,
+  visualShowcaseSchema,
+} from '../../schemas/visualShowcase';
+import { durationsInFrames, SCENE_FPS } from '../../tokens/motion';
+
+export const VISUAL_SHOWCASE_TRANSITION_DURATION_IN_FRAMES =
+  durationsInFrames.transition;
+
+export function getItemDurationInFrames(durationInSeconds: number): number {
+  return Math.round(durationInSeconds * SCENE_FPS);
+}
+
+export function getVisualShowcaseDurationInFrames(
+  props: VisualShowcaseProps
+): number {
+  const itemDurationInFrames = props.items.reduce(
+    (totalDurationInFrames, item) =>
+      totalDurationInFrames + getItemDurationInFrames(item.durationInSeconds),
+    0
+  );
+  const transitionOverlapInFrames =
+    props.items.length * VISUAL_SHOWCASE_TRANSITION_DURATION_IN_FRAMES;
+
+  return (
+    itemDurationInFrames - transitionOverlapInFrames + durationsInFrames.outro
+  );
+}
+
+export const calculateVisualShowcaseMetadata: CalculateMetadataFunction<
+  VisualShowcaseProps
+> = ({ props }) => {
+  const validProps = visualShowcaseSchema.parse(props);
+
+  return { durationInFrames: getVisualShowcaseDurationInFrames(validProps) };
+};

--- a/apps/scene-studio/src/schemas/visualShowcase.test.ts
+++ b/apps/scene-studio/src/schemas/visualShowcase.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { visualShowcaseSchema } from './visualShowcase';
+
+const validProps = {
+  title: 'Quiet Forms',
+  subtitle: 'A visual study',
+  items: [
+    {
+      mediaType: 'image' as const,
+      src: 'https://images.example.com/quiet-forms.jpg',
+      durationInSeconds: 4,
+      caption: 'Morning light',
+    },
+  ],
+  cta: 'Explore more work',
+};
+
+describe('visualShowcaseSchema', () => {
+  it('accepts constrained showcase input', () => {
+    const result = visualShowcaseSchema.safeParse(validProps);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    {
+      description: 'has no items',
+      props: { ...validProps, items: [] },
+      expectedPath: 'items',
+    },
+    {
+      description: 'uses a duration shorter than two seconds',
+      props: {
+        ...validProps,
+        items: [{ ...validProps.items[0], durationInSeconds: 1 }],
+      },
+      expectedPath: 'items.0.durationInSeconds',
+    },
+    {
+      description: 'uses an unsupported media type',
+      props: {
+        ...validProps,
+        items: [{ ...validProps.items[0], mediaType: 'audio' }],
+      },
+      expectedPath: 'items.0.mediaType',
+    },
+  ])('rejects input that $description', ({ props, expectedPath }) => {
+    const result = visualShowcaseSchema.safeParse(props);
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues[0]?.path.join('.')).toBe(expectedPath);
+  });
+});

--- a/apps/scene-studio/src/schemas/visualShowcase.ts
+++ b/apps/scene-studio/src/schemas/visualShowcase.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const visualShowcaseSchema = z.object({
+  title: z.string().min(1),
+  subtitle: z.string().min(1).optional(),
+  items: z
+    .array(
+      z.object({
+        mediaType: z.enum(['image', 'video']),
+        src: z.string().min(1),
+        durationInSeconds: z.number().min(2).max(30),
+        startFromInSeconds: z.number().min(0).optional(),
+        caption: z.string().min(1).optional(),
+      })
+    )
+    .min(1),
+  cta: z.string().min(1).optional(),
+});
+
+export type VisualShowcaseProps = z.infer<typeof visualShowcaseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       '@remotion/cli':
         specifier: 4.0.488
         version: 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/transitions':
+        specifier: 4.0.488
+        version: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -341,6 +344,9 @@ importers:
       tailwind-merge:
         specifier: ^2.5.3
         version: 2.5.3
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@remotion/tailwind-v4':
         specifier: 4.0.488
@@ -2761,6 +2767,9 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@remotion/paths@4.0.488':
+    resolution: {integrity: sha512-MyF1vol5fM7RUBzoNgiGC/wo+6beqXqTqeWvA7Fmn3WU5+EVu1KoZBMM0IV2wKLF5oXNC6gbtanp2urfuD1W1g==}
+
   '@remotion/player@4.0.488':
     resolution: {integrity: sha512-bP9y6PFHtP79ikR2zxFiMwR11Cc5BoN9+PEP1YEdMXhkf4o+zDj6PzNw/Va2SjWhozrOTgVshgs1QZfQYleEkg==}
     peerDependencies:
@@ -2769,6 +2778,12 @@ packages:
 
   '@remotion/renderer@4.0.488':
     resolution: {integrity: sha512-gChcGkdrp4/0hmJDUU75bmvOk6RSO+xbzpQM82DvGbBEKHd/PmfEObsPXW9biMvJ2PG9IUAbfNhCBLJZMOTL6A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@remotion/shapes@4.0.488':
+    resolution: {integrity: sha512-oV2ss6G8lG0aI5pQWdihd9yZmgSaG+dNlNZFRVb6tglECdbX7t9pqrSPZZAwKxeCnyQnjSz9AyTakPZXkKWK3g==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -2795,6 +2810,12 @@ packages:
 
   '@remotion/timeline-utils@4.0.488':
     resolution: {integrity: sha512-TwC4bPkJHm9hwtzI2pVjERKCmcsw82FoGSecc7c7Bwo9az+1l0KenTg1HznMVhqJRtMTTyDSZvkiD7Lat1TFdg==}
+
+  '@remotion/transitions@4.0.488':
+    resolution: {integrity: sha512-b89KyQRkhynn8HXYRs0VrOfOrWjsMNaGgHS/CAJHmWZ0txnd6+1o2gYwdda4IAHBWYtA7fjj5buA445dt4ZUsA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   '@remotion/web-renderer@4.0.488':
     resolution: {integrity: sha512-9hzmwPGRUvlXs0pjdlI4kIS3nogVOa6Wheoob+S7PxaFLK2wobxbNtTAKNidoLJXfv/chCo65v1ThPJFsyb5qw==}
@@ -12280,6 +12301,8 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
+  '@remotion/paths@4.0.488': {}
+
   '@remotion/player@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       react: 19.2.1
@@ -12307,6 +12330,13 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@remotion/shapes@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@remotion/paths': 4.0.488
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   '@remotion/streaming@4.0.488': {}
 
@@ -12387,6 +12417,14 @@ snapshots:
   '@remotion/timeline-utils@4.0.488':
     dependencies:
       mediabunny: 1.50.8
+
+  '@remotion/transitions@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@remotion/paths': 4.0.488
+      '@remotion/shapes': 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   '@remotion/web-renderer@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:


### PR DESCRIPTION
## Summary

Add the first layer-2 generic Remotion pattern for creating data-driven vertical media showcase videos.

### What changed?

- Added the `VisualShowcase` composition with fade transitions, deterministic Ken Burns motion, captions, persistent branding, and a brand outro.
- Added a Zod v3 schema, dynamic composition metadata, sample JSON input, and rendering documentation.
- Added schema, timeline, and motion unit tests.

### Why was this changed?

Video output needs validated, JSON-driven composition data so it can be generated safely without manually editing timelines.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test additions or updates
- [x] 📦 Dependency updates

## Affected Applications

- [ ] 📝 Blog app (`apps/blog/`)
- [ ] 💼 Portfolio app (`apps/portfolio/`)
- [ ] 🎨 UI package (`packages/ui/`)
- [ ] 🔧 Shared packages (`packages/`)
- [ ] 🏗️ Build configuration (Turborepo, configs)

`apps/scene-studio` is affected; it is not listed in the current template.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed

### How to Test

1. Run `pnpm -F scene-studio render visual-showcase --props=./data/visual-showcase.sample.json`.
2. Open the generated `apps/scene-studio/out/visual-showcase.mp4`.
3. Edit an item duration in the sample JSON and render again to confirm the composition duration changes.

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes
- [x] Manual MP4 rendering succeeds

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Screenshots/Videos

### After

Rendered `visual-showcase.mp4` locally using the committed sample props.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] Performance impact considered

## Related Issues

Closes #382

## Additional Context

Remotion emits a Zod v4 recommendation during rendering. Zod v3 is intentionally retained because it is explicitly required by #382; the completed render confirms compatibility for this pattern.

## Reviewer Notes

- Please review the transition-overlap duration calculation and the schema constraints.
