### PR TITLE
✨ Feat: #398 Add depth parallax primitive

### DIFF
--- a/apps/scene-studio/src/compositions/ShaderDemo/scenes.test.ts
+++ b/apps/scene-studio/src/compositions/ShaderDemo/scenes.test.ts
@@ -21,6 +21,7 @@ describe('shaderDemoScenes', () => {
       'halftone',
       'duotone',
       'kaleidoscope',
+      'depth-parallax',
       'gradient-flow',
       'signal-noise',
     ]);
@@ -40,6 +41,6 @@ describe('getShaderDemoDurationInFrames', () => {
     const expectedDuration =
       shaderDemoScenes.length * SHADER_SCENE_DURATION_IN_FRAMES;
     expect(duration).toBe(expectedDuration);
-    expect(duration).toBe(1800);
+    expect(duration).toBe(1950);
   });
 });

--- a/apps/scene-studio/src/compositions/ShaderDemo/scenes.ts
+++ b/apps/scene-studio/src/compositions/ShaderDemo/scenes.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 
 import { ChannelShiftDemo } from '../primitives/ChannelShiftDemo';
+import { DepthParallaxDemo } from '../primitives/DepthParallaxDemo';
 import { DuotoneDemo } from '../primitives/DuotoneDemo';
 import { FluidDistortionDemo } from '../primitives/FluidDistortionDemo';
 import { GlitchShiftDemo } from '../primitives/GlitchShiftDemo';
