### PR TITLE
✨ Feat: #399 Add post-processing effect stage

### DIFF
--- a/apps/scene-studio/package.json
+++ b/apps/scene-studio/package.json
@@ -14,10 +14,12 @@
   },
   "dependencies": {
     "@react-three/fiber": "^9.6.1",
+    "@react-three/postprocessing": "^3.0.4",
     "@remotion/cli": "4.0.488",
     "@remotion/three": "4.0.488",
     "@remotion/transitions": "4.0.488",
     "clsx": "^2.1.1",
+    "postprocessing": "^6.39.3",
     "react": "^19.0.1",
     "react-dom": "^19.0.1",
     "remotion": "4.0.488",

--- a/apps/scene-studio/src/compositions/primitives/PostFxStageDemo.tsx
+++ b/apps/scene-studio/src/compositions/primitives/PostFxStageDemo.tsx
@@ -1,0 +1,46 @@
+import { AbsoluteFill, useCurrentFrame, useVideoConfig } from 'remotion';
+import { PostFxStage } from '../../primitives';
+
+const TURNS_PER_SECOND = 0.15;
+const TWO_PI = Math.PI * 2;
+
+// An emissive knot for the bloom and depth-staggered spheres for the
+// defocus; the spin derives from the frame so the demo stays deterministic.
+export function PostFxStageDemo() {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const angle = (frame / fps) * TURNS_PER_SECOND * TWO_PI;
+
+  return (
+    <AbsoluteFill className="bg-base-black">
+      <PostFxStage
+        bloom={{ intensity: 0.9 }}
+        depthOfField={{
+          focusDistance: 0.005,
+          focalLength: 0.02,
+          bokehScale: 5,
+        }}
+      >
+        <ambientLight intensity={0.4} />
+        <pointLight position={[3, 3, 3]} intensity={40} />
+        <mesh position={[0, 0.4, 0]} rotation={[0, angle, 0.4]}>
+          <torusKnotGeometry args={[0.7, 0.22, 128, 32]} />
+          <meshStandardMaterial
+            color="#b8d200"
+            emissive="#b8d200"
+            emissiveIntensity={1.1}
+            toneMapped={false}
+          />
+        </mesh>
+        <mesh position={[-1.1, -1.8, -3]}>
+          <sphereGeometry args={[0.7, 32, 32]} />
+          <meshStandardMaterial color="#f8b500" />
+        </mesh>
+        <mesh position={[1.3, 2, -6]}>
+          <sphereGeometry args={[1, 32, 32]} />
+          <meshStandardMaterial color="#ffffff" />
+        </mesh>
+      </PostFxStage>
+    </AbsoluteFill>
+  );
+}

--- a/apps/scene-studio/src/compositions/primitives/demos.ts
+++ b/apps/scene-studio/src/compositions/primitives/demos.ts
@@ -24,6 +24,7 @@ import { PaintRevealDemo } from './PaintRevealDemo';
 import { PaintSmearDemo } from './PaintSmearDemo';
 import { ParticleDriftDemo } from './ParticleDriftDemo';
 import { ParticleRevealDemo } from './ParticleRevealDemo';
+import { PostFxStageDemo } from './PostFxStageDemo';
 import { SafeAreaDemo } from './SafeAreaDemo';
 import { ScanlineDemo } from './ScanlineDemo';
 import { SignalNoiseDemo } from './SignalNoiseDemo';
@@ -47,6 +48,7 @@ export const primitiveDemos = [
   { id: 'primitive-media-frame', component: MediaFrameDemo },
   { id: 'primitive-depth-gallery', component: DepthGalleryDemo },
   { id: 'primitive-depth-parallax', component: DepthParallaxDemo },
+  { id: 'primitive-post-fx-stage', component: PostFxStageDemo },
   { id: 'primitive-channel-shift', component: ChannelShiftDemo },
   { id: 'primitive-invert-blend', component: InvertBlendDemo },
   { id: 'primitive-mosaic', component: MosaicDemo },

--- a/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.test.tsx
+++ b/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   composerProps: null as Record<string, unknown> | null,
   bloomProps: null as Record<string, unknown> | null,
   depthOfFieldProps: null as Record<string, unknown> | null,
+  toneMappingProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock('remotion', () => ({
@@ -32,12 +33,21 @@ vi.mock('@react-three/postprocessing', () => ({
     mocks.depthOfFieldProps = props;
     return null;
   },
+  ToneMapping: (props: Record<string, unknown>) => {
+    mocks.toneMappingProps = props;
+    return null;
+  },
+}));
+
+vi.mock('postprocessing', () => ({
+  ToneMappingMode: { ACES_FILMIC: 'aces-filmic' },
 }));
 
 beforeEach(() => {
   mocks.composerProps = null;
   mocks.bloomProps = null;
   mocks.depthOfFieldProps = null;
+  mocks.toneMappingProps = null;
 });
 
 afterEach(() => {
@@ -91,5 +101,15 @@ describe('PostFxStage', () => {
 
     expect(mocks.bloomProps).not.toBeNull();
     expect(mocks.depthOfFieldProps).not.toBeNull();
+  });
+
+  it('restores the default tone mapping whenever the composer mounts', () => {
+    render(
+      <PostFxStage bloom={{}}>
+        <span data-testid="scene" />
+      </PostFxStage>
+    );
+
+    expect(mocks.toneMappingProps?.mode).toBe('aces-filmic');
   });
 });

--- a/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.test.tsx
+++ b/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PostFxStage } from './PostFxStage';
+
+const mocks = vi.hoisted(() => ({
+  composerProps: null as Record<string, unknown> | null,
+  bloomProps: null as Record<string, unknown> | null,
+  depthOfFieldProps: null as Record<string, unknown> | null,
+}));
+
+vi.mock('remotion', () => ({
+  useVideoConfig: () => ({ width: 1080, height: 1920, fps: 30 }),
+}));
+
+vi.mock('@remotion/three', () => ({
+  ThreeCanvas: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@react-three/postprocessing', () => ({
+  EffectComposer: ({ children, ...props }: { children: ReactNode }) => {
+    mocks.composerProps = props;
+    return <div data-testid="composer">{children}</div>;
+  },
+  Bloom: (props: Record<string, unknown>) => {
+    mocks.bloomProps = props;
+    return null;
+  },
+  DepthOfField: (props: Record<string, unknown>) => {
+    mocks.depthOfFieldProps = props;
+    return null;
+  },
+}));
+
+beforeEach(() => {
+  mocks.composerProps = null;
+  mocks.bloomProps = null;
+  mocks.depthOfFieldProps = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PostFxStage', () => {
+  it('renders the bare scene without a composer when no effects are requested', () => {
+    render(
+      <PostFxStage>
+        <span data-testid="scene" />
+      </PostFxStage>
+    );
+
+    expect(screen.getByTestId('scene')).toBeTruthy();
+    expect(screen.queryByTestId('composer')).toBeNull();
+  });
+
+  it('mounts the composer without multisampling when bloom is requested', () => {
+    render(
+      <PostFxStage bloom={{ intensity: 2, luminanceThreshold: 0.5 }}>
+        <span data-testid="scene" />
+      </PostFxStage>
+    );
+
+    expect(mocks.composerProps?.multisampling).toBe(0);
+    expect(mocks.bloomProps?.intensity).toBe(2);
+    expect(mocks.bloomProps?.luminanceThreshold).toBe(0.5);
+    expect(mocks.depthOfFieldProps).toBeNull();
+  });
+
+  it('mounts the depth of field with its defaults', () => {
+    render(
+      <PostFxStage depthOfField={{}}>
+        <span data-testid="scene" />
+      </PostFxStage>
+    );
+
+    expect(mocks.depthOfFieldProps?.focusDistance).toBe(0.02);
+    expect(mocks.depthOfFieldProps?.focalLength).toBe(0.05);
+    expect(mocks.depthOfFieldProps?.bokehScale).toBe(3);
+    expect(mocks.bloomProps).toBeNull();
+  });
+
+  it('stacks both effects when both are requested', () => {
+    render(
+      <PostFxStage bloom={{}} depthOfField={{}}>
+        <span data-testid="scene" />
+      </PostFxStage>
+    );
+
+    expect(mocks.bloomProps).not.toBeNull();
+    expect(mocks.depthOfFieldProps).not.toBeNull();
+  });
+});

--- a/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.tsx
+++ b/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.tsx
@@ -2,8 +2,10 @@ import {
   Bloom,
   DepthOfField,
   EffectComposer,
+  ToneMapping,
 } from '@react-three/postprocessing';
 import { ThreeCanvas } from '@remotion/three';
+import { ToneMappingMode } from 'postprocessing';
 import type { ReactNode } from 'react';
 import { useVideoConfig } from 'remotion';
 
@@ -49,6 +51,15 @@ export function PostFxStage({ bloom, depthOfField, children }: Props) {
       />
     ) : null,
   ].filter((effect) => effect !== null);
+
+  if (effects.length > 0) {
+    // The composer disables the renderer's tone mapping while mounted, so
+    // restore the default ACES output as the final pass — enabling an
+    // effect must not change the color pipeline.
+    effects.push(
+      <ToneMapping key="tone-mapping" mode={ToneMappingMode.ACES_FILMIC} />
+    );
+  }
 
   return (
     <ThreeCanvas width={width} height={height}>

--- a/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.tsx
+++ b/apps/scene-studio/src/primitives/PostFxStage/PostFxStage.tsx
@@ -1,0 +1,61 @@
+import {
+  Bloom,
+  DepthOfField,
+  EffectComposer,
+} from '@react-three/postprocessing';
+import { ThreeCanvas } from '@remotion/three';
+import type { ReactNode } from 'react';
+import { useVideoConfig } from 'remotion';
+
+interface BloomOptions {
+  intensity?: number;
+  luminanceThreshold?: number;
+}
+
+interface DepthOfFieldOptions {
+  focusDistance?: number;
+  focalLength?: number;
+  bokehScale?: number;
+}
+
+interface Props {
+  bloom?: BloomOptions;
+  depthOfField?: DepthOfFieldOptions;
+  children: ReactNode;
+}
+
+// Hosts a 3D scene inside a ThreeCanvas and finishes it with composer-based
+// post-processing. Without effect options the composer is skipped entirely,
+// so the stage renders the bare scene. MSAA stays off (multisampling 0) —
+// the documented safe baseline for composer effects.
+export function PostFxStage({ bloom, depthOfField, children }: Props) {
+  const { width, height } = useVideoConfig();
+
+  const effects = [
+    bloom ? (
+      <Bloom
+        key="bloom"
+        mipmapBlur
+        intensity={bloom.intensity ?? 1}
+        luminanceThreshold={bloom.luminanceThreshold ?? 0.9}
+      />
+    ) : null,
+    depthOfField ? (
+      <DepthOfField
+        key="depth-of-field"
+        focusDistance={depthOfField.focusDistance ?? 0.02}
+        focalLength={depthOfField.focalLength ?? 0.05}
+        bokehScale={depthOfField.bokehScale ?? 3}
+      />
+    ) : null,
+  ].filter((effect) => effect !== null);
+
+  return (
+    <ThreeCanvas width={width} height={height}>
+      {children}
+      {effects.length > 0 ? (
+        <EffectComposer multisampling={0}>{effects}</EffectComposer>
+      ) : null}
+    </ThreeCanvas>
+  );
+}

--- a/apps/scene-studio/src/primitives/PostFxStage/index.tsx
+++ b/apps/scene-studio/src/primitives/PostFxStage/index.tsx
@@ -1,0 +1,1 @@
+export * from './PostFxStage';

--- a/apps/scene-studio/src/primitives/index.ts
+++ b/apps/scene-studio/src/primitives/index.ts
@@ -22,6 +22,7 @@ export { PaintReveal } from './PaintReveal';
 export { PaintSmear } from './PaintSmear';
 export { ParticleDrift } from './ParticleDrift';
 export { ParticleReveal } from './ParticleReveal';
+export { PostFxStage } from './PostFxStage';
 export { SafeArea } from './SafeArea';
 export { Scanline } from './Scanline';
 export { SignalNoise } from './SignalNoise';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1)
+      '@react-three/postprocessing':
+        specifier: ^3.0.4
+        version: 3.0.4(@react-three/fiber@9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1))(@types/three@0.185.1)(react@19.2.1)(three@0.185.1)
       '@remotion/cli':
         specifier: 4.0.488
         version: 4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)
