### PR TITLE
📝 Docs: #406 Document the Scene Studio primitive inventory

### DIFF
--- a/.claude/rules/remotion-template-guidelines.md
+++ b/.claude/rules/remotion-template-guidelines.md
@@ -24,11 +24,14 @@ Layer 3: use-case compositions  — finished videos with a fixed purpose
 
 ### Layer 1 — generic primitives
 
-Small building blocks in `apps/scene-studio/src/primitives/`: `VideoTitle`,
-`Caption`, `SafeArea`, `GradientOverlay`, `Logo`, `MediaFrame`, `BrandOutro`,
-transitions. **Never** encode a use case, material, or platform in a primitive's
-name — no `TravelTitle`, `ArtworkCaption`, `InstagramLogo`. Primitives must work
-for every video genre.
+Small building blocks in `apps/scene-studio/src/primitives/`: layout and brand
+parts (`VideoTitle`, `Caption`, `SafeArea`), overlays (`GradientOverlay`,
+`FilmGrain`), fullscreen effect shaders (`WaveDistortion`, `Kaleidoscope`), and
+3D stages (`DepthGallery`, `PostFxStage`). The full inventory with descriptions
+lives in the Primitive Inventory section of `apps/scene-studio/README.md`.
+**Never** encode a use case, material, or platform in a primitive's name — no
+`TravelTitle`, `ArtworkCaption`, `InstagramLogo`. Primitives must work for
+every video genre.
 
 The layers are directories inside the app, not workspace packages. Extract a
 layer into a `packages/`-level workspace only when a second workspace actually

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,11 +98,12 @@ A Hono-based REST API is integrated into Next.js via a catch-all route handler
 - `apps/scene-studio` renders short-form vertical videos (1080×1920) with
   [Remotion](https://www.remotion.dev/): compositions are React components driven by
   props/JSON, styled with Tailwind v4 reusing `packages/tailwind-config` tokens.
-- Reusable video primitives (titles, captions, safe area, overlays, media, brand outro)
-  live in `apps/scene-studio/src/primitives/`; keep them use-case-agnostic per the
-  template guidelines and verify them via the `primitives` demo compositions in Studio
-  (no Storybook). Extract them into a `packages/`-level workspace only when a second
-  consumer (e.g. a web preview app) actually exists.
+- Reusable video primitives (titles, captions, safe area, overlays, media, effect
+  shaders, 3D stages, brand outro) live in `apps/scene-studio/src/primitives/` — the
+  full inventory is documented in `apps/scene-studio/README.md`; keep them
+  use-case-agnostic per the template guidelines and verify them via the `primitives`
+  demo compositions in Studio (no Storybook). Extract them into a `packages/`-level
+  workspace only when a second consumer (e.g. a web preview app) actually exists.
 - Animations must be deterministic: derive all state from `useCurrentFrame()` and props —
   never `requestAnimationFrame`, unseeded randomness, or the current time.
 - 3D is supported via `@remotion/three`: each 3D effect is a focused primitive built on

--- a/apps/scene-studio/README.md
+++ b/apps/scene-studio/README.md
@@ -72,9 +72,8 @@ pnpm -F scene-studio typecheck   # Run TypeScript checks
 
 The app follows a three-layer video structure:
 
-1. **Primitives** — generic visual building blocks such as `VideoTitle`,
-   `Caption`, `SafeArea`, `GradientOverlay`, `Logo`, `MediaFrame`, and
-   `BrandOutro`.
+1. **Primitives** — generic visual building blocks; see the
+   [Primitive Inventory](#primitive-inventory) below.
 2. **Patterns** — reusable viewing structures such as `VisualShowcase`.
 3. **Use-case compositions** — finished videos with a specific purpose. Add
    these only when a use case requires a structure that the generic patterns
@@ -83,6 +82,84 @@ The app follows a three-layer video structure:
 Template design and naming rules are defined in
 [`.claude/rules/remotion-template-guidelines.md`](../../.claude/rules/remotion-template-guidelines.md).
 The layers remain app-internal until another workspace needs to consume them.
+
+### Primitive Inventory
+
+All Layer-1 primitives live in `src/primitives/` and are exported from
+`src/primitives/index.ts`. Every primitive has a Studio demo composition named
+`primitive-<kebab-case-name>`, and the fullscreen shader effects are also
+collected as labeled segments in `shader-demo`
+(see `src/compositions/ShaderDemo/scenes.ts`).
+
+Effect primitives share these conventions: output derives only from
+`useCurrentFrame()` and props, media sources are cover-fitted to the frame, and
+the neutral endpoint (effect amount `0`, full coverage, or zero intensity)
+renders an untouched passthrough so transitions can cross it invisibly.
+
+#### Layout and brand
+
+| Primitive | Description |
+| --- | --- |
+| `VideoTitle` | Animated headline with tone variants and a configurable entrance delay |
+| `Caption` | Timed caption text with enter and exit animations |
+| `SafeArea` | Padding container that keeps content inside platform-safe insets, with optional guides |
+| `Logo` | Brand logo pinned to a corner with adjustable opacity |
+| `MediaFrame` | Cover- or contain-fitted image/video frame with transform and start-offset control |
+| `BrandOutro` | Closing brand card with call-to-action text and social handle |
+
+#### Atmosphere overlays
+
+| Primitive | Description |
+| --- | --- |
+| `GradientOverlay` | Directional gradient scrim for legibility and mood |
+| `FilmGrain` | Seeded photographic grain overlay |
+| `ParticleDrift` | Slowly drifting field of seeded dust particles |
+| `LightLeak` | Warm radial light washes drifting across the frame |
+| `EdgeBlur` | Miniature-style defocus that blurs the frame's top and bottom bands |
+| `Scanline` | CRT-style horizontal scanlines with optional downward drift |
+
+#### Reveal effects
+
+| Primitive | Description |
+| --- | --- |
+| `PaintReveal` | Transparent paint wash that covers the frame as coverage grows |
+| `PaintSmear` | Warps its children into painterly smears; intensity `0` leaves them untouched |
+| `ParticleReveal` | Dissolves its children into granular dust via a noise-thresholded alpha matte |
+
+#### Media shaders (image and video sources)
+
+| Primitive | Description |
+| --- | --- |
+| `WaveDistortion` | Sine-wave surface displacement with optional RGB shift and ripple center |
+| `FluidDistortion` | Seeded fluid warp driven by fractal noise |
+| `GridDisplacement` | Per-cell grid displacement with RGB separation |
+| `GlitchShift` | Seeded glitch bursts combining band tears with a global RGB split |
+| `Halftone` | Print-style halftone dots with size and angle control |
+| `Duotone` | Two-color tone mapping between shadow and highlight colors |
+| `Kaleidoscope` | Mirrored wedge segments with segment-count and rotation control |
+
+#### Image shaders (image sources)
+
+| Primitive | Description |
+| --- | --- |
+| `ChannelShift` | Opposing UV shift of the red and blue channels |
+| `InvertBlend` | Color inversion blended in by amount |
+| `Mosaic` | Screen-space mosaic cells that quantize the image |
+
+#### Procedural shaders (no source media)
+
+| Primitive | Description |
+| --- | --- |
+| `GradientFlow` | Flowing full-screen color gradient |
+| `SignalNoise` | Full-screen white-noise static |
+
+#### 3D and post-processing
+
+| Primitive | Description |
+| --- | --- |
+| `DepthGallery` | Camera dolly through depth-staggered image planes |
+| `DepthParallax` | Depth-map-driven parallax sway and dolly zoom over a still image, with focus-aware blur |
+| `PostFxStage` | Stage that finishes a hosted 3D scene with composer effects (bloom, depth of field) |
 
 ### Registered Compositions
 


### PR DESCRIPTION
## Summary

Documents the full Scene Studio primitive inventory after the effect-primitive expansion (#394–#399) grew the set from 7 to 30.

### What changed?

- `apps/scene-studio/README.md` — new **Primitive Inventory** section: all 30 primitives in categorized tables (layout & brand, atmosphere overlays, reveal effects, media shaders with image + video sources, image shaders, procedural shaders, 3D & post-processing) with a one-line description each, plus the demo mapping (`primitive-*`, `shader-demo`) and the shared effect conventions (determinism, cover-fit, invisible neutral endpoint). The Composition Layers section now links to the inventory instead of enumerating 7 names.
- `.claude/rules/remotion-template-guidelines.md` — refreshed the Layer 1 illustrative examples to span the current categories and pointed to the README inventory for the full list.
- `AGENTS.md` — updated the primitive category summary (adds effect shaders and 3D stages) and added the inventory pointer.

### Why was this changed?

- None of the 23 newer primitives appeared in any document, so the expanded effect vocabulary was invisible to contributors and agents choosing building blocks (#406).

## Type of Change

- [x] 📚 Documentation update

## Affected Applications

- [x] 🎬 Scene Studio (`apps/scene-studio/`)

## Testing

### Test Coverage

- [x] Manual testing completed

### How to Test

1. `pnpm docs:check` — passes (19 files scanned; covers the edited `AGENTS.md` and `.claude/rules/` file).
2. Cross-check: the 30 names in the README inventory tables match the exports in `apps/scene-studio/src/primitives/index.ts` exactly (verified by diffing the sorted lists).

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

## Documentation

- [x] Documentation updated (this PR is the documentation change)

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings

## Related Issues

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
