### PR TITLE
🐛 Fix: #408 Restore author avatars blocked by CSP and add fallback

### DIFF
--- a/apps/blog/app/blog/page.tsx
+++ b/apps/blog/app/blog/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { Avatar } from 'ui';
 
+import { AuthorAvatar } from '../../components/author-avatar/AuthorAvatar';
 import { BlogCard } from '../../components/blog-card';
 import { CloudinaryImage } from '../../components/cloudinary-image/CloudinaryImage';
 import { PageLayout } from '../../components/page-layout';
@@ -119,12 +119,10 @@ export default async function Page() {
                 excerpt={featureLatest.excerpt ?? undefined}
                 avatar={
                   featureLatest.author && (
-                    <Avatar>
-                      <Avatar.Image
-                        alt="author"
-                        src={featureLatest.author.avatarUrl ?? undefined}
-                      />
-                    </Avatar>
+                    <AuthorAvatar
+                      name={featureLatest.author.name}
+                      avatarUrl={featureLatest.author.avatarUrl}
+                    />
                   )
                 }
                 date={featureLatest.releaseDate}
@@ -179,12 +177,10 @@ export default async function Page() {
                 excerpt={article.excerpt ?? undefined}
                 avatar={
                   article.author && (
-                    <Avatar>
-                      <Avatar.Image
-                        alt="author"
-                        src={article.author?.avatarUrl ?? undefined}
-                      />
-                    </Avatar>
+                    <AuthorAvatar
+                      name={article.author.name}
+                      avatarUrl={article.author.avatarUrl}
+                    />
                   )
                 }
                 date={article.releaseDate}
@@ -243,12 +239,10 @@ export default async function Page() {
                     excerpt={article.excerpt ?? undefined}
                     avatar={
                       article.author && (
-                        <Avatar>
-                          <Avatar.Image
-                            alt="author"
-                            src={article.author.avatarUrl ?? undefined}
-                          />
-                        </Avatar>
+                        <AuthorAvatar
+                          name={article.author.name}
+                          avatarUrl={article.author.avatarUrl}
+                        />
                       )
                     }
                     date={article.releaseDate}
@@ -301,12 +295,10 @@ export default async function Page() {
                   excerpt={article.excerpt ?? undefined}
                   avatar={
                     article.author && (
-                      <Avatar>
-                        <Avatar.Image
-                          alt="author"
-                          src={article.author.avatarUrl ?? undefined}
-                        />
-                      </Avatar>
+                      <AuthorAvatar
+                        name={article.author.name}
+                        avatarUrl={article.author.avatarUrl}
+                      />
                     )
                   }
                   date={article.releaseDate}

--- a/apps/blog/components/article-heading/ArticleHeading.tsx
+++ b/apps/blog/components/article-heading/ArticleHeading.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import { Avatar } from 'ui';
 import type { PostOutput } from '../../modules/post/use-cases';
+import { AuthorAvatar } from '../author-avatar/AuthorAvatar';
 import { BlogCard } from '../blog-card';
 import { CloudinaryImage } from '../cloudinary-image/CloudinaryImage';
 
@@ -26,12 +26,10 @@ export async function ArticleHeading(props: Props) {
         excerpt={article.excerpt ?? undefined}
         avatar={
           article.author && (
-            <Avatar>
-              <Avatar.Image
-                alt="author"
-                src={article.author.avatarUrl || undefined}
-              />
-            </Avatar>
+            <AuthorAvatar
+              name={article.author.name}
+              avatarUrl={article.author.avatarUrl}
+            />
           )
         }
         date={article.releaseDate}

--- a/apps/blog/components/articles/Articles.tsx
+++ b/apps/blog/components/articles/Articles.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { Avatar } from 'ui';
 import type {
   PaginatedResult,
   PostSummaryOutput,
 } from '../../modules/post/use-cases';
+import { AuthorAvatar } from '../author-avatar/AuthorAvatar';
 import { BlogCard } from '../blog-card';
 import { CloudinaryImage } from '../cloudinary-image/CloudinaryImage';
 import { Pagination } from '../pagination/Pagination';
@@ -73,12 +73,10 @@ export async function Articles(props: Props) {
                 excerpt={article.excerpt ?? undefined}
                 avatar={
                   article.author && (
-                    <Avatar>
-                      <Avatar.Image
-                        alt="author"
-                        src={article.author.avatarUrl ?? undefined}
-                      />
-                    </Avatar>
+                    <AuthorAvatar
+                      name={article.author.name}
+                      avatarUrl={article.author.avatarUrl}
+                    />
                   )
                 }
                 date={article.releaseDate}

--- a/apps/blog/components/author-avatar/AuthorAvatar.test.tsx
+++ b/apps/blog/components/author-avatar/AuthorAvatar.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AuthorAvatar } from './AuthorAvatar';
+
+// jsdom never fires image load events, so Base UI keeps the fallback visible.
+describe('AuthorAvatar', () => {
+  it.each([
+    { name: 'krd-knt', expectedInitial: 'K' },
+    { name: 'Test Author', expectedInitial: 'T' },
+    { name: 'unknown author', expectedInitial: 'U' },
+  ])('displays fallback initial $expectedInitial for name $name', ({
+    name,
+    expectedInitial,
+  }) => {
+    render(<AuthorAvatar name={name} avatarUrl={null} />);
+
+    expect(screen.getByText(expectedInitial)).toBeInTheDocument();
+  });
+
+  it('displays the fallback initial while the image has not loaded', () => {
+    render(
+      <AuthorAvatar
+        name="Test Author"
+        avatarUrl="https://example.com/avatar.jpg"
+      />
+    );
+
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
+});

--- a/apps/blog/components/author-avatar/AuthorAvatar.tsx
+++ b/apps/blog/components/author-avatar/AuthorAvatar.tsx
@@ -1,0 +1,15 @@
+import { Avatar } from 'ui';
+
+interface Props {
+  name: string;
+  avatarUrl: string | null;
+}
+
+export function AuthorAvatar({ name, avatarUrl }: Props) {
+  return (
+    <Avatar>
+      <Avatar.Image alt={name} src={avatarUrl ?? undefined} />
+      <Avatar.Fallback>{name.charAt(0).toUpperCase()}</Avatar.Fallback>
+    </Avatar>
+  );
+}

--- a/apps/blog/components/page-heading/PageHeading.tsx
+++ b/apps/blog/components/page-heading/PageHeading.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import { Avatar } from 'ui';
 import type { PostOutput } from '../../modules/post/use-cases';
+import { AuthorAvatar } from '../author-avatar/AuthorAvatar';
 import { BlogCard } from '../blog-card';
 import { CloudinaryImage } from '../cloudinary-image/CloudinaryImage';
 
@@ -20,12 +20,10 @@ export async function PageHeading(props: Props) {
         heading={<h1 className="text-heading-1 font-bold">{article.title}</h1>}
         avatar={
           article.author && (
-            <Avatar>
-              <Avatar.Image
-                alt="author"
-                src={article.author.avatarUrl ?? undefined}
-              />
-            </Avatar>
+            <AuthorAvatar
+              name={article.author.name}
+              avatarUrl={article.author.avatarUrl}
+            />
           )
         }
         date={article.releaseDate}

--- a/apps/blog/components/profile-card/ProfileCard.tsx
+++ b/apps/blog/components/profile-card/ProfileCard.tsx
@@ -1,12 +1,10 @@
-import { Avatar } from 'ui';
+import { AuthorAvatar } from '../author-avatar/AuthorAvatar';
 
 export function ProfileCard() {
   return (
     <div className="flex flex-col gap-spacious p-spacious rounded-lg bg-base-white/50">
       <span className="inline-flex gap-normal">
-        <Avatar>
-          <Avatar.Image alt="author" src="/me.png" />
-        </Avatar>
+        <AuthorAvatar name="krd-knt" avatarUrl="/me.png" />
         <span>krd-knt</span>
       </span>
       <div className="flex flex-col gap-condensed">

--- a/apps/blog/modules/post/adapters/output/external-sources/notion/externalPostSource.test.ts
+++ b/apps/blog/modules/post/adapters/output/external-sources/notion/externalPostSource.test.ts
@@ -173,7 +173,7 @@ describe('NotionExternalPostSource', () => {
     });
   });
 
-  describe('fetchAllPosts', () => {
+  describe('fetchAll', () => {
     it('fetches and maps posts from Notion', async () => {
       const mockClient = createMockNotionClient();
       const mockN2M = createMockN2M();
@@ -195,9 +195,9 @@ describe('NotionExternalPostSource', () => {
         'test-database-id'
       );
 
-      const result = await sut.fetchAllPosts();
+      const result = await sut.fetchAll();
 
-      expect(result).toHaveLength(2);
+      expect(result.posts).toHaveLength(2);
       expect(mockClient.databases.query).toHaveBeenCalledWith(
         expect.objectContaining({
           database_id: 'test-database-id',
@@ -216,7 +216,7 @@ describe('NotionExternalPostSource', () => {
         'test-database-id'
       );
 
-      await sut.fetchAllPosts();
+      await sut.fetchAll();
 
       expect(mockClient.databases.query).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -239,7 +239,7 @@ describe('NotionExternalPostSource', () => {
         'test-database-id'
       );
 
-      await sut.fetchAllPosts();
+      await sut.fetchAll();
 
       expect(mockClient.databases.query).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -264,7 +264,7 @@ describe('NotionExternalPostSource', () => {
         'test-database-id'
       );
 
-      await sut.fetchAllPosts();
+      await sut.fetchAll();
 
       expect(mockN2M.pageToMarkdown).toHaveBeenCalledWith(
         '00000000-0000-4000-a000-000000000001'
@@ -272,7 +272,7 @@ describe('NotionExternalPostSource', () => {
       expect(mockN2M.toMarkdownString).toHaveBeenCalled();
     });
 
-    it('returns empty array when no posts exist', async () => {
+    it('returns an empty batch when no posts exist', async () => {
       const mockClient = createMockNotionClient();
       const mockN2M = createMockN2M();
       mockClient.databases.query.mockResolvedValue({ results: [] });
@@ -283,9 +283,70 @@ describe('NotionExternalPostSource', () => {
         'test-database-id'
       );
 
-      const result = await sut.fetchAllPosts();
+      const result = await sut.fetchAll();
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ posts: [], authors: [] });
+    });
+
+    it('returns a single author record when pages share one author', async () => {
+      const mockClient = createMockNotionClient();
+      const mockN2M = createMockN2M();
+      const notionPages = [
+        createNotionPageResponse({
+          id: '00000000-0000-4000-a000-000000000001',
+        }),
+        createNotionPageResponse({
+          id: '00000000-0000-4000-a000-000000000002',
+        }),
+      ];
+      mockClient.databases.query.mockResolvedValue({ results: notionPages });
+      mockN2M.pageToMarkdown.mockResolvedValue([]);
+      mockN2M.toMarkdownString.mockReturnValue({ parent: 'Markdown content' });
+
+      const sut = new NotionExternalPostSource(
+        mockClient as never,
+        mockN2M as never,
+        'test-database-id'
+      );
+
+      const result = await sut.fetchAll();
+
+      expect(result.authors).toEqual([
+        {
+          id: '660e8400-e29b-41d4-a716-446655440000',
+          name: 'Test Author',
+          avatarUrl: 'https://example.com/avatar.jpg',
+        },
+      ]);
+    });
+
+    it('omits author records for pages with a partial person', async () => {
+      const mockClient = createMockNotionClient();
+      const mockN2M = createMockN2M();
+      const pageWithPartialPerson = createNotionPageResponse({
+        properties: {
+          ...(createNotionPageResponse().properties as Record<string, unknown>),
+          author: {
+            type: 'people',
+            people: [{ id: '660e8400-e29b-41d4-a716-446655440000' }],
+          },
+        },
+      });
+      mockClient.databases.query.mockResolvedValue({
+        results: [pageWithPartialPerson],
+      });
+      mockN2M.pageToMarkdown.mockResolvedValue([]);
+      mockN2M.toMarkdownString.mockReturnValue({ parent: 'Markdown content' });
+
+      const sut = new NotionExternalPostSource(
+        mockClient as never,
+        mockN2M as never,
+        'test-database-id'
+      );
+
+      const result = await sut.fetchAll();
+
+      expect(result.authors).toEqual([]);
     });
 
     it('throws ExternalSourceError on Notion API error', async () => {
@@ -299,7 +360,7 @@ describe('NotionExternalPostSource', () => {
         'test-database-id'
       );
 
-      await expect(sut.fetchAllPosts()).rejects.toThrow(ExternalSourceError);
+      await expect(sut.fetchAll()).rejects.toThrow(ExternalSourceError);
     });
 
     it('includes source name in error', async () => {
@@ -313,7 +374,7 @@ describe('NotionExternalPostSource', () => {
         'test-database-id'
       );
 
-      await expect(sut.fetchAllPosts()).rejects.toThrow('Notion');
+      await expect(sut.fetchAll()).rejects.toThrow('Notion');
     });
   });
 });

--- a/apps/blog/modules/post/adapters/output/external-sources/notion/externalPostSource.ts
+++ b/apps/blog/modules/post/adapters/output/external-sources/notion/externalPostSource.ts
@@ -1,10 +1,18 @@
 import type { Client } from '@notionhq/client';
 import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import type { NotionToMarkdown } from 'notion-to-md';
-import type { Post } from '../../../../domain';
-import type { ExternalPostSource } from '../../../../use-cases';
+import type {
+  AuthorRecord,
+  ExternalPostBatch,
+  ExternalPostSource,
+} from '../../../../use-cases';
 import { ExternalSourceError, postLogger } from '../../../shared';
-import { getEmbedTypeFromPage, mapEmbedType, notionPageToPost } from './mapper';
+import {
+  getEmbedTypeFromPage,
+  mapEmbedType,
+  notionPageToAuthorRecord,
+  notionPageToPost,
+} from './mapper';
 
 const DATABASE_ID = process.env.NOTION_POST_DATABASE_ID ?? '';
 
@@ -45,7 +53,7 @@ export class NotionExternalPostSource implements ExternalPostSource {
     });
   }
 
-  async fetchAllPosts(): Promise<Post[]> {
+  async fetchAll(): Promise<ExternalPostBatch> {
     try {
       const database = await this.notionClient.databases.query({
         database_id: this.databaseId,
@@ -65,8 +73,16 @@ export class NotionExternalPostSource implements ExternalPostSource {
         })
       );
 
+      const authorsById = new Map<string, AuthorRecord>();
+      for (const page of database.results) {
+        const author = notionPageToAuthorRecord(page as PageObjectResponse);
+        if (author) {
+          authorsById.set(author.id, author);
+        }
+      }
+
       postLogger.info({ count: posts.length }, 'Fetched all posts from Notion');
-      return posts;
+      return { posts, authors: Array.from(authorsById.values()) };
     } catch (error) {
       postLogger.error({ err: error }, 'Failed to fetch posts from Notion');
       throw new ExternalSourceError('Notion', error);

--- a/apps/blog/modules/post/adapters/output/external-sources/notion/mapper.test.ts
+++ b/apps/blog/modules/post/adapters/output/external-sources/notion/mapper.test.ts
@@ -5,6 +5,7 @@ import { createNotionPageResponse } from '../../../shared';
 import {
   getEmbedTypeFromPage,
   mapEmbedType,
+  notionPageToAuthorRecord,
   notionPageToImageSource,
   notionPageToPost,
 } from './mapper';
@@ -209,6 +210,75 @@ describe('notion/mapper', () => {
       expect(result).toEqual({
         id: page.id,
         url: 'https://s3.amazonaws.com/image.jpg',
+      });
+    });
+  });
+
+  describe('notionPageToAuthorRecord', () => {
+    it('returns AuthorRecord when the person has full data', () => {
+      const page = createNotionPageResponse() as unknown as PageObjectResponse;
+
+      const result = notionPageToAuthorRecord(page);
+
+      expect(result).toEqual({
+        id: '660e8400-e29b-41d4-a716-446655440000',
+        name: 'Test Author',
+        avatarUrl: 'https://example.com/avatar.jpg',
+      });
+    });
+
+    it('returns null when the author property has no people', () => {
+      const page = createNotionPageResponse({
+        properties: {
+          ...(createNotionPageResponse().properties as Record<string, unknown>),
+          author: { type: 'people', people: [] },
+        },
+      }) as unknown as PageObjectResponse;
+
+      const result = notionPageToAuthorRecord(page);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the person is partial without a name', () => {
+      const page = createNotionPageResponse({
+        properties: {
+          ...(createNotionPageResponse().properties as Record<string, unknown>),
+          author: {
+            type: 'people',
+            people: [{ id: '660e8400-e29b-41d4-a716-446655440000' }],
+          },
+        },
+      }) as unknown as PageObjectResponse;
+
+      const result = notionPageToAuthorRecord(page);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns AuthorRecord with null avatarUrl when avatar_url is null', () => {
+      const page = createNotionPageResponse({
+        properties: {
+          ...(createNotionPageResponse().properties as Record<string, unknown>),
+          author: {
+            type: 'people',
+            people: [
+              {
+                id: '660e8400-e29b-41d4-a716-446655440000',
+                name: 'Test Author',
+                avatar_url: null,
+              },
+            ],
+          },
+        },
+      }) as unknown as PageObjectResponse;
+
+      const result = notionPageToAuthorRecord(page);
+
+      expect(result).toEqual({
+        id: '660e8400-e29b-41d4-a716-446655440000',
+        name: 'Test Author',
+        avatarUrl: null,
       });
     });
   });

--- a/apps/blog/modules/post/adapters/output/external-sources/notion/mapper.ts
+++ b/apps/blog/modules/post/adapters/output/external-sources/notion/mapper.ts
@@ -30,6 +30,7 @@ import {
   Tags,
   Title,
 } from '../../../../domain';
+import type { AuthorRecord } from '../../../../use-cases';
 import { DEFAULT_VALUES, MappingError } from '../../../shared';
 
 /**
@@ -106,6 +107,25 @@ export function notionPageToImageSource(
   return {
     id: page.id,
     url: imageUrl,
+  };
+}
+
+/**
+ * Maps a Notion Page Response to an AuthorRecord.
+ * Returns null when the person is absent or partial (id-only), so existing
+ * author rows are never overwritten with incomplete data.
+ */
+export function notionPageToAuthorRecord(
+  page: PageObjectResponse
+): AuthorRecord | null {
+  const person = getPerson(page.properties, 'author');
+  if (!person?.name) {
+    return null;
+  }
+  return {
+    id: person.id,
+    name: person.name,
+    avatarUrl: person.avatarUrl ?? null,
   };
 }
 

--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/postBatchRepository.db.test.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/postBatchRepository.db.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../../../infrastructure/drizzle/schema';
 import { AuthorId, Title } from '../../../../domain';
 import {
+  createAuthorRecord,
   createPost,
   createPosts,
 } from '../../../../use-cases/shared/testing/factories';
@@ -28,7 +29,7 @@ describe('DrizzlePostBatchRepository', () => {
     it('does nothing when posts array is empty', async () => {
       const sut = new DrizzlePostBatchRepository(getTestDb());
 
-      await sut.upsertAll([]);
+      await sut.upsertAll([], []);
 
       const [postCount] = await getTestDb()
         .select({ value: count() })
@@ -44,7 +45,7 @@ describe('DrizzlePostBatchRepository', () => {
       const sut = new DrizzlePostBatchRepository(getTestDb());
       const newPosts = createPosts(3);
 
-      await sut.upsertAll(newPosts);
+      await sut.upsertAll(newPosts, []);
 
       const storedPosts = await getTestDb().select().from(posts);
       const storedAuthors = await getTestDb().select().from(authors);
@@ -59,11 +60,11 @@ describe('DrizzlePostBatchRepository', () => {
     it('updates posts that already exist by uuid without duplicating the author row', async () => {
       const sut = new DrizzlePostBatchRepository(getTestDb());
       const original = createPost();
-      await sut.upsertAll([original]);
+      await sut.upsertAll([original], []);
 
       const revisedTitle = 'Revised in Batch';
       const revised = createPost({ title: Title.create(revisedTitle) });
-      await sut.upsertAll([revised]);
+      await sut.upsertAll([revised], []);
 
       const [storedPost] = await getTestDb()
         .select()
@@ -74,7 +75,7 @@ describe('DrizzlePostBatchRepository', () => {
       expect(storedAuthors).toHaveLength(1);
     });
 
-    it('preserves a pre-existing author name instead of overwriting it', async () => {
+    it('preserves a pre-existing author name when no author record is provided', async () => {
       const db = getTestDb();
       const realName = 'Real Person';
       const post = createPost();
@@ -85,7 +86,7 @@ describe('DrizzlePostBatchRepository', () => {
       });
 
       const sut = new DrizzlePostBatchRepository(db);
-      await sut.upsertAll([post]);
+      await sut.upsertAll([post], []);
 
       const [storedAuthor] = await db
         .select()
@@ -97,17 +98,87 @@ describe('DrizzlePostBatchRepository', () => {
     it('does not insert a stand-in author when updating an existing post with a changed authorId', async () => {
       const sut = new DrizzlePostBatchRepository(getTestDb());
       const original = createPost();
-      await sut.upsertAll([original]);
+      await sut.upsertAll([original], []);
 
       const changedAuthorId = AuthorId.create(
         '770e8400-e29b-41d4-a716-446655440000'
       );
       const revised = createPost({ authorId: changedAuthorId });
-      await sut.upsertAll([revised]);
+      await sut.upsertAll([revised], []);
 
       const storedAuthors = await getTestDb().select().from(authors);
       expect(storedAuthors).toHaveLength(1);
       expect(storedAuthors[0].uuid).toBe(original.authorId.getValue());
+    });
+
+    it('inserts an author row with name and avatarUrl from the record', async () => {
+      const sut = new DrizzlePostBatchRepository(getTestDb());
+      const post = createPost();
+      const record = createAuthorRecord({ id: post.authorId.getValue() });
+
+      await sut.upsertAll([post], [record]);
+
+      const [storedAuthor] = await getTestDb()
+        .select()
+        .from(authors)
+        .where(eq(authors.uuid, record.id));
+      expect(storedAuthor).toMatchObject({
+        uuid: record.id,
+        name: record.name,
+        avatarUrl: record.avatarUrl,
+      });
+    });
+
+    it('updates an existing author name and avatarUrl on conflict', async () => {
+      const db = getTestDb();
+      const post = createPost();
+      await db.insert(authors).values({
+        uuid: post.authorId.getValue(),
+        name: 'Unknown Author',
+        avatarUrl: null,
+        updatedAt: new Date('2024-01-15T00:00:00.000Z'),
+      });
+      const record = createAuthorRecord({
+        id: post.authorId.getValue(),
+        name: 'Real Person',
+        avatarUrl: 'https://example.com/new-avatar.jpg',
+      });
+
+      const sut = new DrizzlePostBatchRepository(db);
+      await sut.upsertAll([post], [record]);
+
+      const [storedAuthor] = await db
+        .select()
+        .from(authors)
+        .where(eq(authors.uuid, record.id));
+      expect(storedAuthor).toMatchObject({
+        name: 'Real Person',
+        avatarUrl: 'https://example.com/new-avatar.jpg',
+      });
+    });
+
+    it('overwrites avatarUrl with null when the record has no avatar', async () => {
+      const db = getTestDb();
+      const post = createPost();
+      await db.insert(authors).values({
+        uuid: post.authorId.getValue(),
+        name: 'Real Person',
+        avatarUrl: 'https://example.com/old-avatar.jpg',
+        updatedAt: new Date('2024-01-15T00:00:00.000Z'),
+      });
+      const record = createAuthorRecord({
+        id: post.authorId.getValue(),
+        avatarUrl: null,
+      });
+
+      const sut = new DrizzlePostBatchRepository(db);
+      await sut.upsertAll([post], [record]);
+
+      const [storedAuthor] = await db
+        .select()
+        .from(authors)
+        .where(eq(authors.uuid, record.id));
+      expect(storedAuthor.avatarUrl).toBeNull();
     });
   });
 });

--- a/apps/blog/modules/post/adapters/output/repositories/drizzle/postBatchRepository.ts
+++ b/apps/blog/modules/post/adapters/output/repositories/drizzle/postBatchRepository.ts
@@ -5,7 +5,7 @@ import {
   posts as postsTable,
 } from '../../../../../../infrastructure/drizzle/schema';
 import type { Post } from '../../../../domain';
-import type { PostBatchRepository } from '../../../../use-cases';
+import type { AuthorRecord, PostBatchRepository } from '../../../../use-cases';
 import { RepositoryError } from '../../../shared';
 import { toPersistence } from './mapper';
 
@@ -16,13 +16,35 @@ const UNKNOWN_AUTHOR_NAME = 'Unknown Author';
 export class DrizzlePostBatchRepository implements PostBatchRepository {
   constructor(private readonly db: DrizzleClient) {}
 
-  async upsertAll(posts: Post[]): Promise<void> {
+  async upsertAll(posts: Post[], authorRecords: AuthorRecord[]): Promise<void> {
     if (posts.length === 0) {
       return;
     }
 
     try {
       await this.db.transaction(async (tx) => {
+        // Authors go first: Post_authorId_fkey requires the rows to exist
+        // before any new post referencing them is inserted.
+        const now = new Date();
+        for (const record of authorRecords) {
+          await tx
+            .insert(authors)
+            .values({
+              uuid: record.id,
+              name: record.name,
+              avatarUrl: record.avatarUrl,
+              updatedAt: now,
+            })
+            .onConflictDoUpdate({
+              target: authors.uuid,
+              set: {
+                name: record.name,
+                avatarUrl: record.avatarUrl,
+                updatedAt: now,
+              },
+            });
+        }
+
         for (const post of posts) {
           const data = toPersistence(post);
 

--- a/apps/blog/modules/post/use-cases/index.ts
+++ b/apps/blog/modules/post/use-cases/index.ts
@@ -59,6 +59,8 @@ export {
   type SyncHeroImagesOutput,
 } from './sync/sync-hero-images';
 export {
+  type AuthorRecord,
+  type ExternalPostBatch,
   type ExternalPostSource,
   type PostBatchRepository,
   SyncPostsFromExternal,

--- a/apps/blog/modules/post/use-cases/shared/testing/factories.ts
+++ b/apps/blog/modules/post/use-cases/shared/testing/factories.ts
@@ -15,6 +15,7 @@ import {
   Tags,
   Title,
 } from '../../../domain';
+import type { AuthorRecord } from '../../sync/sync-posts-from-external';
 import type {
   AuthorOutput,
   PaginatedResult,
@@ -136,6 +137,17 @@ export function createPosts(
     const slug = Slug.create(`test-post-${index}`);
     return createPost({ ...overrides, id, slug });
   });
+}
+
+export function createAuthorRecord(
+  overrides: Partial<AuthorRecord> = {}
+): AuthorRecord {
+  return {
+    id: '660e8400-e29b-41d4-a716-446655440000',
+    name: 'Test Author',
+    avatarUrl: 'https://example.com/avatar.jpg',
+    ...overrides,
+  };
 }
 
 export interface PostWithAuthor {

--- a/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/authorRecord.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/authorRecord.ts
@@ -1,0 +1,11 @@
+/**
+ * Author data extracted from the external source alongside posts.
+ *
+ * Produced only when the source supplies a full person object with a name;
+ * partial persons yield no record so existing rows are preserved.
+ */
+export interface AuthorRecord {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+}

--- a/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/externalPostSource.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/externalPostSource.ts
@@ -1,13 +1,19 @@
 import type { Post } from '../../../domain';
+import type { AuthorRecord } from './authorRecord';
+
+export interface ExternalPostBatch {
+  posts: Post[];
+  authors: AuthorRecord[];
+}
 
 /**
  * External post source interface
  *
- * Abstracts the source of posts
+ * Abstracts the source of posts and their authors
  */
 export interface ExternalPostSource {
   /**
-   * Fetches all posts from the external source
+   * Fetches all posts and their author records from the external source
    */
-  fetchAllPosts(): Promise<Post[]>;
+  fetchAll(): Promise<ExternalPostBatch>;
 }

--- a/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/index.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/index.ts
@@ -1,4 +1,8 @@
-export type { ExternalPostSource } from './externalPostSource';
+export type { AuthorRecord } from './authorRecord';
+export type {
+  ExternalPostBatch,
+  ExternalPostSource,
+} from './externalPostSource';
 export type { PostBatchRepository } from './postBatchRepository';
 export {
   SyncPostsFromExternal,

--- a/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/postBatchRepository.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/postBatchRepository.ts
@@ -1,4 +1,5 @@
 import type { Post } from '../../../domain';
+import type { AuthorRecord } from './authorRecord';
 
 /**
  * Repository interface for batch post operations
@@ -7,7 +8,7 @@ import type { Post } from '../../../domain';
  */
 export interface PostBatchRepository {
   /**
-   * Upserts multiple posts (insert or update)
+   * Upserts multiple posts (insert or update) and their author records
    */
-  upsertAll(posts: Post[]): Promise<void>;
+  upsertAll(posts: Post[], authorRecords: AuthorRecord[]): Promise<void>;
 }

--- a/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/useCase.test.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/useCase.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { SyncError } from '../../shared';
-import { createPost, createPosts } from '../../shared/testing/factories';
+import {
+  createAuthorRecord,
+  createPost,
+  createPosts,
+} from '../../shared/testing/factories';
 import type { ExternalPostSource } from './externalPostSource';
 import type { PostBatchRepository } from './postBatchRepository';
 import { SyncPostsFromExternal } from './useCase';
@@ -9,7 +13,7 @@ describe('SyncPostsFromExternal', () => {
   const createMockExternalSource = (
     overrides: Partial<ExternalPostSource> = {}
   ): ExternalPostSource => ({
-    fetchAllPosts: vi.fn().mockResolvedValue([]),
+    fetchAll: vi.fn().mockResolvedValue({ posts: [], authors: [] }),
     ...overrides,
   });
 
@@ -24,7 +28,7 @@ describe('SyncPostsFromExternal', () => {
     it('syncs posts from external source', async () => {
       const posts = createPosts(3);
       const externalSource = createMockExternalSource({
-        fetchAllPosts: vi.fn().mockResolvedValue(posts),
+        fetchAll: vi.fn().mockResolvedValue({ posts, authors: [] }),
       });
       const batchRepository = createMockBatchRepository();
       const sut = new SyncPostsFromExternal(externalSource, batchRepository);
@@ -35,10 +39,11 @@ describe('SyncPostsFromExternal', () => {
       expect(result.syncedPosts).toHaveLength(3);
     });
 
-    it('calls upsertAll with fetched posts', async () => {
+    it('calls upsertAll with fetched posts and author records', async () => {
       const posts = createPosts(2);
+      const authors = [createAuthorRecord()];
       const externalSource = createMockExternalSource({
-        fetchAllPosts: vi.fn().mockResolvedValue(posts),
+        fetchAll: vi.fn().mockResolvedValue({ posts, authors }),
       });
       const upsertAll = vi.fn().mockResolvedValue(undefined);
       const batchRepository = createMockBatchRepository({ upsertAll });
@@ -46,12 +51,12 @@ describe('SyncPostsFromExternal', () => {
 
       await sut.execute();
 
-      expect(upsertAll).toHaveBeenCalledWith(posts);
+      expect(upsertAll).toHaveBeenCalledWith(posts, authors);
     });
 
     it('does not call upsertAll when no posts are found', async () => {
       const externalSource = createMockExternalSource({
-        fetchAllPosts: vi.fn().mockResolvedValue([]),
+        fetchAll: vi.fn().mockResolvedValue({ posts: [], authors: [] }),
       });
       const upsertAll = vi.fn();
       const batchRepository = createMockBatchRepository({ upsertAll });
@@ -65,7 +70,7 @@ describe('SyncPostsFromExternal', () => {
 
     it('throws SyncError when external source fails', async () => {
       const externalSource = createMockExternalSource({
-        fetchAllPosts: vi.fn().mockRejectedValue(new Error('API error')),
+        fetchAll: vi.fn().mockRejectedValue(new Error('API error')),
       });
       const batchRepository = createMockBatchRepository();
       const sut = new SyncPostsFromExternal(externalSource, batchRepository);
@@ -77,7 +82,7 @@ describe('SyncPostsFromExternal', () => {
     it('throws SyncError when batch repository fails', async () => {
       const posts = createPosts(1);
       const externalSource = createMockExternalSource({
-        fetchAllPosts: vi.fn().mockResolvedValue(posts),
+        fetchAll: vi.fn().mockResolvedValue({ posts, authors: [] }),
       });
       const batchRepository = createMockBatchRepository({
         upsertAll: vi.fn().mockRejectedValue(new Error('Database error')),
@@ -91,7 +96,7 @@ describe('SyncPostsFromExternal', () => {
     it('maps synced posts to PostOutput', async () => {
       const post = createPost();
       const externalSource = createMockExternalSource({
-        fetchAllPosts: vi.fn().mockResolvedValue([post]),
+        fetchAll: vi.fn().mockResolvedValue({ posts: [post], authors: [] }),
       });
       const batchRepository = createMockBatchRepository();
       const sut = new SyncPostsFromExternal(externalSource, batchRepository);

--- a/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/useCase.ts
+++ b/apps/blog/modules/post/use-cases/sync/sync-posts-from-external/useCase.ts
@@ -20,10 +20,10 @@ export class SyncPostsFromExternal {
 
   async execute(): Promise<SyncPostsFromExternalOutput> {
     try {
-      const posts = await this.externalSource.fetchAllPosts();
+      const { posts, authors } = await this.externalSource.fetchAll();
 
       if (posts.length > 0) {
-        await this.batchRepository.upsertAll(posts);
+        await this.batchRepository.upsertAll(posts, authors);
       }
 
       return {

--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -31,7 +31,7 @@ const securityHeaders = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://platform.twitter.com https://*.hcaptcha.com https://hcaptcha.com https://fundingchoicesmessages.google.com https://*.adtrafficquality.google https://adtrafficquality.google",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' https://res.cloudinary.com https://images.unsplash.com https://*.cdninstagram.com https://pbs.twimg.com https://pagead2.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google data:",
+      "img-src 'self' https://res.cloudinary.com https://s3-us-west-2.amazonaws.com/public.notion-static.com/ https://images.unsplash.com https://*.cdninstagram.com https://pbs.twimg.com https://pagead2.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google data:",
       "font-src 'self'",
       "connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://*.googletagmanager.com https://*.hcaptcha.com https://hcaptcha.com https://api.cloudinary.com https://www.instagram.com https://pagead2.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google https://fundingchoicesmessages.google.com",
       'frame-src https://*.hcaptcha.com https://hcaptcha.com https://platform.twitter.com https://syndication.twitter.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://*.adtrafficquality.google https://adtrafficquality.google https://www.google.com',


### PR DESCRIPTION
## Summary

Restores author avatars on the blog, which have been rendering as empty gaps in production.

### What changed?

- Re-added the Notion avatar host to the CSP `img-src` with minimal scope (`https://s3-us-west-2.amazonaws.com/public.notion-static.com/` — a single host+path source, not the old `*.amazonaws.com` wildcard). `images.remotePatterns` stays untouched since avatars use Base UI's plain `<img>`, not `next/image`.
- The Notion sync now persists author `name` / `avatarUrl`: `fetchAll()` returns `{ posts, authors }` (deduped `AuthorRecord`s), and `DrizzlePostBatchRepository.upsertAll()` upserts author rows before posts. Partial (id-only) persons produce no record, so the existing stand-in path preserves current rows.
- Added a shared `AuthorAvatar` component that renders `Avatar.Fallback` (author's initial) and replaced all 7 avatar call sites plus `ProfileCard`, so future load failures degrade visibly instead of silently.

### Why was this changed?

- Commit 824364f (#332) removed `https://*.amazonaws.com` from `img-src` on the premise that all images go through Cloudinary — true only for hero images. Author avatars are raw Notion S3 URLs, so the browser blocked them.
- The sync never wrote `authors.avatarUrl` (only an `'Unknown Author'` stand-in), leaving frozen Prisma-era data that a re-sync could not repair.
- No call site rendered a fallback, so the failure was completely silent.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Affected Applications

- [x] 📝 Blog app (`apps/blog/`)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed

### How to Test

1. `pnpm -F blog typecheck && pnpm -F blog lint && pnpm -F blog test && pnpm -F blog test:db` (db tests need Docker)
2. `pnpm -F blog dev`, then `curl -sI http://localhost:3000/blog | grep -i content-security-policy` — `img-src` contains `https://s3-us-west-2.amazonaws.com/public.notion-static.com/`
3. Open `http://localhost:3000/blog` — author avatars render; with `avatarUrl` NULL, a gray circle with the author's initial appears instead of an empty gap

### Test Results

- [x] All existing tests pass (`pnpm test`)
- [x] New tests pass
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes

jsdom: 106 files / 944 tests passed. node-db (Testcontainers): 10 files / 45 tests passed. Verified against the local dev DB (which carries the same frozen S3 avatar URL as production) that the CSP header includes the new host and the SSR HTML renders the fallback initial.

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No environment variable changes

## Screenshots/Videos

### Before

Production article cards show an empty gap where the author avatar belongs (see #408).

### After

Avatar image renders again; when the image cannot load, a gray circle with the author's initial is shown.

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment requirements

**Deployment instructions:**

Rendering is fixed immediately on deploy (the stored S3 URL still serves 200). To also repair the frozen `authors` rows, run the posts sync from `/settings` after deploy. Note: if the Notion integration token lacks the user-information capability, person objects arrive id-only and no author records are produced — rendering is still fixed, but the DB repair needs the capability enabled.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Commit messages are clear and descriptive
- [x] Branch is up to date with main
- [x] No console errors or warnings
- [x] Performance impact considered

## Related Issues

Fixes #408

## Additional Context

Mirroring avatars to Cloudinary (hero-image parity, which would let the CSP stay fully closed) is deliberately out of scope; a follow-up issue tracks it. If a future avatar moves to `lh3.googleusercontent.com` or a signed `prod-files-secure.s3` URL, the fallback initial keeps the UI intact until that follow-up lands.

## Reviewer Notes

- The overwrite rule in `DrizzlePostBatchRepository.upsertAll`: full person records overwrite `name`/`avatarUrl` unconditionally (Notion is the source of truth; `avatarUrl: null` legitimately means "no avatar"), while partial persons produce no record and leave rows untouched.
- The port rename `fetchAllPosts` → `fetchAll` — a method returning posts and authors under the old name would be misleading; impact is confined to the sync slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