@@ -338,6 +341,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      postprocessing:
+        specifier: ^6.39.3
+        version: 6.39.3(three@0.185.1)
       react:
         specifier: ^19.0.1
         version: 19.2.1
@@ -2736,6 +2742,13 @@ packages:
         optional: true
       react-native:
         optional: true
+
+  '@react-three/postprocessing@3.0.4':
+    resolution: {integrity: sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.0
+      react: ^19.0
+      three: '>= 0.156.0'
 
   '@remotion/bundler@4.0.488':
     resolution: {integrity: sha512-HBBH+IRRSuGjgc23e4uujOJffKvPcMhDiMrl9X3TJJXCO/qc9CqUQzW4yH4m04yecUBEZjogmrXLBoSVNYhZcw==}
@@ -6971,6 +6984,12 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  maath@0.6.0:
+    resolution: {integrity: sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==}
+    peerDependencies:
+      '@types/three': '>=0.144.0'
+      three: '>=0.144.0'
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -7314,6 +7333,12 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  n8ao@1.10.3:
+    resolution: {integrity: sha512-JFRk4WgUAUWO2KdJTqmBT02dP9kG7rE2oQbBy64E9+YwQ3d96KB9QBanqNy/NnYUfUTYU6Z/5OS5t/yLey7+6Q==}
+    peerDependencies:
+      postprocessing: '>=6.30.0'
+      three: '>=0.137'
 
   nan@2.27.0:
     resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
@@ -7916,6 +7941,11 @@ packages:
   postgres@3.4.9:
     resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
     engines: {node: '>=12'}
+
+  postprocessing@6.39.3:
+    resolution: {integrity: sha512-h5H1iuN96aRkU06CzJ8d/FqFe3Qs2bI7LiGHTzOI5T5mQqjzovi2t1EkRHb8qkHgoD9cTJDb4uA30AkSxsFB7A==}
+    peerDependencies:
+      three: '>= 0.168.0 < 0.186.0'
 
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
@@ -12310,6 +12340,17 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - immer
+
+  '@react-three/postprocessing@3.0.4(@react-three/fiber@9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1))(@types/three@0.185.1)(react@19.2.1)(three@0.185.1)':
+    dependencies:
+      '@react-three/fiber': 9.6.1(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.185.1)
+      maath: 0.6.0(@types/three@0.185.1)(three@0.185.1)
+      n8ao: 1.10.3(postprocessing@6.39.3(three@0.185.1))(three@0.185.1)
+      postprocessing: 6.39.3(three@0.185.1)
+      react: 19.2.1
+      three: 0.185.1
+    transitivePeerDependencies:
+      - '@types/three'
 
   '@remotion/bundler@4.0.488(@swc/core@1.13.5)(@swc/helpers@0.5.15)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(webpack-hot-middleware@2.26.1)':
     dependencies:
@@ -16943,6 +16984,11 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  maath@0.6.0(@types/three@0.185.1)(three@0.185.1):
+    dependencies:
+      '@types/three': 0.185.1
+      three: 0.185.1
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -17533,6 +17579,11 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  n8ao@1.10.3(postprocessing@6.39.3(three@0.185.1))(three@0.185.1):
+    dependencies:
+      postprocessing: 6.39.3(three@0.185.1)
+      three: 0.185.1
 
   nan@2.27.0:
     optional: true
@@ -18262,6 +18313,10 @@ snapshots:
       source-map-js: 1.2.1
 
   postgres@3.4.9: {}
+
+  postprocessing@6.39.3(three@0.185.1):
+    dependencies:
+      three: 0.185.1
 
   prettier@3.8.1: {}
 


### PR DESCRIPTION
## Summary

Final batch of the effect-primitive expansion (#394–#399): composer-based post-processing, gated on a determinism verification.

### What changed?

- Added `postprocessing` and `@react-three/postprocessing` to `apps/scene-studio` only (dedicated dependency commit; the lockfile diff is confined to the scene-studio importer, web apps unaffected).
- Added `PostFxStage` — hosts a 3D scene inside a `ThreeCanvas` and finishes it with `EffectComposer` (`multisampling={0}`, the documented safe baseline): optional `bloom` (`intensity`, `luminanceThreshold`) and `depthOfField` (`focusDistance`, `focalLength`, `bokehScale`) props. Without effect options the composer is skipped entirely and the stage renders the bare scene.
- Registered the `primitive-post-fx-stage` demo: a frame-driven spinning emissive knot (bloom source) with depth-staggered spheres (defocus targets). Not added to `shader-demo`, which is reserved for media-effect shaders.

### Why was this changed?

- Multi-pass effects such as bloom and depth of field cannot be expressed as single-pass `ScreenQuad` shaders, so 3D scenes had no way to gain cinematic glow or focus falloff (#399).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📦 Dependency updates

## Affected Applications

- [x] 🎬 Scene Studio (`apps/scene-studio/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing completed

`PostFxStage.test.tsx` covers the composition contract: bare scene without a composer when no effects are requested, composer mounted with `multisampling` 0, prop mapping for Bloom and DepthOfField (including defaults), and stacking both effects.

### How to Test

1. `pnpm -F scene-studio test && pnpm -F scene-studio typecheck && pnpm -F scene-studio lint`
2. `pnpm -F scene-studio dev` → open `primitive-post-fx-stage` and scrub: the knot glows and spins, the background spheres sit out of focus.

### Test Results

- [x] All existing tests pass (`pnpm test`) — 164 tests across 33 files
- [x] New tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

**Determinism gate (the critical concern for composer adoption): PASSED.** The composer's render-loop takeover coexists with `@remotion/three`'s frame-driven rendering: `ThreeCanvas`'s per-frame `advance()` drives the composer pass, stills at frames 0/60/120 show the bloomed knot at distinct rotation phases (motion works), and repeated renders of the same frame are **byte-identical** (`cmp`). Bloom and DepthOfField carry no time-dependent state; if future effects with internal clocks (e.g. the library's Glitch/Noise) are considered, they need their own determinism verification first.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

Dependency addition is scoped to `apps/scene-studio`; no web app depends on scene-studio.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #399

## Additional Context

This closes out the #394–#399 expansion series. `GodRays` remains explicitly out of scope (scene-dependent, hero-shot oriented) per the issue; the documented fallback (self-built `ScreenQuad` bloom) was not needed since the determinism gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
