### PR TITLE
✨ Feat: #389 Add DepthGallery 3D primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,10 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
   consumer (e.g. a web preview app) actually exists.
 - Animations must be deterministic: derive all state from `useCurrentFrame()` and props —
   never `requestAnimationFrame`, unseeded randomness, or the current time.
+- 3D is supported via `@remotion/three`: each 3D effect is a focused primitive built on
+  `ThreeCanvas` (e.g. `DepthGallery`), driven by props and `useCurrentFrame()` — never
+  React Three Fiber's `useFrame`. Headless rendering uses the `angle` OpenGL renderer set
+  in `remotion.config.ts`. There is no general-purpose 3D abstraction or scene DSL.
 - Media assets are never committed; `apps/scene-studio/public/assets/` is gitignored
   (reference files via `staticFile()`). Rendering is local-macOS-only for now (brand
   system fonts are unavailable on Linux/CI).

--- a/apps/scene-studio/package.json
+++ b/apps/scene-studio/package.json
@@ -13,13 +13,16 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
+    "@react-three/fiber": "^9.6.1",
     "@remotion/cli": "4.0.488",
+    "@remotion/three": "4.0.488",
     "@remotion/transitions": "4.0.488",
     "clsx": "^2.1.1",
     "react": "^19.0.1",
     "react-dom": "^19.0.1",
     "remotion": "4.0.488",
     "tailwind-merge": "^2.5.3",
+    "three": "^0.185.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -27,6 +30,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/three": "^0.185.1",
     "biome-config": "workspace:*",
     "jsdom": "^26.0.0",
     "tailwind-config": "workspace:*",

--- a/apps/scene-studio/remotion.config.ts
+++ b/apps/scene-studio/remotion.config.ts
@@ -7,4 +7,7 @@ Config.setEntryPoint('./src/index.ts');
 Config.overrideWebpackConfig((currentConfiguration) =>
   enableTailwind(currentConfiguration)
 );
+// WebGL content (ThreeCanvas primitives) needs a GPU-backed renderer in
+// headless rendering; 'angle' is the recommended backend on macOS.
+Config.setChromiumOpenGlRenderer('angle');
 Config.setOverwriteOutput(true);

