### PR TITLE
✨ Feat: #392 Add shader effect primitives

### DIFF
--- a/apps/scene-studio/README.md
+++ b/apps/scene-studio/README.md
@@ -89,6 +89,7 @@ The layers remain app-internal until another workspace needs to consume them.
 | Folder | Composition ID | Description |
 | --- | --- | --- |
 | `demo` | `brand-demo` | Brand typography and design-token demonstration |
+| `demo` | `shader-demo` | Shader effect showcase with one labeled segment per effect primitive |
 | `primitives` | `primitive-*` | One Studio demonstration for each video primitive |
 | `patterns` | `visual-showcase` | Validated vertical media showcase with captions, transitions, and brand outro |
 

--- a/apps/scene-studio/src/Root.tsx
+++ b/apps/scene-studio/src/Root.tsx
@@ -6,6 +6,8 @@ import {
   PRIMITIVE_DEMO_DURATION_IN_FRAMES,
   primitiveDemos,
 } from './compositions/primitives/demos';
+import { ShaderDemo } from './compositions/ShaderDemo';
+import { getShaderDemoDurationInFrames } from './compositions/ShaderDemo/scenes';
 import { VisualShowcase } from './patterns/VisualShowcase';
 import {
   calculateVisualShowcaseMetadata,
@@ -32,6 +34,14 @@ export function RemotionRoot() {
           height={SCENE_HEIGHT}
           fps={SCENE_FPS}
           durationInFrames={getBrandDemoDurationInFrames()}
+        />
+        <Composition
+          id="shader-demo"
+          component={ShaderDemo}
+          width={SCENE_WIDTH}
+          height={SCENE_HEIGHT}
+          fps={SCENE_FPS}
+          durationInFrames={getShaderDemoDurationInFrames()}
         />
       </Folder>
       <Folder name="primitives">

--- a/apps/scene-studio/src/compositions/ShaderDemo/index.tsx
+++ b/apps/scene-studio/src/compositions/ShaderDemo/index.tsx
@@ -1,0 +1,24 @@
+import { AbsoluteFill, Series } from 'remotion';
+
+import { Caption, SafeArea } from '../../primitives';
+import { SHADER_SCENE_DURATION_IN_FRAMES, shaderDemoScenes } from './scenes';
+
+export function ShaderDemo() {
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <Series>
+        {shaderDemoScenes.map((scene) => (
+          <Series.Sequence
+            key={scene.name}
+            durationInFrames={SHADER_SCENE_DURATION_IN_FRAMES}
+          >
+            <scene.component />
+            <SafeArea className="flex items-end justify-center">
+              <Caption text={scene.label} />
+            </SafeArea>
+          </Series.Sequence>
+        ))}
+      </Series>
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/ShaderDemo/scenes.test.ts
+++ b/apps/scene-studio/src/compositions/ShaderDemo/scenes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getShaderDemoDurationInFrames,
+  SHADER_SCENE_DURATION_IN_FRAMES,
+  shaderDemoScenes,
+} from './scenes';
+
+describe('shaderDemoScenes', () => {
+  it('shows every shader effect in the planned order', () => {
+    const sceneNames = shaderDemoScenes.map((scene) => scene.name);
+
+    expect(sceneNames).toEqual([
+      'channel-shift',
+      'invert-blend',
+      'mosaic',
+      'gradient-flow',
+      'signal-noise',
+    ]);
+  });
+
+  it('labels every scene for the on-screen caption', () => {
+    const labels = shaderDemoScenes.map((scene) => scene.label);
+
+    expect(labels.every((label) => label.length > 0)).toBe(true);
+  });
+});
+
+describe('getShaderDemoDurationInFrames', () => {
+  it('multiplies the scene count by the scene duration', () => {
+    const duration = getShaderDemoDurationInFrames();
+
+    const expectedDuration =
+      shaderDemoScenes.length * SHADER_SCENE_DURATION_IN_FRAMES;
+    expect(duration).toBe(expectedDuration);
+    expect(duration).toBe(750);
+  });
+});

--- a/apps/scene-studio/src/compositions/ShaderDemo/scenes.ts
+++ b/apps/scene-studio/src/compositions/ShaderDemo/scenes.ts
@@ -1,0 +1,33 @@
+import type { ComponentType } from 'react';
+
+import { ChannelShiftDemo } from '../primitives/ChannelShiftDemo';
+import { GradientFlowDemo } from '../primitives/GradientFlowDemo';
+import { InvertBlendDemo } from '../primitives/InvertBlendDemo';
+import { MosaicDemo } from '../primitives/MosaicDemo';
+import { SignalNoiseDemo } from '../primitives/SignalNoiseDemo';
+
+export const SHADER_SCENE_DURATION_IN_FRAMES = 150;
+
+export const shaderDemoScenes = [
+  {
+    name: 'channel-shift',
+    label: 'Channel Shift',
+    component: ChannelShiftDemo,
+  },
+  { name: 'invert-blend', label: 'Invert Blend', component: InvertBlendDemo },
+  { name: 'mosaic', label: 'Mosaic', component: MosaicDemo },
+  {
+    name: 'gradient-flow',
+    label: 'Gradient Flow',
+    component: GradientFlowDemo,
+  },
+  { name: 'signal-noise', label: 'Signal Noise', component: SignalNoiseDemo },
+] as const satisfies ReadonlyArray<{
+  name: string;
+  label: string;
+  component: ComponentType;
+}>;
+
+export function getShaderDemoDurationInFrames(): number {
+  return shaderDemoScenes.length * SHADER_SCENE_DURATION_IN_FRAMES;
+}

--- a/apps/scene-studio/src/compositions/primitives/ChannelShiftDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/ChannelShiftDemo.tsx
@@ -1,0 +1,24 @@
+import { AbsoluteFill, interpolate, useCurrentFrame } from 'remotion';
+import { ChannelShift } from '../../primitives';
+import { SAMPLE_IMAGE_SOURCE } from './sampleImage';
+
+// Local cycle length keeps the ramp intact when the demo is re-hosted inside
+// another composition's sequence.
+const EFFECT_CYCLE_IN_FRAMES = 150;
+
+export function ChannelShiftDemo() {
+  const frame = useCurrentFrame();
+
+  const amount = interpolate(
+    frame,
+    [0, EFFECT_CYCLE_IN_FRAMES / 2, EFFECT_CYCLE_IN_FRAMES],
+    [0, 1, 0],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
+  );
+
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <ChannelShift src={SAMPLE_IMAGE_SOURCE} amount={amount} />
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/GradientFlowDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/GradientFlowDemo.tsx
@@ -1,0 +1,10 @@
+import { AbsoluteFill } from 'remotion';
+import { GradientFlow } from '../../primitives';
+
+export function GradientFlowDemo() {
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <GradientFlow />
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/InvertBlendDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/InvertBlendDemo.tsx
@@ -1,0 +1,24 @@
+import { AbsoluteFill, interpolate, useCurrentFrame } from 'remotion';
+import { InvertBlend } from '../../primitives';
+import { SAMPLE_IMAGE_SOURCE } from './sampleImage';
+
+// Local cycle length keeps the ramp intact when the demo is re-hosted inside
+// another composition's sequence.
+const EFFECT_CYCLE_IN_FRAMES = 150;
+
+export function InvertBlendDemo() {
+  const frame = useCurrentFrame();
+
+  const amount = interpolate(
+    frame,
+    [0, EFFECT_CYCLE_IN_FRAMES / 2, EFFECT_CYCLE_IN_FRAMES],
+    [0, 1, 0],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
+  );
+
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <InvertBlend src={SAMPLE_IMAGE_SOURCE} amount={amount} />
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/MosaicDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/MosaicDemo.tsx
@@ -1,0 +1,24 @@
+import { AbsoluteFill, interpolate, useCurrentFrame } from 'remotion';
+import { Mosaic } from '../../primitives';
+import { SAMPLE_IMAGE_SOURCE } from './sampleImage';
+
+// Local cycle length keeps the ramp intact when the demo is re-hosted inside
+// another composition's sequence.
+const EFFECT_CYCLE_IN_FRAMES = 150;
+
+export function MosaicDemo() {
+  const frame = useCurrentFrame();
+
+  const amount = interpolate(
+    frame,
+    [0, EFFECT_CYCLE_IN_FRAMES / 2, EFFECT_CYCLE_IN_FRAMES],
+    [0, 1, 0],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
+  );
+
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <Mosaic src={SAMPLE_IMAGE_SOURCE} amount={amount} />
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/SignalNoiseDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/SignalNoiseDemo.tsx
@@ -1,0 +1,10 @@
+import { AbsoluteFill } from 'remotion';
+import { SignalNoise } from '../../primitives';
+
+export function SignalNoiseDemo() {
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <SignalNoise />
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/demos.ts
+++ b/apps/scene-studio/src/compositions/primitives/demos.ts
@@ -2,11 +2,16 @@ import type { ComponentType } from 'react';
 
 import { BrandOutroDemo } from './BrandOutroDemo';
 import { CaptionDemo } from './CaptionDemo';
+import { ChannelShiftDemo } from './ChannelShiftDemo';
 import { DepthGalleryDemo } from './DepthGalleryDemo';
+import { GradientFlowDemo } from './GradientFlowDemo';
 import { GradientOverlayDemo } from './GradientOverlayDemo';
+import { InvertBlendDemo } from './InvertBlendDemo';
 import { LogoDemo } from './LogoDemo';
 import { MediaFrameDemo } from './MediaFrameDemo';
+import { MosaicDemo } from './MosaicDemo';
 import { SafeAreaDemo } from './SafeAreaDemo';
+import { SignalNoiseDemo } from './SignalNoiseDemo';
 import { VideoTitleDemo } from './VideoTitleDemo';
 
 export const PRIMITIVE_DEMO_DURATION_IN_FRAMES = 150;
@@ -19,6 +24,11 @@ export const primitiveDemos = [
   { id: 'primitive-logo', component: LogoDemo },
   { id: 'primitive-media-frame', component: MediaFrameDemo },
   { id: 'primitive-depth-gallery', component: DepthGalleryDemo },
+  { id: 'primitive-channel-shift', component: ChannelShiftDemo },
+  { id: 'primitive-invert-blend', component: InvertBlendDemo },
+  { id: 'primitive-mosaic', component: MosaicDemo },
+  { id: 'primitive-gradient-flow', component: GradientFlowDemo },
+  { id: 'primitive-signal-noise', component: SignalNoiseDemo },
   { id: 'primitive-brand-outro', component: BrandOutroDemo },
 ] as const satisfies ReadonlyArray<{
   id: string;

--- a/apps/scene-studio/src/compositions/primitives/sampleImage.ts
+++ b/apps/scene-studio/src/compositions/primitives/sampleImage.ts
@@ -1,0 +1,5 @@
+// Shared sample card for the shader-effect demos: high-contrast circles,
+// stripes, and text make channel shifts and mosaic cells easy to read.
+const sampleSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="900"><rect width="600" height="900" fill="#474a4d"/><circle cx="300" cy="300" r="180" fill="#b8d200"/><circle cx="300" cy="300" r="100" fill="#f8b500"/><rect x="60" y="560" width="480" height="16" fill="#f8b500"/><rect x="60" y="600" width="360" height="16" fill="#b8d200"/><rect x="60" y="640" width="420" height="16" fill="#ffffff"/><text x="300" y="810" font-family="Helvetica, Arial, sans-serif" font-size="120" font-weight="700" fill="#ffffff" text-anchor="middle">K2BG</text></svg>`;
+
+export const SAMPLE_IMAGE_SOURCE = `data:image/svg+xml,${encodeURIComponent(sampleSvg)}`;

--- a/apps/scene-studio/src/primitives/ChannelShift/ChannelShift.tsx
+++ b/apps/scene-studio/src/primitives/ChannelShift/ChannelShift.tsx
@@ -1,0 +1,75 @@
+import { ThreeCanvas } from '@remotion/three';
+import { useVideoConfig } from 'remotion';
+import { NoColorSpace, Vector2 } from 'three';
+
+import { clampUnit } from '../../utils/clampUnit';
+import {
+  COVER_FIT_VERTEX_SHADER,
+  getCoverUvScale,
+  getImageAspect,
+} from '../shared/coverFit';
+import { ScreenQuad } from '../shared/ScreenQuad';
+import { useImageTexture } from '../shared/useImageTexture';
+
+interface Props {
+  src: string;
+  amount: number;
+}
+
+// UV shift of the red/blue channels at amount = 1.
+const MAX_SHIFT_IN_UV = 0.05;
+
+const FRAGMENT_SHADER = `
+varying vec2 vUv;
+
+uniform sampler2D uTex;
+uniform float uShiftInUv;
+
+void main() {
+  float r = texture2D(uTex, vUv + vec2(uShiftInUv, 0.0)).r;
+  float g = texture2D(uTex, vUv).g;
+  float b = texture2D(uTex, vUv - vec2(uShiftInUv, 0.0)).b;
+  gl_FragColor = vec4(r, g, b, 1.0);
+}
+`;
+
+export function ChannelShift({ src, amount }: Props) {
+  const { width, height } = useVideoConfig();
+
+  return (
+    <ThreeCanvas width={width} height={height}>
+      <ShiftedImage src={src} amount={amount} canvasAspect={width / height} />
+    </ThreeCanvas>
+  );
+}
+
+function ShiftedImage({
+  src,
+  amount,
+  canvasAspect,
+}: Props & { canvasAspect: number }) {
+  // The shader writes raw values without an output color transform, so the
+  // texture stays untagged for a byte-faithful passthrough at amount = 0.
+  const texture = useImageTexture(src, { colorSpace: NoColorSpace });
+
+  if (!texture) {
+    return null;
+  }
+
+  const coverScale = getCoverUvScale({
+    canvasAspect,
+    imageAspect: getImageAspect(texture),
+  });
+
+  return (
+    <ScreenQuad
+      vertexShader={COVER_FIT_VERTEX_SHADER}
+      fragmentShader={FRAGMENT_SHADER}
+      uniformValues={{
+        uTex: texture,
+        uCoverScale: new Vector2(coverScale.x, coverScale.y),
+        uShiftInUv: clampUnit(amount) * MAX_SHIFT_IN_UV,
+      }}
+    />
+  );
+}

--- a/apps/scene-studio/src/primitives/ChannelShift/index.tsx
+++ b/apps/scene-studio/src/primitives/ChannelShift/index.tsx
@@ -1,0 +1,1 @@
+export { ChannelShift } from './ChannelShift';

--- a/apps/scene-studio/src/primitives/DepthGallery/ImagePlane.tsx
+++ b/apps/scene-studio/src/primitives/DepthGallery/ImagePlane.tsx
@@ -1,12 +1,4 @@
-import { useThree } from '@react-three/fiber';
-import { useEffect, useState } from 'react';
-import {
-  cancelRender,
-  continueRender,
-  delayRender,
-  useRemotionEnvironment,
-} from 'remotion';
-import { SRGBColorSpace, type Texture, TextureLoader } from 'three';
+import { useImageTexture } from '../shared/useImageTexture';
 
 interface Props {
   src: string;
@@ -19,37 +11,7 @@ const PLANE_WIDTH_IN_WORLD_UNITS = 2;
 const PLANE_HEIGHT_IN_WORLD_UNITS = 3;
 
 export function ImagePlane({ src, position, opacity }: Props) {
-  const [texture, setTexture] = useState<Texture | null>(null);
-  const [delayRenderHandle] = useState(() =>
-    delayRender(`Loading DepthGallery texture: ${src.slice(0, 48)}`)
-  );
-  const advance = useThree((state) => state.advance);
-  const { isRendering } = useRemotionEnvironment();
-
-  useEffect(() => {
-    new TextureLoader().load(
-      src,
-      (loadedTexture) => {
-        loadedTexture.colorSpace = SRGBColorSpace;
-        setTexture(loadedTexture);
-      },
-      undefined,
-      (error) => cancelRender(error)
-    );
-  }, [src]);
-
-  useEffect(() => {
-    if (!texture) {
-      return;
-    }
-    // During rendering the frameloop is 'never' and the canvas was already
-    // drawn for this frame before the texture arrived; advance once so the
-    // screenshot includes the textured mesh, then release Remotion.
-    if (isRendering) {
-      advance(performance.now());
-    }
-    continueRender(delayRenderHandle);
-  }, [texture, isRendering, advance, delayRenderHandle]);
+  const texture = useImageTexture(src);
 
   if (!texture) {
     return null;

--- a/apps/scene-studio/src/primitives/GradientFlow/GradientFlow.tsx
+++ b/apps/scene-studio/src/primitives/GradientFlow/GradientFlow.tsx
@@ -1,0 +1,33 @@
+import { ThreeCanvas } from '@remotion/three';
+import { useCurrentFrame, useVideoConfig } from 'remotion';
+
+import { ScreenQuad } from '../shared/ScreenQuad';
+import { getGradientTime } from './gradientMotion';
+
+const FRAGMENT_SHADER = `
+varying vec2 vUv;
+
+uniform float uTime;
+
+void main() {
+  vec2 p = vUv - 0.5;
+  float r = 1.0 + 0.5 * (sin(5.0 * p.x + uTime));
+  float g = 1.0 + 0.5 * (sin(5.0 * p.y) + sin(uTime + 2.0 * p.x));
+  float b = 1.0 + 0.5 * (sin(5.0 + p.x * p.y * 17.0) + sin(uTime * 0.4 + 4.0 * p.y));
+  gl_FragColor = vec4(r, g, b, 1.0);
+}
+`;
+
+export function GradientFlow() {
+  const frame = useCurrentFrame();
+  const { width, height, fps } = useVideoConfig();
+
+  return (
+    <ThreeCanvas width={width} height={height}>
+      <ScreenQuad
+        fragmentShader={FRAGMENT_SHADER}
+        uniformValues={{ uTime: getGradientTime({ frame, fps }) }}
+      />
+    </ThreeCanvas>
+  );
+}

--- a/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.test.ts
+++ b/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGradientTime } from './gradientMotion';
+
+describe('getGradientTime', () => {
+  it('starts at zero on the first frame', () => {
+    const time = getGradientTime({ frame: 0, fps: 30 });
+
+    expect(time).toBe(0);
+  });
+
+  it.each([
+    { frame: 15 },
+    { frame: 90 },
+    { frame: 300 },
+    { frame: 9000 },
+  ])('stays within [-1, 1] at frame $frame', ({ frame }) => {
+    const time = getGradientTime({ frame, fps: 30 });
+
+    expect(time).toBeGreaterThanOrEqual(-1);
+    expect(time).toBeLessThanOrEqual(1);
+  });
+
+  it('advances at the same speed regardless of the frame rate', () => {
+    const timeAtThirtyFps = getGradientTime({ frame: 30, fps: 30 });
+    const timeAtSixtyFps = getGradientTime({ frame: 60, fps: 60 });
+
+    expect(timeAtThirtyFps).toBeCloseTo(timeAtSixtyFps);
+  });
+});

--- a/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.test.ts
+++ b/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.test.ts
@@ -10,15 +10,17 @@ describe('getGradientTime', () => {
   });
 
   it.each([
-    { frame: 15 },
-    { frame: 90 },
-    { frame: 300 },
-    { frame: 9000 },
-  ])('stays within [-1, 1] at frame $frame', ({ frame }) => {
-    const time = getGradientTime({ frame, fps: 30 });
+    { earlierFrame: 0, laterFrame: 15 },
+    { earlierFrame: 15, laterFrame: 90 },
+    { earlierFrame: 90, laterFrame: 9000 },
+  ])('advances monotonically between frame $earlierFrame and $laterFrame', ({
+    earlierFrame,
+    laterFrame,
+  }) => {
+    const earlierTime = getGradientTime({ frame: earlierFrame, fps: 30 });
+    const laterTime = getGradientTime({ frame: laterFrame, fps: 30 });
 
-    expect(time).toBeGreaterThanOrEqual(-1);
-    expect(time).toBeLessThanOrEqual(1);
+    expect(laterTime).toBeGreaterThan(earlierTime);
   });
 
   it('advances at the same speed regardless of the frame rate', () => {

--- a/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.ts
+++ b/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.ts
@@ -1,0 +1,7 @@
+// The reference implementation accumulated 0.01 per ~60fps frame; expressing
+// the step per second keeps the flow speed independent of the composition fps.
+const TIME_ACCUMULATION_PER_SECOND = 0.6;
+
+export function getGradientTime(input: { frame: number; fps: number }): number {
+  return Math.sin((TIME_ACCUMULATION_PER_SECOND * input.frame) / input.fps);
+}

--- a/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.ts
+++ b/apps/scene-studio/src/primitives/GradientFlow/gradientMotion.ts
@@ -1,7 +1,9 @@
-// The reference implementation accumulated 0.01 per ~60fps frame; expressing
-// the step per second keeps the flow speed independent of the composition fps.
+// The reference implementation accumulated 0.01 per ~60fps frame but wrapped
+// it in Math.sin, slowly rocking the field back and forth; linear elapsed
+// time keeps the gradient flowing continuously instead. The per-second step
+// keeps the flow speed independent of the composition fps.
 const TIME_ACCUMULATION_PER_SECOND = 0.6;
 
 export function getGradientTime(input: { frame: number; fps: number }): number {
-  return Math.sin((TIME_ACCUMULATION_PER_SECOND * input.frame) / input.fps);
+  return (TIME_ACCUMULATION_PER_SECOND * input.frame) / input.fps;
 }

--- a/apps/scene-studio/src/primitives/GradientFlow/index.tsx
+++ b/apps/scene-studio/src/primitives/GradientFlow/index.tsx
@@ -1,0 +1,1 @@
+export { GradientFlow } from './GradientFlow';

--- a/apps/scene-studio/src/primitives/InvertBlend/InvertBlend.tsx
+++ b/apps/scene-studio/src/primitives/InvertBlend/InvertBlend.tsx
@@ -1,0 +1,70 @@
+import { ThreeCanvas } from '@remotion/three';
+import { useVideoConfig } from 'remotion';
+import { NoColorSpace, Vector2 } from 'three';
+
+import { clampUnit } from '../../utils/clampUnit';
+import {
+  COVER_FIT_VERTEX_SHADER,
+  getCoverUvScale,
+  getImageAspect,
+} from '../shared/coverFit';
+import { ScreenQuad } from '../shared/ScreenQuad';
+import { useImageTexture } from '../shared/useImageTexture';
+
+interface Props {
+  src: string;
+  amount: number;
+}
+
+const FRAGMENT_SHADER = `
+varying vec2 vUv;
+
+uniform sampler2D uTex;
+uniform float uMixRatio;
+
+void main() {
+  vec3 color = texture2D(uTex, vUv).rgb;
+  gl_FragColor = vec4(mix(color, 1.0 - color, uMixRatio), 1.0);
+}
+`;
+
+export function InvertBlend({ src, amount }: Props) {
+  const { width, height } = useVideoConfig();
+
+  return (
+    <ThreeCanvas width={width} height={height}>
+      <InvertedImage src={src} amount={amount} canvasAspect={width / height} />
+    </ThreeCanvas>
+  );
+}
+
+function InvertedImage({
+  src,
+  amount,
+  canvasAspect,
+}: Props & { canvasAspect: number }) {
+  // The shader writes raw values without an output color transform, so the
+  // texture stays untagged for a byte-faithful passthrough at amount = 0.
+  const texture = useImageTexture(src, { colorSpace: NoColorSpace });
+
+  if (!texture) {
+    return null;
+  }
+
+  const coverScale = getCoverUvScale({
+    canvasAspect,
+    imageAspect: getImageAspect(texture),
+  });
+
+  return (
+    <ScreenQuad
+      vertexShader={COVER_FIT_VERTEX_SHADER}
+      fragmentShader={FRAGMENT_SHADER}
+      uniformValues={{
+        uTex: texture,
+        uCoverScale: new Vector2(coverScale.x, coverScale.y),
+        uMixRatio: clampUnit(amount),
+      }}
+    />
+  );
+}

--- a/apps/scene-studio/src/primitives/InvertBlend/index.tsx
+++ b/apps/scene-studio/src/primitives/InvertBlend/index.tsx
@@ -1,0 +1,1 @@
+export { InvertBlend } from './InvertBlend';

--- a/apps/scene-studio/src/primitives/Mosaic/Mosaic.tsx
+++ b/apps/scene-studio/src/primitives/Mosaic/Mosaic.tsx
@@ -1,0 +1,78 @@
+import { ThreeCanvas } from '@remotion/three';
+import { useVideoConfig } from 'remotion';
+import { NoColorSpace, Vector2 } from 'three';
+
+import { clampUnit } from '../../utils/clampUnit';
+import { getCoverUvScale, getImageAspect } from '../shared/coverFit';
+import { ScreenQuad } from '../shared/ScreenQuad';
+import { useImageTexture } from '../shared/useImageTexture';
+
+interface Props {
+  src: string;
+  amount: number;
+}
+
+// Horizontal UV size of a mosaic cell at amount = 1.
+const MAX_CELL_SIZE_IN_UV = 0.02;
+
+// Cells are quantized in screen UV space (square on screen thanks to the
+// canvas-aspect correction), then the cover-fit transform picks the texel.
+const FRAGMENT_SHADER = `
+varying vec2 vUv;
+
+uniform sampler2D uTex;
+uniform vec2 uCoverScale;
+uniform float uCellSizeInUv;
+uniform float uCanvasAspect;
+
+void main() {
+  vec2 uv = vUv;
+  if (uCellSizeInUv > 0.0) {
+    vec2 cellSize = vec2(uCellSizeInUv, uCellSizeInUv * uCanvasAspect);
+    uv = floor(uv / cellSize) * cellSize + cellSize * 0.5;
+  }
+  vec2 coverUv = (uv - 0.5) * uCoverScale + 0.5;
+  gl_FragColor = vec4(texture2D(uTex, coverUv).rgb, 1.0);
+}
+`;
+
+export function Mosaic({ src, amount }: Props) {
+  const { width, height } = useVideoConfig();
+
+  return (
+    <ThreeCanvas width={width} height={height}>
+      <MosaicImage src={src} amount={amount} canvasAspect={width / height} />
+    </ThreeCanvas>
+  );
+}
+
+function MosaicImage({
+  src,
+  amount,
+  canvasAspect,
+}: Props & { canvasAspect: number }) {
+  // The shader writes raw values without an output color transform, so the
+  // texture stays untagged for a byte-faithful passthrough at amount = 0.
+  const texture = useImageTexture(src, { colorSpace: NoColorSpace });
+
+  if (!texture) {
+    return null;
+  }
+
+  const coverScale = getCoverUvScale({
+    canvasAspect,
+    imageAspect: getImageAspect(texture),
+  });
+
+  return (
+    <ScreenQuad
+      fragmentShader={FRAGMENT_SHADER}
+      uniformValues={{
+        uTex: texture,
+        uCoverScale: new Vector2(coverScale.x, coverScale.y),
+        uCellSizeInUv: clampUnit(amount) * MAX_CELL_SIZE_IN_UV,
+        uCanvasAspect: canvasAspect,
+      }}
+    />
+  );
+}

--- a/apps/scene-studio/src/primitives/Mosaic/index.tsx
+++ b/apps/scene-studio/src/primitives/Mosaic/index.tsx
@@ -1,0 +1,1 @@
+export { Mosaic } from './Mosaic';

--- a/apps/scene-studio/src/primitives/SignalNoise/SignalNoise.tsx
+++ b/apps/scene-studio/src/primitives/SignalNoise/SignalNoise.tsx
@@ -1,0 +1,37 @@
+import { ThreeCanvas } from '@remotion/three';
+import { useCurrentFrame, useVideoConfig } from 'remotion';
+
+import { ScreenQuad } from '../shared/ScreenQuad';
+import { getNoiseSeed } from './noiseMotion';
+
+const FRAGMENT_SHADER = `
+varying vec2 vUv;
+
+uniform float uSeed;
+
+float random(vec2 st, float seed) {
+  const float a = 12.9898;
+  const float b = 78.233;
+  const float c = 43758.543123;
+  return fract(sin(dot(st.xy, vec2(a, b)) + seed) * c);
+}
+
+void main() {
+  vec3 color = random(vUv, uSeed) * vec3(1.0);
+  gl_FragColor = vec4(color, 1.0);
+}
+`;
+
+export function SignalNoise() {
+  const frame = useCurrentFrame();
+  const { width, height } = useVideoConfig();
+
+  return (
+    <ThreeCanvas width={width} height={height}>
+      <ScreenQuad
+        fragmentShader={FRAGMENT_SHADER}
+        uniformValues={{ uSeed: getNoiseSeed({ frame }) }}
+      />
+    </ThreeCanvas>
+  );
+}

--- a/apps/scene-studio/src/primitives/SignalNoise/index.tsx
+++ b/apps/scene-studio/src/primitives/SignalNoise/index.tsx
@@ -1,0 +1,1 @@
+export { SignalNoise } from './SignalNoise';

--- a/apps/scene-studio/src/primitives/SignalNoise/noiseMotion.test.ts
+++ b/apps/scene-studio/src/primitives/SignalNoise/noiseMotion.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNoiseSeed } from './noiseMotion';
+
+describe('getNoiseSeed', () => {
+  it('matches the reference seed on the first frame', () => {
+    const seed = getNoiseSeed({ frame: 0 });
+
+    const referenceSeed = 1;
+    expect(seed).toBe(referenceSeed);
+  });
+
+  it('yields a different seed on consecutive frames', () => {
+    const firstSeed = getNoiseSeed({ frame: 1 });
+    const secondSeed = getNoiseSeed({ frame: 2 });
+
+    expect(firstSeed).not.toBe(secondSeed);
+  });
+
+  it('steps linearly between frames', () => {
+    const earlyStep = getNoiseSeed({ frame: 5 }) - getNoiseSeed({ frame: 4 });
+    const lateStep = getNoiseSeed({ frame: 10 }) - getNoiseSeed({ frame: 9 });
+
+    expect(earlyStep).toBe(lateStep);
+  });
+});

--- a/apps/scene-studio/src/primitives/SignalNoise/noiseMotion.ts
+++ b/apps/scene-studio/src/primitives/SignalNoise/noiseMotion.ts
@@ -1,0 +1,8 @@
+// The reference implementation left the seed frozen at 1; stepping it per
+// frame turns the hash field into animated static.
+const INITIAL_NOISE_SEED = 1;
+const NOISE_SEED_STEP_PER_FRAME = 1;
+
+export function getNoiseSeed(input: { frame: number }): number {
+  return INITIAL_NOISE_SEED + input.frame * NOISE_SEED_STEP_PER_FRAME;
+}

--- a/apps/scene-studio/src/primitives/index.ts
+++ b/apps/scene-studio/src/primitives/index.ts
@@ -1,8 +1,13 @@
 export { BrandOutro } from './BrandOutro';
 export { Caption } from './Caption';
+export { ChannelShift } from './ChannelShift';
 export { DepthGallery } from './DepthGallery';
+export { GradientFlow } from './GradientFlow';
 export { GradientOverlay } from './GradientOverlay';
+export { InvertBlend } from './InvertBlend';
 export { Logo } from './Logo';
 export { MediaFrame } from './MediaFrame';
+export { Mosaic } from './Mosaic';
 export { SafeArea } from './SafeArea';
+export { SignalNoise } from './SignalNoise';
 export { VideoTitle } from './VideoTitle';

--- a/apps/scene-studio/src/primitives/shared/ScreenQuad.tsx
+++ b/apps/scene-studio/src/primitives/shared/ScreenQuad.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import type { IUniform, Texture, Vector2 } from 'three';
+
+type UniformValue = number | Vector2 | Texture;
+
+interface Props {
+  fragmentShader: string;
+  vertexShader?: string;
+  uniformValues: Record<string, UniformValue>;
+}
+
+const PASSTHROUGH_VERTEX_SHADER = `
+varying vec2 vUv;
+
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position, 1.0);
+}
+`;
+
+// Fullscreen NDC quad: the vertex shaders bypass the camera matrices, so the
+// 2x2 plane always covers the whole canvas. ShaderMaterial captures its
+// uniforms object at construction, so the record identity must stay stable
+// (created once below); per-frame values are routed through pierced props
+// (uniforms-<name>-value) so the reconciler applies them in the same commit
+// that triggers the frame draw — mutating the captured record during render is
+// not picked up reliably during sequential rendering, and useFrame is
+// off-limits (animations must be pure functions of the current frame). The
+// uniform key set is fixed per mount.
+export function ScreenQuad({
+  fragmentShader,
+  vertexShader = PASSTHROUGH_VERTEX_SHADER,
+  uniformValues,
+}: Props) {
+  const [uniforms] = useState<Record<string, IUniform>>(() =>
+    Object.fromEntries(
+      Object.entries(uniformValues).map(([name, value]) => [name, { value }])
+    )
+  );
+
+  const piercedUniformProps = Object.fromEntries(
+    Object.entries(uniformValues).map(([name, value]) => [
+      `uniforms-${name}-value`,
+      value,
+    ])
+  );
+
+  return (
+    <mesh>
+      <planeGeometry args={[2, 2]} />
+      <shaderMaterial
+        uniforms={uniforms}
+        vertexShader={vertexShader}
+        fragmentShader={fragmentShader}
+        {...piercedUniformProps}
+      />
+    </mesh>
+  );
+}

--- a/apps/scene-studio/src/primitives/shared/coverFit.test.ts
+++ b/apps/scene-studio/src/primitives/shared/coverFit.test.ts
@@ -1,0 +1,43 @@
+import type { Texture } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { getCoverUvScale, getImageAspect } from './coverFit';
+
+describe('getCoverUvScale', () => {
+  it.each([
+    {
+      description: 'crops the sides of a wider image',
+      canvasAspect: 0.5,
+      imageAspect: 2,
+      expected: { x: 0.25, y: 1 },
+    },
+    {
+      description: 'crops the top and bottom of a taller image',
+      canvasAspect: 2,
+      imageAspect: 0.5,
+      expected: { x: 1, y: 0.25 },
+    },
+    {
+      description: 'keeps the full image when aspects match',
+      canvasAspect: 0.5625,
+      imageAspect: 0.5625,
+      expected: { x: 1, y: 1 },
+    },
+  ])('$description', ({ canvasAspect, imageAspect, expected }) => {
+    const scale = getCoverUvScale({ canvasAspect, imageAspect });
+
+    expect(scale).toEqual(expected);
+  });
+});
+
+describe('getImageAspect', () => {
+  it('derives the aspect from the decoded image dimensions', () => {
+    const texture = {
+      image: { width: 600, height: 900 },
+    } as unknown as Texture;
+
+    const aspect = getImageAspect(texture);
+
+    expect(aspect).toBeCloseTo(2 / 3);
+  });
+});

--- a/apps/scene-studio/src/primitives/shared/coverFit.ts
+++ b/apps/scene-studio/src/primitives/shared/coverFit.ts
@@ -1,0 +1,33 @@
+import type { Texture } from 'three';
+
+// Cover-fit texture mapping: scale UV around the center so an arbitrary-aspect
+// image fills the canvas, cropping the overflowing axis (CSS object-fit: cover).
+export const COVER_FIT_VERTEX_SHADER = `
+varying vec2 vUv;
+
+uniform vec2 uCoverScale;
+
+void main() {
+  vUv = (uv - 0.5) * uCoverScale + 0.5;
+  gl_Position = vec4(position, 1.0);
+}
+`;
+
+// TextureLoader always decodes into an HTMLImageElement, but three types
+// Texture.image as unknown; centralize the cast here.
+export function getImageAspect(texture: Texture): number {
+  const image = texture.image as HTMLImageElement;
+
+  return image.width / image.height;
+}
+
+export function getCoverUvScale(input: {
+  canvasAspect: number;
+  imageAspect: number;
+}): { x: number; y: number } {
+  if (input.imageAspect >= input.canvasAspect) {
+    return { x: input.canvasAspect / input.imageAspect, y: 1 };
+  }
+
+  return { x: 1, y: input.imageAspect / input.canvasAspect };
+}

--- a/apps/scene-studio/src/primitives/shared/useImageTexture.test.tsx
+++ b/apps/scene-studio/src/primitives/shared/useImageTexture.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { act, cleanup, render } from '@testing-library/react';
+import type { ColorSpace } from 'three';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ImagePlane } from './ImagePlane';
+import { useImageTexture } from './useImageTexture';
 
 const mocks = vi.hoisted(() => ({
   delayRender: vi.fn(() => 42),
@@ -32,6 +33,7 @@ vi.mock('@react-three/fiber', () => ({
 
 vi.mock('three', () => ({
   SRGBColorSpace: 'srgb',
+  NoColorSpace: '',
   TextureLoader: class {
     load(
       _src: string,
@@ -45,14 +47,13 @@ vi.mock('three', () => ({
   },
 }));
 
-function renderImagePlane() {
-  return render(
-    <ImagePlane
-      src="data:image/svg+xml,card"
-      position={[0, 0, -2.5]}
-      opacity={1}
-    />
+function TextureProbe({ colorSpace }: { colorSpace?: ColorSpace }) {
+  useImageTexture(
+    'data:image/svg+xml,card',
+    colorSpace === undefined ? undefined : { colorSpace }
   );
+
+  return null;
 }
 
 beforeEach(() => {
@@ -66,16 +67,16 @@ afterEach(() => {
   cleanup();
 });
 
-describe('ImagePlane', () => {
+describe('useImageTexture', () => {
   it('delays the render until the texture has loaded', () => {
-    renderImagePlane();
+    render(<TextureProbe />);
 
     expect(mocks.delayRender).toHaveBeenCalledTimes(1);
     expect(mocks.continueRender).not.toHaveBeenCalled();
   });
 
   it('releases the delayed render once the texture has loaded', () => {
-    renderImagePlane();
+    render(<TextureProbe />);
 
     act(() => {
       mocks.textureLoad.onLoad?.({});
@@ -86,7 +87,7 @@ describe('ImagePlane', () => {
   });
 
   it('redraws the frozen canvas before releasing the render while rendering', () => {
-    renderImagePlane();
+    render(<TextureProbe />);
 
     act(() => {
       mocks.textureLoad.onLoad?.({});
@@ -100,7 +101,7 @@ describe('ImagePlane', () => {
 
   it('does not redraw the canvas in the preview environment', () => {
     mocks.environment.isRendering = false;
-    renderImagePlane();
+    render(<TextureProbe />);
 
     act(() => {
       mocks.textureLoad.onLoad?.({});
@@ -110,8 +111,8 @@ describe('ImagePlane', () => {
     expect(mocks.continueRender).toHaveBeenCalledTimes(1);
   });
 
-  it('marks the loaded texture as sRGB for correct colors', () => {
-    renderImagePlane();
+  it('marks the loaded texture as sRGB by default', () => {
+    render(<TextureProbe />);
     const loadedTexture: { colorSpace?: string } = {};
 
     act(() => {
@@ -121,8 +122,19 @@ describe('ImagePlane', () => {
     expect(loadedTexture.colorSpace).toBe('srgb');
   });
 
+  it('applies a color space override to the loaded texture', () => {
+    render(<TextureProbe colorSpace="" />);
+    const loadedTexture: { colorSpace?: string } = {};
+
+    act(() => {
+      mocks.textureLoad.onLoad?.(loadedTexture);
+    });
+
+    expect(loadedTexture.colorSpace).toBe('');
+  });
+
   it('cancels the render when the texture fails to load', () => {
-    renderImagePlane();
+    render(<TextureProbe />);
     const loadError = new Error('texture decode failed');
 
     act(() => {

--- a/apps/scene-studio/src/primitives/shared/useImageTexture.ts
+++ b/apps/scene-studio/src/primitives/shared/useImageTexture.ts
@@ -1,0 +1,54 @@
+import { useThree } from '@react-three/fiber';
+import { useEffect, useState } from 'react';
+import {
+  cancelRender,
+  continueRender,
+  delayRender,
+  useRemotionEnvironment,
+} from 'remotion';
+import {
+  type ColorSpace,
+  SRGBColorSpace,
+  type Texture,
+  TextureLoader,
+} from 'three';
+
+// Must be called under a ThreeCanvas: the redraw below relies on useThree.
+export function useImageTexture(
+  src: string,
+  { colorSpace = SRGBColorSpace }: { colorSpace?: ColorSpace } = {}
+): Texture | null {
+  const [texture, setTexture] = useState<Texture | null>(null);
+  const [delayRenderHandle] = useState(() =>
+    delayRender(`Loading texture: ${src.slice(0, 48)}`)
+  );
+  const advance = useThree((state) => state.advance);
+  const { isRendering } = useRemotionEnvironment();
+
+  useEffect(() => {
+    new TextureLoader().load(
+      src,
+      (loadedTexture) => {
+        loadedTexture.colorSpace = colorSpace;
+        setTexture(loadedTexture);
+      },
+      undefined,
+      (error) => cancelRender(error)
+    );
+  }, [src, colorSpace]);
+
+  useEffect(() => {
+    if (!texture) {
+      return;
+    }
+    // During rendering the frameloop is 'never' and the canvas was already
+    // drawn for this frame before the texture arrived; advance once so the
+    // screenshot includes the textured mesh, then release Remotion.
+    if (isRendering) {
+      advance(performance.now());
+    }
+    continueRender(delayRenderHandle);
+  }, [texture, isRendering, advance, delayRenderHandle]);
+
+  return texture;
+}

--- a/apps/scene-studio/src/utils/clampUnit.test.ts
+++ b/apps/scene-studio/src/utils/clampUnit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { clampUnit } from './clampUnit';
+
+describe('clampUnit', () => {
+  it.each([
+    {
+      description: 'clamps a negative value to zero',
+      value: -0.5,
+      expected: 0,
+    },
+    {
+      description: 'passes an in-range value through',
+      value: 0.4,
+      expected: 0.4,
+    },
+    { description: 'clamps a value above one to one', value: 1.5, expected: 1 },
+  ])('$description', ({ value, expected }) => {
+    const result = clampUnit(value);
+
+    expect(result).toBe(expected);
+  });
+});

--- a/apps/scene-studio/src/utils/clampUnit.ts
+++ b/apps/scene-studio/src/utils/clampUnit.ts
@@ -1,0 +1,3 @@
+export function clampUnit(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
+}


### PR DESCRIPTION
## Summary

Ports the five shader effects from the [krd-knt/threejs-graphics](https://github.com/krd-knt/threejs-graphics) reference repo into Scene Studio as fine-grained, independently reusable primitives (`ChannelShift`, `InvertBlend`, `Mosaic`, `GradientFlow`, `SignalNoise`), and adds a `shader-demo` composition that renders all five effects with captions as one demo video.

### What changed?

- Extracted the DepthGallery texture-loading gating (delayRender → load → advance → continueRender, cancelRender on error) into a shared `useImageTexture` hook with a `colorSpace` option; `ImagePlane` now consumes it (behavior-preserving — verified by the unchanged test suite and a byte-identical `primitive-depth-gallery` still).
- Added shared internals (not exported as primitives): `ScreenQuad` (fullscreen NDC quad + ShaderMaterial with pierced-prop uniform updates), `coverFit` (cover-fit UV math + shared vertex shader), `clampUnit`.
- Added the five effect primitives with inline template-string GLSL (no webpack change) and pure, node-tested motion/math modules.
- Registered five `primitive-*` Studio demos plus the `shader-demo` composition (5 scenes × 150 frames = 750 frames / 25 s) and a README table row.

### Why was this changed?

- The reference repo's effects were locked inside a window-global rAF harness; Scene Studio needs them as deterministic, per-frame-driven building blocks for future compositions (#392).

## Deliberate adaptations from the reference

- Cover-fit UV mapping replaces the window-aspect UV hack (correct for arbitrary image aspects on the 9:16 canvas).
- The noise shader gets a per-frame seed (the original was frozen at seed 1) and a fullscreen NDC quad (the original used an MVP-projected centered quad).
- Mosaic cells are quantized square in screen space via the canvas aspect.
- Dead uniforms (`uTime`/`uResolution` where unused) are dropped; GLSL magic scale factors moved to testable TypeScript constants.
- `GradientFlow` uses linear elapsed time (the reference wrapped accumulated time in `Math.sin`, slowly rocking the field back and forth instead of flowing).
- Image-effect textures load untagged (`NoColorSpace`) because `ShaderMaterial` has no output color transform — verified byte-faithful passthrough at `amount = 0` (background pixel exactly `#474a4d` at frame 0).

## Rendering note

Uniform values are routed through React Three Fiber pierced props (`uniforms-<name>-value`) instead of mutating the captured uniforms record during render: during sequential rendering (`frameloop='never'` + advance-per-frame), render-body mutations were not picked up after the initial mount — effects froze at their mount-time amount. Pierced props go through the reconciler's commit-phase applyProps, the same mechanism DepthGallery's animated props already rely on. Verified by a segment-range render showing the inversion peak mid-segment.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔧 Refactoring (code changes that neither fix a bug nor add a feature)
- [x] 🧪 Test additions or updates
- [x] 📝 Documentation update

## Affected Applications

- [x] 🎬 Scene Studio (`apps/scene-studio/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed

92 tests across 18 files. New coverage: `useImageTexture` gating contract (moved from `ImagePlane.test.tsx`, plus a colorSpace-override case), cover-fit scaling, unit clamping, gradient time (zero start, bounds, fps independence), noise seed (reference value, distinctness, linearity), and shader-demo scene order/duration. The shader components themselves are verified by real renders (WebGL cannot run in jsdom — same rationale as PR #391).

### How to Test

1. `pnpm -F scene-studio test && pnpm -F scene-studio typecheck && pnpm -F scene-studio lint`
2. `pnpm -F scene-studio dev` → scrub `primitive-channel-shift` / `primitive-mosaic` etc.
3. `pnpm -F scene-studio render shader-demo` (local macOS) → 25 s video with five labeled segments.

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

Determinism: identical bytes across repeated stills (GPU/`angle`). DepthGallery regression: pre/post-refactor stills byte-identical. Effect verification: per-effect stills at peak amount plus full `shader-demo` render inspected frame-by-frame.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (README, CLAUDE.md, etc.)

README gains the `shader-demo` row. `AGENTS.md` needs no change: the existing 3D boundary statement (focused ThreeCanvas primitives, frame-driven, no general 3D abstraction) already covers these primitives; `ScreenQuad` is internal DRY plumbing, not a public abstraction.

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #392

## Additional Context

Media stays uncommitted (`out/` is gitignored); demo textures are inline SVG data URIs. Follow-ups intentionally out of scope: applying effects to video textures, postprocessing (DOF), and integrating effects into the travel video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