@@ -45,6 +46,11 @@ export const shaderDemoScenes = [
     name: 'kaleidoscope',
     label: 'Kaleidoscope',
     component: KaleidoscopeDemo,
+  },
+  {
+    name: 'depth-parallax',
+    label: 'Depth Parallax',
+    component: DepthParallaxDemo,
   },
   {
     name: 'gradient-flow',

--- a/apps/scene-studio/src/compositions/primitives/DepthParallaxDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/DepthParallaxDemo.tsx
@@ -1,0 +1,20 @@
+import { AbsoluteFill } from 'remotion';
+import { DepthParallax } from '../../primitives';
+import { SAMPLE_DEPTH_SOURCE, SAMPLE_IMAGE_SOURCE } from './sampleImage';
+
+export function DepthParallaxDemo() {
+  return (
+    <AbsoluteFill className="bg-base-black">
+      {/* The sway and push-in are time-driven, so constant amounts show the
+          full orbit across the demo cycle. */}
+      <DepthParallax
+        src={SAMPLE_IMAGE_SOURCE}
+        depthSrc={SAMPLE_DEPTH_SOURCE}
+        parallaxAmount={1}
+        dollyAmount={0.6}
+        focus={0.85}
+        blurAmount={0.6}
+      />
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/demos.ts
+++ b/apps/scene-studio/src/compositions/primitives/demos.ts
@@ -4,6 +4,7 @@ import { BrandOutroDemo } from './BrandOutroDemo';
 import { CaptionDemo } from './CaptionDemo';
 import { ChannelShiftDemo } from './ChannelShiftDemo';
 import { DepthGalleryDemo } from './DepthGalleryDemo';
+import { DepthParallaxDemo } from './DepthParallaxDemo';
 import { DuotoneDemo } from './DuotoneDemo';
 import { EdgeBlurDemo } from './EdgeBlurDemo';
 import { FilmGrainDemo } from './FilmGrainDemo';
@@ -45,6 +46,7 @@ export const primitiveDemos = [
   { id: 'primitive-logo', component: LogoDemo },
   { id: 'primitive-media-frame', component: MediaFrameDemo },
   { id: 'primitive-depth-gallery', component: DepthGalleryDemo },
+  { id: 'primitive-depth-parallax', component: DepthParallaxDemo },
   { id: 'primitive-channel-shift', component: ChannelShiftDemo },
   { id: 'primitive-invert-blend', component: InvertBlendDemo },
   { id: 'primitive-mosaic', component: MosaicDemo },

--- a/apps/scene-studio/src/compositions/primitives/sampleImage.ts
+++ b/apps/scene-studio/src/compositions/primitives/sampleImage.ts
@@ -3,3 +3,9 @@
 const sampleSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="900"><rect width="600" height="900" fill="#474a4d"/><circle cx="300" cy="300" r="180" fill="#b8d200"/><circle cx="300" cy="300" r="100" fill="#f8b500"/><rect x="60" y="560" width="480" height="16" fill="#f8b500"/><rect x="60" y="600" width="360" height="16" fill="#b8d200"/><rect x="60" y="640" width="420" height="16" fill="#ffffff"/><text x="300" y="810" font-family="Helvetica, Arial, sans-serif" font-size="120" font-weight="700" fill="#ffffff" text-anchor="middle">K2BG</text></svg>`;
 
 export const SAMPLE_IMAGE_SOURCE = `data:image/svg+xml,${encodeURIComponent(sampleSvg)}`;
+
+// Synthetic depth map matched to the card: the big circle reads as near
+// (white), the frame edges as far (black) — the monocular-depth convention.
+const sampleDepthSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="900"><defs><radialGradient id="depth" cx="50%" cy="33.3%" r="66%"><stop offset="0%" stop-color="#ffffff"/><stop offset="45%" stop-color="#888888"/><stop offset="100%" stop-color="#000000"/></radialGradient></defs><rect width="600" height="900" fill="url(#depth)"/></svg>`;
+
+export const SAMPLE_DEPTH_SOURCE = `data:image/svg+xml,${encodeURIComponent(sampleDepthSvg)}`;

--- a/apps/scene-studio/src/primitives/DepthParallax/DepthParallax.test.tsx
+++ b/apps/scene-studio/src/primitives/DepthParallax/DepthParallax.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Vector2 } from 'three';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DepthParallax } from './DepthParallax';
+
+const mocks = vi.hoisted(() => ({
+  capturedUniforms: null as Record<string, unknown> | null,
+  frame: 0,
+  loadedTexture: { image: { width: 600, height: 900 } },
+}));
+
+vi.mock('remotion', () => ({
+  useCurrentFrame: () => mocks.frame,
+  useVideoConfig: () => ({ width: 1080, height: 1920, fps: 30 }),
+}));
+
+vi.mock('@remotion/three', () => ({
+  ThreeCanvas: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../shared/useImageTexture', () => ({
+  useImageTexture: () => mocks.loadedTexture,
+}));
+
+vi.mock('../shared/ScreenQuad', () => ({
+  ScreenQuad: ({
+    uniformValues,
+  }: {
+    uniformValues: Record<string, unknown>;
+  }) => {
+    mocks.capturedUniforms = uniformValues;
+    return null;
+  },
+}));
+
+beforeEach(() => {
+  mocks.capturedUniforms = null;
+  mocks.frame = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DepthParallax', () => {
+  it('starts the push-in from the untouched frame', () => {
+    render(
+      <DepthParallax
+        src="photo.jpg"
+        depthSrc="depth.png"
+        parallaxAmount={1}
+        dollyAmount={1}
+      />
+    );
+
+    const offset = mocks.capturedUniforms?.uParallaxOffset as Vector2;
+    expect(offset.x).toBeCloseTo(0);
+    expect(mocks.capturedUniforms?.uZoom).toBe(1);
+  });
+
+  it('sways within the parallax amplitude as time advances', () => {
+    mocks.frame = 30;
+
+    render(
+      <DepthParallax src="photo.jpg" depthSrc="depth.png" parallaxAmount={1} />
+    );
+
+    const offset = mocks.capturedUniforms?.uParallaxOffset as Vector2;
+    const maxParallaxInUv = 0.04;
+    expect(Math.abs(offset.x)).toBeGreaterThan(0);
+    expect(Math.abs(offset.x)).toBeLessThanOrEqual(maxParallaxInUv);
+  });
+
+  it('clamps focus into the unit range', () => {
+    render(
+      <DepthParallax
+        src="photo.jpg"
+        depthSrc="depth.png"
+        parallaxAmount={0}
+        focus={1.5}
+      />
+    );
+
+    expect(mocks.capturedUniforms?.uFocus).toBe(1);
+  });
+
+  it('scales the blur radius from the blur amount', () => {
+    render(
+      <DepthParallax
+        src="photo.jpg"
+        depthSrc="depth.png"
+        parallaxAmount={0}
+        blurAmount={0.5}
+      />
+    );
+
+    const maxBlurInUv = 0.012;
+    expect(mocks.capturedUniforms?.uMaxBlurInUv).toBeCloseTo(maxBlurInUv * 0.5);
+  });
+
+  it('rests as the untouched photo with zero amounts', () => {
+    render(
+      <DepthParallax src="photo.jpg" depthSrc="depth.png" parallaxAmount={0} />
+    );
+
+    const offset = mocks.capturedUniforms?.uParallaxOffset as Vector2;
+    expect(offset.x).toBe(0);
+    expect(offset.y).toBe(0);
+    expect(mocks.capturedUniforms?.uZoom).toBe(1);
+    expect(mocks.capturedUniforms?.uMaxBlurInUv).toBe(0);
+  });
+});

--- a/apps/scene-studio/src/primitives/DepthParallax/DepthParallax.tsx
+++ b/apps/scene-studio/src/primitives/DepthParallax/DepthParallax.tsx
@@ -1,0 +1,142 @@
+import { ThreeCanvas } from '@remotion/three';
+import { useCurrentFrame, useVideoConfig } from 'remotion';
+import { NoColorSpace, Vector2 } from 'three';
+
+import { clampUnit } from '../../utils/clampUnit';
+import {
+  COVER_FIT_VERTEX_SHADER,
+  getCoverUvScale,
+  getTextureAspect,
+} from '../shared/coverFit';
+import { ScreenQuad } from '../shared/ScreenQuad';
+import { useImageTexture } from '../shared/useImageTexture';
+import { getParallaxMotion } from './parallaxMotion';
+
+interface Props {
+  src: string;
+  depthSrc: string;
+  parallaxAmount: number;
+  dollyAmount?: number;
+  speed?: number;
+  focus?: number;
+  blurAmount?: number;
+}
+
+// Blur disc radius in UV at blurAmount = 1 and a full focus distance.
+const MAX_BLUR_IN_UV = 0.012;
+
+// The depth map scales both the sway (pixels at the focus depth stay still,
+// near and far layers move apart) and the defocus blur. Brighter depth
+// values read as nearer, the usual monocular-depth convention.
+const FRAGMENT_SHADER = `
+varying vec2 vUv;
+
+uniform sampler2D uTex;
+uniform sampler2D uDepthTex;
+uniform vec2 uParallaxOffset;
+uniform float uZoom;
+uniform float uFocus;
+uniform float uMaxBlurInUv;
+
+const float DIAGONAL_SHARE = 0.7071;
+
+void main() {
+  vec2 zoomedUv = (vUv - 0.5) / uZoom + 0.5;
+  float depth = texture2D(uDepthTex, zoomedUv).r;
+  vec2 displacedUv = zoomedUv + uParallaxOffset * (depth - uFocus);
+
+  float blurRadius = uMaxBlurInUv * abs(depth - uFocus);
+  float diagonal = blurRadius * DIAGONAL_SHARE;
+  vec3 color = texture2D(uTex, displacedUv).rgb;
+  color += texture2D(uTex, displacedUv + vec2(blurRadius, 0.0)).rgb;
+  color += texture2D(uTex, displacedUv - vec2(blurRadius, 0.0)).rgb;
+  color += texture2D(uTex, displacedUv + vec2(0.0, blurRadius)).rgb;
+  color += texture2D(uTex, displacedUv - vec2(0.0, blurRadius)).rgb;
+  color += texture2D(uTex, displacedUv + vec2(diagonal, diagonal)).rgb;
+  color += texture2D(uTex, displacedUv + vec2(diagonal, -diagonal)).rgb;
+  color += texture2D(uTex, displacedUv + vec2(-diagonal, diagonal)).rgb;
+  color += texture2D(uTex, displacedUv + vec2(-diagonal, -diagonal)).rgb;
+
+  gl_FragColor = vec4(color / 9.0, 1.0);
+}
+`;
+
+// Gives a still photo internal camera motion from a depth map: an elliptical
+// sway whose displacement follows depth, a breathing push-in, and a depth-
+// weighted defocus. Zero amounts render the untouched photo.
+export function DepthParallax({
+  src,
+  depthSrc,
+  parallaxAmount,
+  dollyAmount = 0,
+  speed = 0.25,
+  focus = 0.5,
+  blurAmount = 0,
+}: Props) {
+  const { width, height } = useVideoConfig();
+
+  return (
+    <ThreeCanvas width={width} height={height}>
+      <ParallaxImage
+        src={src}
+        depthSrc={depthSrc}
+        parallaxAmount={parallaxAmount}
+        dollyAmount={dollyAmount}
+        speed={speed}
+        focus={focus}
+        blurAmount={blurAmount}
+        canvasAspect={width / height}
+      />
+    </ThreeCanvas>
+  );
+}
+
+function ParallaxImage({
+  src,
+  depthSrc,
+  parallaxAmount,
+  dollyAmount,
+  speed,
+  focus,
+  blurAmount,
+  canvasAspect,
+}: Required<Props> & { canvasAspect: number }) {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  // Raw passthrough for the photo (ChannelShift convention); the depth map
+  // is data, never color-managed.
+  const texture = useImageTexture(src, { colorSpace: NoColorSpace });
+  const depthTexture = useImageTexture(depthSrc, { colorSpace: NoColorSpace });
+
+  if (!texture || !depthTexture) {
+    return null;
+  }
+
+  const coverScale = getCoverUvScale({
+    canvasAspect,
+    imageAspect: getTextureAspect(texture),
+  });
+  const motion = getParallaxMotion({
+    frame,
+    fps,
+    speed,
+    parallaxAmount,
+    dollyAmount,
+  });
+
+  return (
+    <ScreenQuad
+      vertexShader={COVER_FIT_VERTEX_SHADER}
+      fragmentShader={FRAGMENT_SHADER}
+      uniformValues={{
+        uTex: texture,
+        uDepthTex: depthTexture,
+        uCoverScale: new Vector2(coverScale.x, coverScale.y),
+        uParallaxOffset: new Vector2(motion.offsetXInUv, motion.offsetYInUv),
+        uZoom: motion.zoom,
+        uFocus: clampUnit(focus),
+        uMaxBlurInUv: clampUnit(blurAmount) * MAX_BLUR_IN_UV,
+      }}
+    />
+  );
+}

--- a/apps/scene-studio/src/primitives/DepthParallax/index.tsx
+++ b/apps/scene-studio/src/primitives/DepthParallax/index.tsx
@@ -1,0 +1,1 @@
+export * from './DepthParallax';

--- a/apps/scene-studio/src/primitives/DepthParallax/parallaxMotion.test.ts
+++ b/apps/scene-studio/src/primitives/DepthParallax/parallaxMotion.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { getParallaxMotion } from './parallaxMotion';
+
+describe('getParallaxMotion', () => {
+  it('rests at the exact identity with zero amounts', () => {
+    const motion = getParallaxMotion({
+      frame: 77,
+      fps: 30,
+      speed: 0.25,
+      parallaxAmount: 0,
+      dollyAmount: 0,
+    });
+
+    // Strict equality treats -0 as 0, unlike Object.is-based matchers.
+    expect(motion.offsetXInUv === 0).toBe(true);
+    expect(motion.offsetYInUv === 0).toBe(true);
+    expect(motion.zoom).toBe(1);
+  });
+
+  it('starts the push-in from the untouched frame', () => {
+    const motion = getParallaxMotion({
+      frame: 0,
+      fps: 30,
+      speed: 0.25,
+      parallaxAmount: 1,
+      dollyAmount: 1,
+    });
+
+    expect(motion.offsetXInUv).toBe(0);
+    expect(motion.zoom).toBe(1);
+  });
+
+  it('keeps the sway and zoom within their amplitudes', () => {
+    const frames = Array.from({ length: 240 }, (_, frame) => frame);
+
+    const motions = frames.map((frame) =>
+      getParallaxMotion({
+        frame,
+        fps: 30,
+        speed: 0.5,
+        parallaxAmount: 1,
+        dollyAmount: 1,
+      })
+    );
+
+    const maxParallaxInUv = 0.04;
+    const maxZoom = 1.12;
+    expect(
+      motions.every(
+        (motion) =>
+          Math.abs(motion.offsetXInUv) <= maxParallaxInUv &&
+          Math.abs(motion.offsetYInUv) <= maxParallaxInUv &&
+          motion.zoom >= 1 &&
+          motion.zoom <= maxZoom
+      )
+    ).toBe(true);
+  });
+
+  it('sways at the same pace regardless of the frame rate', () => {
+    const atThirtyFps = getParallaxMotion({
+      frame: 30,
+      fps: 30,
+      speed: 0.25,
+      parallaxAmount: 1,
+      dollyAmount: 1,
+    });
+    const atSixtyFps = getParallaxMotion({
+      frame: 60,
+      fps: 60,
+      speed: 0.25,
+      parallaxAmount: 1,
+      dollyAmount: 1,
+    });
+
+    expect(atThirtyFps.offsetXInUv).toBeCloseTo(atSixtyFps.offsetXInUv);
+    expect(atThirtyFps.zoom).toBeCloseTo(atSixtyFps.zoom);
+  });
+});

--- a/apps/scene-studio/src/primitives/DepthParallax/parallaxMotion.ts
+++ b/apps/scene-studio/src/primitives/DepthParallax/parallaxMotion.ts
@@ -1,0 +1,34 @@
+import { clampUnit } from '../../utils/clampUnit';
+
+const TWO_PI = Math.PI * 2;
+// Screen-UV amplitude of the sway at parallaxAmount = 1.
+const MAX_PARALLAX_IN_UV = 0.04;
+// Push-in share of the frame at dollyAmount = 1.
+const MAX_DOLLY_ZOOM = 0.12;
+// The vertical sway is smaller than the horizontal one, like a handheld
+// camera orbit.
+const VERTICAL_SWAY_SHARE = 0.6;
+
+// One elliptical camera orbit per 1 / speed seconds, plus a breathing
+// push-in. Zero amounts return the exact identity so the primitive can rest
+// invisibly.
+export function getParallaxMotion(input: {
+  frame: number;
+  fps: number;
+  speed: number;
+  parallaxAmount: number;
+  dollyAmount: number;
+}): { offsetXInUv: number; offsetYInUv: number; zoom: number } {
+  const phase = (input.frame / input.fps) * input.speed * TWO_PI;
+  const amplitudeInUv = clampUnit(input.parallaxAmount) * MAX_PARALLAX_IN_UV;
+
+  return {
+    offsetXInUv: Math.sin(phase) * amplitudeInUv,
+    offsetYInUv: Math.cos(phase) * amplitudeInUv * VERTICAL_SWAY_SHARE,
+    zoom:
+      1 +
+      clampUnit(input.dollyAmount) *
+        MAX_DOLLY_ZOOM *
+        (0.5 - 0.5 * Math.cos(phase)),
+  };
+}

--- a/apps/scene-studio/src/primitives/index.ts
+++ b/apps/scene-studio/src/primitives/index.ts
@@ -2,6 +2,7 @@ export { BrandOutro } from './BrandOutro';
 export { Caption } from './Caption';
 export { ChannelShift } from './ChannelShift';
 export { DepthGallery } from './DepthGallery';
+export { DepthParallax } from './DepthParallax';
 export { Duotone } from './Duotone';
 export { EdgeBlur } from './EdgeBlur';
 export { FilmGrain } from './FilmGrain';


### PR DESCRIPTION
## Summary

Fifth batch of the effect-primitive expansion (#394–#399): the "still photo that moves" primitive.

### What changed?

- Added `DepthParallax` — takes `src` plus `depthSrc` (both loaded through `useImageTexture`, the depth map deliberately never color-managed) and animates the photo from its depth map:
  - depth-weighted UV displacement: pixels at the `focus` depth stay still while nearer and farther layers move apart, driven by an elliptical camera sway (`parallaxAmount`, `speed`)
  - a breathing push-in (`dollyAmount`)
  - a 9-tap depth-weighted defocus (`blurAmount`) — the blur radius follows the distance from the focus plane
  - all motion comes from the tested pure helper `getParallaxMotion`; zero amounts return the exact identity so the primitive can rest invisibly
- Added a synthetic depth map (`SAMPLE_DEPTH_SOURCE`, a data-URI radial-gradient SVG matched to the sample card, following the `sampleImage.ts` convention) so the committed demo needs no media assets.
- Registered the `primitive-depth-parallax` demo and extended `shader-demo` (now 13 scenes / 1950 frames).

### Why was this changed?

- `DepthGallery` places multiple flat photos in 3D space, but there was no way to give a single photograph internal depth motion — the staple "photo with camera movement" look for product and gallery videos (#398).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Affected Applications

- [x] 🎬 Scene Studio (`apps/scene-studio/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed

`parallaxMotion.test.ts` covers the identity endpoint at zero amounts, the untouched first frame of the push-in, amplitude bounds across a sweep, and frame-rate independence. `DepthParallax.test.tsx` covers the prop-to-uniform behavior (sway amplitude over time, focus clamping, blur scaling, zero-amount identity). `scenes.test.ts` pins the new shader-demo order.

### How to Test

1. `pnpm -F scene-studio test && pnpm -F scene-studio typecheck && pnpm -F scene-studio lint`
2. `pnpm -F scene-studio dev` → open `primitive-depth-parallax` and scrub: the near circle and far text should move at different rates, edges defocused.
3. For real footage, pass a photo and a monocular depth map (e.g. from Depth Anything) via `staticFile('assets/…')` locally.

### Test Results

- [x] All existing tests pass (`pnpm test`) — 160 tests across 32 files
- [x] New tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

Manual verification: stills at four sway phases show the near circle and far text/stripes displacing by different amounts (true parallax), the focus-plane circle staying sharp while off-focus regions soften, and the push-in breathing. Repeated renders of the same frame are byte-identical (`cmp`).

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #398

## Additional Context

Depth-map generation tooling is out of scope; maps are provided as input assets. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