--- a/apps/scene-studio/src/compositions/primitives/DepthGalleryDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/DepthGalleryDemo.tsx
@@ -1,0 +1,25 @@
+import { AbsoluteFill } from 'remotion';
+import { DepthGallery } from '../../primitives';
+
+const CARD_DEFINITIONS = [
+  { background: '#b8d200', foreground: '#1a1c1e', label: '1' },
+  { background: '#474a4d', foreground: '#f8b500', label: '2' },
+  { background: '#f8b500', foreground: '#1a1c1e', label: '3' },
+  { background: '#1a1c1e', foreground: '#b8d200', label: '4' },
+];
+
+function createCardSource(definition: (typeof CARD_DEFINITIONS)[number]) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="900"><rect width="600" height="900" fill="${definition.background}"/><circle cx="300" cy="330" r="150" fill="${definition.foreground}" opacity="0.35"/><text x="300" y="640" font-family="Helvetica, Arial, sans-serif" font-size="320" font-weight="700" fill="${definition.foreground}" text-anchor="middle">${definition.label}</text></svg>`;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+const CARD_SOURCES = CARD_DEFINITIONS.map(createCardSource);
+
+export function DepthGalleryDemo() {
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <DepthGallery sources={CARD_SOURCES} />
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/demos.ts
+++ b/apps/scene-studio/src/compositions/primitives/demos.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react';
 
 import { BrandOutroDemo } from './BrandOutroDemo';
 import { CaptionDemo } from './CaptionDemo';
+import { DepthGalleryDemo } from './DepthGalleryDemo';
 import { GradientOverlayDemo } from './GradientOverlayDemo';
 import { LogoDemo } from './LogoDemo';
 import { MediaFrameDemo } from './MediaFrameDemo';
@@ -17,6 +18,7 @@ export const primitiveDemos = [
   { id: 'primitive-gradient-overlay', component: GradientOverlayDemo },
   { id: 'primitive-logo', component: LogoDemo },
   { id: 'primitive-media-frame', component: MediaFrameDemo },
+  { id: 'primitive-depth-gallery', component: DepthGalleryDemo },
   { id: 'primitive-brand-outro', component: BrandOutroDemo },
 ] as const satisfies ReadonlyArray<{
   id: string;

--- a/apps/scene-studio/src/primitives/DepthGallery/DepthGallery.tsx
+++ b/apps/scene-studio/src/primitives/DepthGallery/DepthGallery.tsx
@@ -1,0 +1,53 @@
+import { ThreeCanvas } from '@remotion/three';
+import { useCurrentFrame, useVideoConfig } from 'remotion';
+
+import {
+  getDollyDistance,
+  getPlaneOpacity,
+  getPlanePlacement,
+} from './depthMotion';
+import { ImagePlane } from './ImagePlane';
+
+interface Props {
+  sources: string[];
+}
+
+const CAMERA_FOV_IN_DEGREES = 50;
+
+export function DepthGallery({ sources }: Props) {
+  const frame = useCurrentFrame();
+  const { width, height, durationInFrames } = useVideoConfig();
+  const dollyDistance = getDollyDistance({
+    frame,
+    durationInFrames,
+    planeCount: sources.length,
+  });
+
+  return (
+    <ThreeCanvas
+      width={width}
+      height={height}
+      camera={{ fov: CAMERA_FOV_IN_DEGREES, position: [0, 0, 0] }}
+    >
+      {/* The camera stays fixed; translating the plane group toward it keeps
+          the dolly a pure function of the current frame. */}
+      <group position={[0, 0, dollyDistance]}>
+        {sources.map((source, planeIndex) => {
+          const placement = getPlanePlacement({ planeIndex });
+
+          return (
+            <ImagePlane
+              key={source}
+              src={source}
+              position={[placement.x, placement.y, placement.z]}
+              opacity={getPlaneOpacity({
+                planeZ: placement.z,
+                dollyDistance,
+              })}
+            />
+          );
+        })}
+      </group>
+    </ThreeCanvas>
+  );
+}

--- a/apps/scene-studio/src/primitives/DepthGallery/ImagePlane.test.tsx
+++ b/apps/scene-studio/src/primitives/DepthGallery/ImagePlane.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ImagePlane } from './ImagePlane';
+
+const mocks = vi.hoisted(() => ({
+  delayRender: vi.fn(() => 42),
+  continueRender: vi.fn(),
+  cancelRender: vi.fn(),
+  advance: vi.fn(),
+  environment: { isRendering: true },
+  textureLoad: {} as {
+    onLoad?: (texture: { colorSpace?: string }) => void;
+    onError?: (error: unknown) => void;
+  },
+}));
+
+vi.mock('remotion', () => ({
+  delayRender: mocks.delayRender,
+  continueRender: mocks.continueRender,
+  cancelRender: mocks.cancelRender,
+  useRemotionEnvironment: () => ({
+    isRendering: mocks.environment.isRendering,
+  }),
+}));
+
+vi.mock('@react-three/fiber', () => ({
+  useThree: (selector: (state: { advance: () => void }) => unknown) =>
+    selector({ advance: mocks.advance }),
+}));
+
+vi.mock('three', () => ({
+  SRGBColorSpace: 'srgb',
+  TextureLoader: class {
+    load(
+      _src: string,
+      onLoad: (texture: { colorSpace?: string }) => void,
+      _onProgress: undefined,
+      onError: (error: unknown) => void
+    ) {
+      mocks.textureLoad.onLoad = onLoad;
+      mocks.textureLoad.onError = onError;
+    }
+  },
+}));
+
+function renderImagePlane() {
+  return render(
+    <ImagePlane
+      src="data:image/svg+xml,card"
+      position={[0, 0, -2.5]}
+      opacity={1}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.environment.isRendering = true;
+  mocks.textureLoad.onLoad = undefined;
+  mocks.textureLoad.onError = undefined;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ImagePlane', () => {
+  it('delays the render until the texture has loaded', () => {
+    renderImagePlane();
+
+    expect(mocks.delayRender).toHaveBeenCalledTimes(1);
+    expect(mocks.continueRender).not.toHaveBeenCalled();
+  });
+
+  it('releases the delayed render once the texture has loaded', () => {
+    renderImagePlane();
+
+    act(() => {
+      mocks.textureLoad.onLoad?.({});
+    });
+
+    const delayRenderHandle = 42;
+    expect(mocks.continueRender).toHaveBeenCalledWith(delayRenderHandle);
+  });
+
+  it('redraws the frozen canvas before releasing the render while rendering', () => {
+    renderImagePlane();
+
+    act(() => {
+      mocks.textureLoad.onLoad?.({});
+    });
+
+    const advanceCallOrder = mocks.advance.mock.invocationCallOrder[0];
+    const continueRenderCallOrder =
+      mocks.continueRender.mock.invocationCallOrder[0];
+    expect(advanceCallOrder).toBeLessThan(continueRenderCallOrder);
+  });
+
+  it('does not redraw the canvas in the preview environment', () => {
+    mocks.environment.isRendering = false;
+    renderImagePlane();
+
+    act(() => {
+      mocks.textureLoad.onLoad?.({});
+    });
+
+    expect(mocks.advance).not.toHaveBeenCalled();
+    expect(mocks.continueRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the loaded texture as sRGB for correct colors', () => {
+    renderImagePlane();
+    const loadedTexture: { colorSpace?: string } = {};
+
+    act(() => {
+      mocks.textureLoad.onLoad?.(loadedTexture);
+    });
+
+    expect(loadedTexture.colorSpace).toBe('srgb');
+  });
+
+  it('cancels the render when the texture fails to load', () => {
+    renderImagePlane();
+    const loadError = new Error('texture decode failed');
+
+    act(() => {
+      mocks.textureLoad.onError?.(loadError);
+    });
+
+    expect(mocks.cancelRender).toHaveBeenCalledWith(loadError);
+    expect(mocks.continueRender).not.toHaveBeenCalled();
+  });
+});

--- a/apps/scene-studio/src/primitives/DepthGallery/ImagePlane.tsx
+++ b/apps/scene-studio/src/primitives/DepthGallery/ImagePlane.tsx
@@ -1,0 +1,66 @@
+import { useThree } from '@react-three/fiber';
+import { useEffect, useState } from 'react';
+import {
+  cancelRender,
+  continueRender,
+  delayRender,
+  useRemotionEnvironment,
+} from 'remotion';
+import { SRGBColorSpace, type Texture, TextureLoader } from 'three';
+
+interface Props {
+  src: string;
+  position: readonly [number, number, number];
+  opacity: number;
+}
+
+// Portrait 2:3 plane, matching the aspect ratio of typical photo cards.
+const PLANE_WIDTH_IN_WORLD_UNITS = 2;
+const PLANE_HEIGHT_IN_WORLD_UNITS = 3;
+
+export function ImagePlane({ src, position, opacity }: Props) {
+  const [texture, setTexture] = useState<Texture | null>(null);
+  const [delayRenderHandle] = useState(() =>
+    delayRender(`Loading DepthGallery texture: ${src.slice(0, 48)}`)
+  );
+  const advance = useThree((state) => state.advance);
+  const { isRendering } = useRemotionEnvironment();
+
+  useEffect(() => {
+    new TextureLoader().load(
+      src,
+      (loadedTexture) => {
+        loadedTexture.colorSpace = SRGBColorSpace;
+        setTexture(loadedTexture);
+      },
+      undefined,
+      (error) => cancelRender(error)
+    );
+  }, [src]);
+
+  useEffect(() => {
+    if (!texture) {
+      return;
+    }
+    // During rendering the frameloop is 'never' and the canvas was already
+    // drawn for this frame before the texture arrived; advance once so the
+    // screenshot includes the textured mesh, then release Remotion.
+    if (isRendering) {
+      advance(performance.now());
+    }
+    continueRender(delayRenderHandle);
+  }, [texture, isRendering, advance, delayRenderHandle]);
+
+  if (!texture) {
+    return null;
+  }
+
+  return (
+    <mesh position={[position[0], position[1], position[2]]}>
+      <planeGeometry
+        args={[PLANE_WIDTH_IN_WORLD_UNITS, PLANE_HEIGHT_IN_WORLD_UNITS]}
+      />
+      <meshBasicMaterial map={texture} transparent opacity={opacity} />
+    </mesh>
+  );
+}

--- a/apps/scene-studio/src/primitives/DepthGallery/depthMotion.test.ts
+++ b/apps/scene-studio/src/primitives/DepthGallery/depthMotion.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getDollyDistance,
+  getPlaneOpacity,
+  getPlanePlacement,
+  LATERAL_OFFSET_IN_WORLD_UNITS,
+  PLANE_SPACING_IN_WORLD_UNITS,
+} from './depthMotion';
+
+describe('getDollyDistance', () => {
+  it('returns the same distance for the same input', () => {
+    const input = { frame: 40, durationInFrames: 150, planeCount: 4 };
+
+    const firstResult = getDollyDistance(input);
+    const secondResult = getDollyDistance(input);
+
+    expect(firstResult).toBe(secondResult);
+  });
+
+  it('starts at zero on the first frame', () => {
+    const distance = getDollyDistance({
+      frame: 0,
+      durationInFrames: 150,
+      planeCount: 4,
+    });
+
+    expect(distance).toBe(0);
+  });
+
+  it('reaches the full corridor length on the last frame', () => {
+    const planeCount = 4;
+
+    const distance = getDollyDistance({
+      frame: 149,
+      durationInFrames: 150,
+      planeCount,
+    });
+
+    const fullCorridorLength = (planeCount - 1) * PLANE_SPACING_IN_WORLD_UNITS;
+    expect(distance).toBeCloseTo(fullCorridorLength);
+  });
+
+  it.each([
+    { earlierFrame: 0, laterFrame: 30 },
+    { earlierFrame: 30, laterFrame: 75 },
+    { earlierFrame: 75, laterFrame: 149 },
+  ])('never moves backwards between frame $earlierFrame and $laterFrame', ({
+    earlierFrame,
+    laterFrame,
+  }) => {
+    const durationInFrames = 150;
+    const planeCount = 4;
+
+    const earlierDistance = getDollyDistance({
+      frame: earlierFrame,
+      durationInFrames,
+      planeCount,
+    });
+    const laterDistance = getDollyDistance({
+      frame: laterFrame,
+      durationInFrames,
+      planeCount,
+    });
+
+    expect(laterDistance).toBeGreaterThanOrEqual(earlierDistance);
+  });
+
+  it.each([
+    { frame: -5, expectedDistance: 0 },
+    { frame: 200, expectedDistance: 3 * PLANE_SPACING_IN_WORLD_UNITS },
+  ])('clamps out-of-range frame $frame to $expectedDistance', ({
+    frame,
+    expectedDistance,
+  }) => {
+    const distance = getDollyDistance({
+      frame,
+      durationInFrames: 150,
+      planeCount: 4,
+    });
+
+    expect(distance).toBeCloseTo(expectedDistance);
+  });
+});
+
+describe('getPlanePlacement', () => {
+  it('returns the same placement for the same plane index', () => {
+    const firstResult = getPlanePlacement({ planeIndex: 2 });
+    const secondResult = getPlanePlacement({ planeIndex: 2 });
+
+    expect(firstResult).toEqual(secondResult);
+  });
+
+  it.each([
+    { planeIndex: 0 },
+    { planeIndex: 1 },
+    { planeIndex: 2 },
+  ])('spaces plane $planeIndex and its successor one spacing apart in depth', ({
+    planeIndex,
+  }) => {
+    const placement = getPlanePlacement({ planeIndex });
+    const nextPlacement = getPlanePlacement({ planeIndex: planeIndex + 1 });
+
+    expect(placement.z - nextPlacement.z).toBeCloseTo(
+      PLANE_SPACING_IN_WORLD_UNITS
+    );
+  });
+
+  it('alternates the lateral side between consecutive planes', () => {
+    const evenPlacement = getPlanePlacement({ planeIndex: 0 });
+    const oddPlacement = getPlanePlacement({ planeIndex: 1 });
+
+    expect(Math.sign(evenPlacement.x)).toBe(-Math.sign(oddPlacement.x));
+  });
+
+  it.each([
+    { planeIndex: 0 },
+    { planeIndex: 1 },
+    { planeIndex: 5 },
+  ])('keeps plane $planeIndex within the lateral offset bound', ({
+    planeIndex,
+  }) => {
+    const placement = getPlanePlacement({ planeIndex });
+
+    expect(Math.abs(placement.x)).toBeLessThanOrEqual(
+      LATERAL_OFFSET_IN_WORLD_UNITS
+    );
+  });
+});
+
+describe('getPlaneOpacity', () => {
+  it.each([
+    {
+      description: 'a plane far beyond the fade range',
+      planeZ: -10,
+      dollyDistance: 0,
+      expectedOpacity: 0,
+    },
+    {
+      description: 'a plane fully in view',
+      planeZ: -2.5,
+      dollyDistance: 0,
+      expectedOpacity: 1,
+    },
+    {
+      description: 'a plane that has passed the camera',
+      planeZ: -2.5,
+      dollyDistance: 5,
+      expectedOpacity: 0,
+    },
+  ])('returns $expectedOpacity for $description', ({
+    planeZ,
+    dollyDistance,
+    expectedOpacity,
+  }) => {
+    const opacity = getPlaneOpacity({ planeZ, dollyDistance });
+
+    expect(opacity).toBeCloseTo(expectedOpacity);
+  });
+
+  it('fades a plane in while it approaches from the far distance', () => {
+    const opacity = getPlaneOpacity({ planeZ: -7.5, dollyDistance: 0 });
+
+    expect(opacity).toBeGreaterThan(0);
+    expect(opacity).toBeLessThan(1);
+  });
+
+  it('fades a plane out while it slips past the camera', () => {
+    const opacity = getPlaneOpacity({ planeZ: -2.5, dollyDistance: 1.8 });
+
+    expect(opacity).toBeGreaterThan(0);
+    expect(opacity).toBeLessThan(1);
+  });
+
+  it.each([
+    { description: 'extremely far', planeZ: -1000, dollyDistance: 0 },
+    { description: 'extremely behind', planeZ: 1000, dollyDistance: 0 },
+  ])('stays within [0, 1] for a plane $description', ({
+    planeZ,
+    dollyDistance,
+  }) => {
+    const opacity = getPlaneOpacity({ planeZ, dollyDistance });
+
+    expect(opacity).toBeGreaterThanOrEqual(0);
+    expect(opacity).toBeLessThanOrEqual(1);
+  });
+});

--- a/apps/scene-studio/src/primitives/DepthGallery/depthMotion.ts
+++ b/apps/scene-studio/src/primitives/DepthGallery/depthMotion.ts
@@ -1,0 +1,77 @@
+import { Easing, interpolate } from 'remotion';
+
+// World-unit layout of the gallery corridor: planes sit PLANE_SPACING apart
+// along -z and alternate laterally so the dolly path reads as depth, not a
+// flat slideshow.
+export const PLANE_SPACING_IN_WORLD_UNITS = 2.5;
+export const LATERAL_OFFSET_IN_WORLD_UNITS = 0.6;
+export const VERTICAL_OFFSET_IN_WORLD_UNITS = 0.25;
+
+const FAR_FADE_START_DISTANCE_IN_WORLD_UNITS = 6;
+const FAR_FADE_END_DISTANCE_IN_WORLD_UNITS = 8;
+const NEAR_FADE_START_DISTANCE_IN_WORLD_UNITS = 0.2;
+const NEAR_FADE_END_DISTANCE_IN_WORLD_UNITS = 1.2;
+
+const CLAMP_OPTIONS = {
+  extrapolateLeft: 'clamp',
+  extrapolateRight: 'clamp',
+} as const;
+
+export function getDollyDistance(input: {
+  frame: number;
+  durationInFrames: number;
+  planeCount: number;
+}): number {
+  const travelDistance = (input.planeCount - 1) * PLANE_SPACING_IN_WORLD_UNITS;
+
+  return interpolate(
+    input.frame,
+    [0, input.durationInFrames - 1],
+    [0, travelDistance],
+    { ...CLAMP_OPTIONS, easing: Easing.inOut(Easing.ease) }
+  );
+}
+
+export function getPlanePlacement(input: { planeIndex: number }): {
+  x: number;
+  y: number;
+  z: number;
+} {
+  const lateralDirection = input.planeIndex % 2 === 0 ? -1 : 1;
+
+  return {
+    x: lateralDirection * LATERAL_OFFSET_IN_WORLD_UNITS,
+    y: -lateralDirection * VERTICAL_OFFSET_IN_WORLD_UNITS,
+    z: -(input.planeIndex + 1) * PLANE_SPACING_IN_WORLD_UNITS,
+  };
+}
+
+export function getPlaneOpacity(input: {
+  planeZ: number;
+  dollyDistance: number;
+}): number {
+  // The dolly moves the plane group toward the camera at z = 0, so the
+  // distance still in front of the camera shrinks as the journey progresses.
+  const distanceInFrontOfCamera = -(input.planeZ + input.dollyDistance);
+
+  const farFade = interpolate(
+    distanceInFrontOfCamera,
+    [
+      FAR_FADE_START_DISTANCE_IN_WORLD_UNITS,
+      FAR_FADE_END_DISTANCE_IN_WORLD_UNITS,
+    ],
+    [1, 0],
+    CLAMP_OPTIONS
+  );
+  const nearFade = interpolate(
+    distanceInFrontOfCamera,
+    [
+      NEAR_FADE_START_DISTANCE_IN_WORLD_UNITS,
+      NEAR_FADE_END_DISTANCE_IN_WORLD_UNITS,
+    ],
+    [0, 1],
+    CLAMP_OPTIONS
+  );
+
+  return farFade * nearFade;
+}

--- a/apps/scene-studio/src/primitives/DepthGallery/index.tsx
+++ b/apps/scene-studio/src/primitives/DepthGallery/index.tsx
@@ -1,0 +1,1 @@
+export { DepthGallery } from './DepthGallery';

--- a/apps/scene-studio/src/primitives/index.ts
+++ b/apps/scene-studio/src/primitives/index.ts
@@ -1,5 +1,6 @@
 export { BrandOutro } from './BrandOutro';
 export { Caption } from './Caption';
+export { DepthGallery } from './DepthGallery';
 export { GradientOverlay } from './GradientOverlay';
 export { Logo } from './Logo';
 export { MediaFrame } from './MediaFrame';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,9 +323,15 @@ importers:
 
   apps/scene-studio:
     dependencies:
+      '@react-three/fiber':
+        specifier: ^9.6.1
+        version: 9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1)
       '@remotion/cli':
         specifier: 4.0.488
         version: 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
+      '@remotion/three':
+        specifier: 4.0.488
+        version: 4.0.488(@react-three/fiber@9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(remotion@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(three@0.185.1)
       '@remotion/transitions':
         specifier: 4.0.488
         version: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -344,6 +350,9 @@ importers:
       tailwind-merge:
         specifier: ^2.5.3
         version: 2.5.3
+      three:
+        specifier: ^0.185.1
+        version: 0.185.1
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -360,6 +369,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.4
         version: 19.0.4(@types/react@19.0.10)
+      '@types/three':
+        specifier: ^0.185.1
+        version: 0.185.1
       biome-config:
         specifier: workspace:*
         version: link:../../packages/biome-config
@@ -1953,6 +1965,9 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
   '@dotenvx/dotenvx@1.31.0':
     resolution: {integrity: sha512-GeDxvtjiRuoyWVU9nQneId879zIyNdL05bS7RKiqMkfBSKpHMWHLoRyRqjYWLaXmX/llKO1hTlqHDmatkQAjPA==}
     hasBin: true
@@ -2697,6 +2712,31 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
+  '@react-three/fiber@9.6.1':
+    resolution: {integrity: sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   '@remotion/bundler@4.0.488':
     resolution: {integrity: sha512-HBBH+IRRSuGjgc23e4uujOJffKvPcMhDiMrl9X3TJJXCO/qc9CqUQzW4yH4m04yecUBEZjogmrXLBoSVNYhZcw==}
     peerDependencies:
@@ -2807,6 +2847,15 @@ packages:
     resolution: {integrity: sha512-ZlWS1YbsfrWYiSgcU+LI5S2Rs4EManNzLM1yKsFq9jr/m1mgUTcsAdNgJyk5QN71rrFbFBtU3WSXDe02ci8+jg==}
     peerDependencies:
       '@remotion/bundler': 4.0.488
+
+  '@remotion/three@4.0.488':
+    resolution: {integrity: sha512-5C3hrE1avAi2qjZmSnDAHyuJvx6aMU9au97MwOlg9O/CsV3r9xqFyyPKMxKByP2pk2Olr+TzW+QO0AKQmZu+Tg==}
+    peerDependencies:
+      '@react-three/fiber': '>=8.0.0'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      remotion: 4.0.488
+      three: '>=0.137.0'
 
   '@remotion/timeline-utils@4.0.488':
     resolution: {integrity: sha512-TwC4bPkJHm9hwtzI2pVjERKCmcsw82FoGSecc7c7Bwo9az+1l0KenTg1HznMVhqJRtMTTyDSZvkiD7Lat1TFdg==}
@@ -4130,6 +4179,9 @@ packages:
     resolution: {integrity: sha512-3uYg2b5TWCiupetbDFMbBFMHl33xQTvp5DNg0fZSYal73Z9AlFH9yWabHWMYw6ywmwM1evkYRpTVA2n7GgqT5A==}
     hasBin: true
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -4231,6 +4283,11 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
@@ -4252,8 +4309,14 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/three@0.185.1':
+    resolution: {integrity: sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==}
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
@@ -4269,6 +4332,9 @@ packages:
 
   '@types/webpack-env@1.18.5':
     resolution: {integrity: sha512-wz7kjjRRj8/Lty4B+Kr0LN6Ypc/3SymeCCGSbaXp2leH0ZVg/PriNiOwNj4bD4uphI7A8NXS4b6Gl373sfO5mA==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -5893,6 +5959,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -6483,6 +6552,11 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -7002,6 +7076,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.1:
     resolution: {integrity: sha512-CUQyKr1e///ZODyD1U3xit6zXwy1a8q2a1S1HKtIlmgvurrEpaw/Y9y6KSIbF8P59cn/NjzHyO+Q2fAyYLQrAA==}
@@ -8001,6 +8078,15 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.1:
     resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
@@ -8583,6 +8669,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
@@ -8724,6 +8815,9 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -11544,6 +11638,8 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
+  '@dimforge/rapier3d-compat@0.12.0': {}
+
   '@dotenvx/dotenvx@1.31.0':
     dependencies:
       commander: 11.1.0
@@ -12195,6 +12291,26 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
+  '@react-three/fiber@9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.0.10)(react@19.2.1)
+      react: 19.2.1
+      react-use-measure: 2.1.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.1)
+      three: 0.185.1
+      use-sync-external-store: 1.6.0(react@19.2.1)
+      zustand: 5.0.3(@types/react@19.0.10)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
+    optionalDependencies:
+      react-dom: 19.2.1(react@19.2.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@remotion/media-parser': 4.0.488
@@ -12413,6 +12529,14 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
+
+  '@remotion/three@4.0.488(@react-three/fiber@9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(remotion@4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(three@0.185.1)':
+    dependencies:
+      '@react-three/fiber': 9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      remotion: 4.0.488(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      three: 0.185.1
 
   '@remotion/timeline-utils@4.0.488':
     dependencies:
@@ -13922,6 +14046,8 @@ snapshots:
       semver: 7.7.3
       update-check: 1.5.4
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -14042,6 +14168,10 @@ snapshots:
     dependencies:
       '@types/react': 19.0.10
 
+  '@types/react-reconciler@0.28.9(@types/react@19.0.10)':
+    dependencies:
+      '@types/react': 19.0.10
+
   '@types/react-syntax-highlighter@15.5.13':
     dependencies:
       '@types/react': 19.0.10
@@ -14067,7 +14197,18 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/statuses@2.0.6': {}
+
+  '@types/three@0.185.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
 
   '@types/through@0.0.33':
     dependencies:
@@ -14080,6 +14221,8 @@ snapshots:
   '@types/unist@3.0.2': {}
 
   '@types/webpack-env@1.18.5': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@ungap/structured-clone@1.2.0': {}
 
@@ -15776,6 +15919,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.3: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -16473,6 +16618,13 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  its-fine@2.0.0(@types/react@19.0.10)(react@19.2.1):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.0.10)
+      react: 19.2.1
+    transitivePeerDependencies:
+      - '@types/react'
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -17009,6 +17161,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.1:
     dependencies:
@@ -18316,6 +18470,12 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-use-measure@2.1.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      react-dom: 19.2.1(react@19.2.1)
+
   react@19.2.1: {}
 
   readable-stream@2.3.8:
@@ -19065,6 +19225,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  suspend-react@0.1.3(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+
   svg-parser@2.0.4: {}
 
   svgo@3.3.2:
@@ -19237,6 +19401,8 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  three@0.185.1: {}
 
   through@2.3.8: {}
 


### PR DESCRIPTION
## Summary

Adds the use-case-led Three.js integration defined in #389: one focused proof-of-concept primitive, `DepthGallery`, built on `@remotion/three` / `ThreeCanvas`. Photos are textured planes staggered in z, and a forward dolly driven entirely by props and `useCurrentFrame()` travels through them with distance-based fades. No general 3D abstraction or scene DSL is introduced.

### What changed?

- Added `@remotion/three` (exact-pinned with the other Remotion packages), `three`, `@react-three/fiber`, and `@types/three` to `apps/scene-studio` only.
- Added `Config.setChromiumOpenGlRenderer('angle')` to `remotion.config.ts` so headless rendering supports WebGL (no webpack change was required).
- Added the `DepthGallery` primitive (`src/primitives/DepthGallery/`) with pure motion functions in `depthMotion.ts`, plus the `primitive-depth-gallery` demo composition using inline SVG data-URI cards (no committed media).
- Added node-environment unit tests for the motion functions and a 3D boundary statement to `AGENTS.md`.

### Why was this changed?

- The travel short-form video needs a transition where the camera dollies forward through photos placed at different depths; the current CSS `perspective` approximation cannot produce true parallax, occlusion, or depth-based focus between overlapping cards (use case documented in #389 before implementation).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📦 Dependency updates

## Affected Applications

- [x] 🎬 Scene Studio (`apps/scene-studio/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed

`depthMotion.test.ts` covers determinism, monotonic dolly travel, clamping, corridor spacing/alternation, and opacity fade bounds. `ImagePlane.test.tsx` covers the async texture gating contract with the Remotion/Three hooks mocked: the render is delayed until the texture loads, the frozen canvas is redrawn (`advance()`) before `continueRender` while rendering (and not in preview), the loaded texture is marked sRGB, and load failures cancel the render. Scene-level WebGL output (which jsdom cannot execute) is verified by the actual local render below.

### How to Test

1. `pnpm -F scene-studio test && pnpm -F scene-studio typecheck && pnpm -F scene-studio lint`
2. `pnpm -F scene-studio dev` → open `primitive-depth-gallery` and scrub the timeline.
3. `pnpm -F scene-studio render primitive-depth-gallery out/depth-gallery-demo.mp4` (local macOS).

### Test Results

- [x] All existing tests pass (`pnpm test`) — 66 tests including 23 new motion tests
- [x] New tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes — including root `pnpm typecheck` across all workspaces

Determinism: rendering the same frame twice produces byte-identical PNGs (verified with `cmp`, GPU/`angle` renderer). During implementation a still-rendering race was found and fixed: with the render-time `frameloop: 'never'`, the async texture load lands after the frame's `advance()`, so `ImagePlane` re-advances the canvas once the texture is committed before releasing `delayRender` (same pattern as the official video-as-texture docs).

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

Web apps are unaffected: the lockfile diff is confined to the `apps/scene-studio` importer, and no web app depends on scene-studio.

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

`AGENTS.md` now states the supported 3D boundary (focused `ThreeCanvas` primitives, frame-driven, `angle` renderer, no universal 3D abstraction). `pnpm docs:check` passes.

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #389

## Additional Context

Rendering remains local-macOS-only per the existing Scene Studio constraints. Follow-ups intentionally out of scope: integrating `DepthGallery` into the travel video, postprocessing (DOF/bokeh), and video textures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
